### PR TITLE
docs: added vee-validate in ecosystem form libraries section

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -22,6 +22,7 @@ Use the button at the bottom left of this page to add your project to this ecosy
 ### Form libraries
 
 - [Modular Forms](https://modularforms.dev/): Modular and type-safe form library for SolidJS, Qwik, Preact and React
+- [vee-validate](https://vee-validate.logaretm.com/v4/): A Vue.js form library
 
 ### Component libraries
 

--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -22,7 +22,7 @@ Use the button at the bottom left of this page to add your project to this ecosy
 ### Form libraries
 
 - [Modular Forms](https://modularforms.dev/): Modular and type-safe form library for SolidJS, Qwik, Preact and React
-- [vee-validate](https://vee-validate.logaretm.com/v4/): A Vue.js form library
+- [vee-validate](https://vee-validate.logaretm.com/v4/): Painless Vue.js forms
 
 ### Component libraries
 


### PR DESCRIPTION
vee-validate v4.11.0 now supports valibot as a schema provider

Relevant [doc link](https://vee-validate.logaretm.com/v4/guide/composition-api/getting-started/#validating-with-valibot).

Thanks for building this and cheers!