### PR TITLE
chore(docs): fix typo in union document page

### DIFF
--- a/website/src/routes/api/(schemas)/union/index.mdx
+++ b/website/src/routes/api/(schemas)/union/index.mdx
@@ -1,7 +1,7 @@
 ---
-title: undefinedType
+title: union
 ---
 
 # union
 
-> The content of this page is not yet ready. Until then just use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/schemas/undefinedType/undefinedType.ts).
+> The content of this page is not yet ready. Until then just use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/schemas/union/union.ts).


### PR DESCRIPTION
As it's a tiny copy paste miss, I didn't open a issue for it.