### PR TITLE
Rename `tuble` to `tuples` in index.mdx

### DIFF
--- a/website/src/routes/guides/(main-concepts)/schemas/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/schemas/index.mdx
@@ -84,7 +84,7 @@ const UndefinedSchema = undefinedType(); // undefined
 
 ## Complex values
 
-Among complex values I support objects, records, arrays, tuble as well as various other classes.
+Among complex values I support objects, records, arrays, tuples as well as various other classes.
 
 > For objects I provide various methods like <Link href="/api/partial">`partial`</Link> and <Link href="/api/merge">`merge`</Link>. Learn more about them <Link href="/guides/methods">here</Link>.
 


### PR DESCRIPTION
This updates the typo `tuble` to `tuples` in the docs.