### PR TITLE
docs: add typeschema to ecosystem

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -28,13 +28,9 @@ Use the button at the bottom left of this page to add your project to this ecosy
 
 - No entry yet - be quick to be the first
 
-### Adapter libraries
-
-- [TypeSchema](https://typeschema.com/): Universal adapter for schema validation
-
 ### Valibot to X
 
-- No entry yet - be quick to be the first
+- [TypeSchema](https://typeschema.com/): Universal adapter for schema validation
 
 ### X to Valibot
 

--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -28,6 +28,10 @@ Use the button at the bottom left of this page to add your project to this ecosy
 
 - No entry yet - be quick to be the first
 
+### Adapter libraries
+
+- [TypeSchema](https://typeschema.com/): Universal adapter for schema validation
+
 ### Valibot to X
 
 - No entry yet - be quick to be the first


### PR DESCRIPTION
Following up on https://github.com/decs/typeschema/issues/11, this pull request lists TypeSchema on the ecosystem page