### PR TITLE
Rename `offers` to `offer` in index.mdx

### DIFF
--- a/website/src/routes/guides/(main-concepts)/methods/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/methods/index.mdx
@@ -68,7 +68,7 @@ Object methods: <Link href="/api/keyof">`keyof`</Link>, <Link href="/api/merge">
 
 ### TypeScript similarities
 
-I offers almost the same options as TypeScript. For example, you can make the values of an object optional with <Link href="/api/partial">`partial`</Link> or make them required with <Link href="/api/required">`required`</Link>. With <Link href="/api/merge">`merge`</Link>, you can join multiple object schemas and with <Link href="/api/pick">`pick`</Link> or <Link href="/api/omit">`omit`</Link>, you can include or exclude certain values of an existing schema.
+I offer almost the same options as TypeScript. For example, you can make the values of an object optional with <Link href="/api/partial">`partial`</Link> or make them required with <Link href="/api/required">`required`</Link>. With <Link href="/api/merge">`merge`</Link>, you can join multiple object schemas and with <Link href="/api/pick">`pick`</Link> or <Link href="/api/omit">`omit`</Link>, you can include or exclude certain values of an existing schema.
 
 ```ts
 import { number, object, partial, pick, string } from 'valibot'; // 0.76 kB


### PR DESCRIPTION
Fixes typo.