### PR TITLE
Fix ISO validation hours to allow `00`

### DIFF
--- a/library/src/validations/isoDateTime/isoDateTime.test.ts
+++ b/library/src/validations/isoDateTime/isoDateTime.test.ts
@@ -8,7 +8,7 @@ describe('isoDateTime', () => {
     const validate = isoDateTime();
     const value1 = '2023-07-11T19:34';
     expect(validate(value1, info)).toBe(value1);
-    const value2 = '0000-01-01T01:00';
+    const value2 = '0000-01-01T00:00';
     expect(validate(value2, info)).toBe(value2);
     const value3 = '9999-12-31T23:59';
     expect(validate(value3, info)).toBe(value3);
@@ -16,9 +16,9 @@ describe('isoDateTime', () => {
     expect(() => validate('', info)).toThrowError();
     expect(() => validate('2023-7-11T19:34', info)).toThrowError();
     expect(() => validate('23-07-11T19:34', info)).toThrowError();
-    expect(() => validate('2023-07-11T00:00', info)).toThrowError();
     expect(() => validate('0000-00-00T00:00', info)).toThrowError();
     expect(() => validate('9999-13-32T25:60', info)).toThrowError();
+    expect(() => validate('0000-01-01T24:00', info)).toThrowError();
     // FIXME: expect(() => validate('2023-06-31T00:00', info)).toThrowError();
     expect(() => validate('12345-01-01T01:00', info)).toThrowError();
   });

--- a/library/src/validations/isoDateTime/isoDateTime.ts
+++ b/library/src/validations/isoDateTime/isoDateTime.ts
@@ -17,7 +17,7 @@ import type { ValidateInfo } from '../../types.ts';
 export function isoDateTime<TInput extends string>(error?: string) {
   return (input: TInput, info: ValidateInfo) => {
     if (
-      !/^\d{4}-(0[1-9]|1[0-2])-([12]\d|0[1-9]|3[01])T(0[1-9]|1\d|2[0-3]):[0-5]\d$/.test(
+      !/^\d{4}-(0[1-9]|1[0-2])-([12]\d|0[1-9]|3[01])T(0[0-9]|1\d|2[0-3]):[0-5]\d$/.test(
         input
       )
     ) {

--- a/library/src/validations/isoTime/isoTime.test.ts
+++ b/library/src/validations/isoTime/isoTime.test.ts
@@ -8,16 +8,20 @@ describe('isoTime', () => {
     const validate = isoTime();
     const value1 = '19:34';
     expect(validate(value1, info)).toBe(value1);
-    const value2 = '01:00';
+    const value2 = '00:00';
     expect(validate(value2, info)).toBe(value2);
     const value3 = '23:59';
     expect(validate(value3, info)).toBe(value3);
 
     expect(() => validate('', info)).toThrowError();
     expect(() => validate('1:34', info)).toThrowError();
-    expect(() => validate('00:00', info)).toThrowError();
-    expect(() => validate('25:00', info)).toThrowError();
+    expect(() => validate('24:00', info)).toThrowError();
     expect(() => validate('01:60', info)).toThrowError();
+    expect(() => validate('99:99', info)).toThrowError();
+    expect(() => validate('0:00', info)).toThrowError();
+    expect(() => validate('00:0', info)).toThrowError();
+    expect(() => validate('000:00', info)).toThrowError();
+    expect(() => validate('00:000', info)).toThrowError();
   });
 
   test('should throw custom error', () => {

--- a/library/src/validations/isoTime/isoTime.ts
+++ b/library/src/validations/isoTime/isoTime.ts
@@ -12,7 +12,7 @@ import type { ValidateInfo } from '../../types.ts';
  */
 export function isoTime<TInput extends string>(error?: string) {
   return (input: TInput, info: ValidateInfo) => {
-    if (!/^(0[1-9]|1\d|2[0-3]):[0-5]\d$/.test(input)) {
+    if (!/^(0[0-9]|1\d|2[0-3]):[0-5]\d$/.test(input)) {
       throw new ValiError([
         {
           validation: 'iso_time',

--- a/library/src/validations/isoTimeSecond/isoTimeSecond.test.ts
+++ b/library/src/validations/isoTimeSecond/isoTimeSecond.test.ts
@@ -8,17 +8,23 @@ describe('isoTimeSecond', () => {
     const validate = isoTimeSecond();
     const value1 = '19:34:12';
     expect(validate(value1, info)).toBe(value1);
-    const value2 = '01:00:00';
+    const value2 = '00:00:00';
     expect(validate(value2, info)).toBe(value2);
     const value3 = '23:59:59';
     expect(validate(value3, info)).toBe(value3);
 
     expect(() => validate('', info)).toThrowError();
     expect(() => validate('1:34:12', info)).toThrowError();
-    expect(() => validate('00:00:00', info)).toThrowError();
-    expect(() => validate('25:00:00', info)).toThrowError();
+    expect(() => validate('0:00:00', info)).toThrowError();
+    expect(() => validate('00:0:00', info)).toThrowError();
+    expect(() => validate('00:00:0', info)).toThrowError();
+    expect(() => validate('000:00:00', info)).toThrowError();
+    expect(() => validate('00:000:00', info)).toThrowError();
+    expect(() => validate('00:00:000', info)).toThrowError();
+    expect(() => validate('24:00:00', info)).toThrowError();
     expect(() => validate('01:60:00', info)).toThrowError();
     expect(() => validate('01:00:60', info)).toThrowError();
+    expect(() => validate('99:99:99', info)).toThrowError();
   });
 
   test('should throw custom error', () => {

--- a/library/src/validations/isoTimeSecond/isoTimeSecond.ts
+++ b/library/src/validations/isoTimeSecond/isoTimeSecond.ts
@@ -12,7 +12,7 @@ import type { ValidateInfo } from '../../types.ts';
  */
 export function isoTimeSecond<TInput extends string>(error?: string) {
   return (input: TInput, info: ValidateInfo) => {
-    if (!/^(0[1-9]|1\d|2[0-3]):[0-5]\d:[0-5]\d$/.test(input)) {
+    if (!/^(0[0-9]|1\d|2[0-3]):[0-5]\d:[0-5]\d$/.test(input)) {
       throw new ValiError([
         {
           validation: 'iso_time_second',

--- a/library/src/validations/isoTimestamp/isoTimestamp.test.ts
+++ b/library/src/validations/isoTimestamp/isoTimestamp.test.ts
@@ -8,7 +8,7 @@ describe('isoTimestamp', () => {
     const validate = isoTimestamp();
     const value1 = '2023-07-11T17:26:27.243Z';
     expect(validate(value1, info)).toBe(value1);
-    const value2 = '0000-01-01T01:00:00.000Z';
+    const value2 = '0000-01-01T00:00:00.000Z';
     expect(validate(value2, info)).toBe(value2);
     const value3 = '9999-12-31T23:59:59.999Z';
     expect(validate(value3, info)).toBe(value3);
@@ -17,6 +17,7 @@ describe('isoTimestamp', () => {
     expect(() => validate('2023-07-11T17:26:27.243', info)).toThrowError();
     expect(() => validate('2023-07-1117:26:27.243Z', info)).toThrowError();
     expect(() => validate('0000-00-00T00:00:00.000Z', info)).toThrowError();
+    expect(() => validate('9999-12-31T24:00:00.000', info)).toThrowError();
     expect(() => validate('10000-01-01T01:00:00.000Z', info)).toThrowError();
     expect(() => validate('0000-13-01T01:00:00.000Z', info)).toThrowError();
     expect(() => validate('0000-01-32T01:00:00.000Z', info)).toThrowError();

--- a/library/src/validations/isoTimestamp/isoTimestamp.ts
+++ b/library/src/validations/isoTimestamp/isoTimestamp.ts
@@ -17,7 +17,7 @@ import type { ValidateInfo } from '../../types.ts';
 export function isoTimestamp<TInput extends string>(error?: string) {
   return (input: TInput, info: ValidateInfo) => {
     if (
-      !/^\d{4}-(0[1-9]|1[0-2])-([12]\d|0[1-9]|3[01])T(0[1-9]|1\d|2[0-3]):[0-5]\d:[0-5]\d\.\d{3}Z$/.test(
+      !/^\d{4}-(0[1-9]|1[0-2])-([12]\d|0[1-9]|3[01])T(0[0-9]|1\d|2[0-3]):[0-5]\d:[0-5]\d\.\d{3}Z$/.test(
         input
       )
     ) {


### PR DESCRIPTION
The existing ISO timestamp validations only allowed `01`-`09` for hours, but not `00`. This fixes that.