### PR TITLE
Reduce spread operators to improve runtime performance

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `getPipeInfo` util and refactor code for performance reasons (pull request #46)
+
 ## v0.12.0 (August 11, 2023)
 
 - Change input type of `mimeType` validation to `Blob`

--- a/library/src/schemas/any/any.ts
+++ b/library/src/schemas/any/any.ts
@@ -1,5 +1,5 @@
 import type { BaseSchema, Pipe } from '../../types.ts';
-import { executePipe } from '../../utils/index.ts';
+import { executePipe, getPipeInfo } from '../../utils/index.ts';
 
 /**
  * Any schema type.
@@ -36,7 +36,7 @@ export function any(pipe: Pipe<any> = []): AnySchema {
      * @returns The parsed output.
      */
     parse(input, info) {
-      return executePipe(input, pipe, { ...info, reason: 'any' });
+      return executePipe(input, pipe, getPipeInfo(info, 'any'));
     },
   };
 }

--- a/library/src/schemas/any/anyAsync.ts
+++ b/library/src/schemas/any/anyAsync.ts
@@ -1,5 +1,5 @@
 import type { BaseSchemaAsync, PipeAsync } from '../../types.ts';
-import { executePipeAsync } from '../../utils/index.ts';
+import { executePipeAsync, getPipeInfo } from '../../utils/index.ts';
 
 /**
  * Any schema type.
@@ -36,7 +36,7 @@ export function anyAsync(pipe: PipeAsync<any> = []): AnySchemaAsync {
      * @returns The parsed output.
      */
     async parse(input, info) {
-      return executePipeAsync(input, pipe, { ...info, reason: 'any' });
+      return executePipeAsync(input, pipe, getPipeInfo(info, 'any'));
     },
   };
 }

--- a/library/src/schemas/array/array.ts
+++ b/library/src/schemas/array/array.ts
@@ -4,6 +4,7 @@ import {
   executePipe,
   getCurrentPath,
   getErrorAndPipe,
+  getPipeInfo,
 } from '../../utils/index.ts';
 
 /**
@@ -137,10 +138,11 @@ export function array<TArrayItem extends BaseSchema>(
       }
 
       // Execute pipe and return output
-      return executePipe(output as Output<TArrayItem>[], pipe, {
-        ...info,
-        reason: 'array',
-      });
+      return executePipe(
+        output as Output<TArrayItem>[],
+        pipe,
+        getPipeInfo(info, 'array')
+      );
     },
   };
 }

--- a/library/src/schemas/array/arrayAsync.ts
+++ b/library/src/schemas/array/arrayAsync.ts
@@ -10,6 +10,7 @@ import {
   executePipeAsync,
   getCurrentPath,
   getErrorAndPipe,
+  getPipeInfo,
 } from '../../utils/index.ts';
 
 /**
@@ -133,10 +134,11 @@ export function arrayAsync<TArrayItem extends BaseSchema | BaseSchemaAsync>(
       }
 
       // Execute pipe and return output
-      return executePipeAsync(output as Output<TArrayItem>[], pipe, {
-        ...info,
-        reason: 'array',
-      });
+      return executePipeAsync(
+        output as Output<TArrayItem>[],
+        pipe,
+        getPipeInfo(info, 'array')
+      );
     },
   };
 }

--- a/library/src/schemas/bigint/bigint.ts
+++ b/library/src/schemas/bigint/bigint.ts
@@ -1,6 +1,10 @@
 import { ValiError } from '../../error/index.ts';
 import type { BaseSchema, Pipe } from '../../types.ts';
-import { executePipe, getErrorAndPipe } from '../../utils/index.ts';
+import {
+  executePipe,
+  getErrorAndPipe,
+  getPipeInfo,
+} from '../../utils/index.ts';
 
 /**
  * Bigint schema type.
@@ -71,7 +75,7 @@ export function bigint(
       }
 
       // Execute pipe and return output
-      return executePipe(input, pipe, { ...info, reason: 'bigint' });
+      return executePipe(input, pipe, getPipeInfo(info, 'bigint'));
     },
   };
 }

--- a/library/src/schemas/bigint/bigintAsync.ts
+++ b/library/src/schemas/bigint/bigintAsync.ts
@@ -1,6 +1,10 @@
 import { ValiError } from '../../error/index.ts';
 import type { BaseSchemaAsync, PipeAsync } from '../../types.ts';
-import { executePipeAsync, getErrorAndPipe } from '../../utils/index.ts';
+import {
+  executePipeAsync,
+  getErrorAndPipe,
+  getPipeInfo,
+} from '../../utils/index.ts';
 
 /**
  * Bigint schema async type.
@@ -77,7 +81,7 @@ export function bigintAsync(
       }
 
       // Execute pipe and return output
-      return executePipeAsync(input, pipe, { ...info, reason: 'bigint' });
+      return executePipeAsync(input, pipe, getPipeInfo(info, 'bigint'));
     },
   };
 }

--- a/library/src/schemas/blob/blob.ts
+++ b/library/src/schemas/blob/blob.ts
@@ -1,6 +1,10 @@
 import { ValiError } from '../../error/index.ts';
 import type { BaseSchema, Pipe } from '../../types.ts';
-import { executePipe, getErrorAndPipe } from '../../utils/index.ts';
+import {
+  executePipe,
+  getErrorAndPipe,
+  getPipeInfo,
+} from '../../utils/index.ts';
 
 /**
  * Blob schema type.
@@ -71,7 +75,7 @@ export function blob(
       }
 
       // Execute pipe and return output
-      return executePipe(input, pipe, { ...info, reason: 'blob' });
+      return executePipe(input, pipe, getPipeInfo(info, 'blob'));
     },
   };
 }

--- a/library/src/schemas/blob/blobAsync.ts
+++ b/library/src/schemas/blob/blobAsync.ts
@@ -1,6 +1,10 @@
 import { ValiError } from '../../error/index.ts';
 import type { BaseSchemaAsync, PipeAsync } from '../../types.ts';
-import { executePipeAsync, getErrorAndPipe } from '../../utils/index.ts';
+import {
+  executePipeAsync,
+  getErrorAndPipe,
+  getPipeInfo,
+} from '../../utils/index.ts';
 
 /**
  * Blob schema async type.
@@ -74,7 +78,7 @@ export function blobAsync(
       }
 
       // Execute pipe and return output
-      return executePipeAsync(input, pipe, { ...info, reason: 'blob' });
+      return executePipeAsync(input, pipe, getPipeInfo(info, 'blob'));
     },
   };
 }

--- a/library/src/schemas/boolean/boolean.ts
+++ b/library/src/schemas/boolean/boolean.ts
@@ -1,6 +1,10 @@
 import { ValiError } from '../../error/index.ts';
 import type { BaseSchema, Pipe } from '../../types.ts';
-import { executePipe, getErrorAndPipe } from '../../utils/index.ts';
+import {
+  executePipe,
+  getErrorAndPipe,
+  getPipeInfo,
+} from '../../utils/index.ts';
 
 /**
  * Boolean schema type.
@@ -71,7 +75,7 @@ export function boolean(
       }
 
       // Execute pipe and return output
-      return executePipe(input, pipe, { ...info, reason: 'boolean' });
+      return executePipe(input, pipe, getPipeInfo(info, 'boolean'));
     },
   };
 }

--- a/library/src/schemas/boolean/booleanAsync.ts
+++ b/library/src/schemas/boolean/booleanAsync.ts
@@ -1,6 +1,10 @@
 import { ValiError } from '../../error/index.ts';
 import type { BaseSchemaAsync, PipeAsync } from '../../types.ts';
-import { executePipeAsync, getErrorAndPipe } from '../../utils/index.ts';
+import {
+  executePipeAsync,
+  getErrorAndPipe,
+  getPipeInfo,
+} from '../../utils/index.ts';
 
 /**
  * Boolean schema async type.
@@ -77,7 +81,7 @@ export function booleanAsync(
       }
 
       // Execute pipe and return output
-      return executePipeAsync(input, pipe, { ...info, reason: 'boolean' });
+      return executePipeAsync(input, pipe, getPipeInfo(info, 'boolean'));
     },
   };
 }

--- a/library/src/schemas/date/date.ts
+++ b/library/src/schemas/date/date.ts
@@ -1,6 +1,10 @@
 import { ValiError } from '../../error/index.ts';
 import type { BaseSchema, Pipe } from '../../types.ts';
-import { executePipe, getErrorAndPipe } from '../../utils/index.ts';
+import {
+  executePipe,
+  getErrorAndPipe,
+  getPipeInfo,
+} from '../../utils/index.ts';
 
 /**
  * Date schema type.
@@ -71,7 +75,7 @@ export function date(
       }
 
       // Execute pipe and return output
-      return executePipe(input, pipe, { ...info, reason: 'date' });
+      return executePipe(input, pipe, getPipeInfo(info, 'date'));
     },
   };
 }

--- a/library/src/schemas/date/dateAsync.ts
+++ b/library/src/schemas/date/dateAsync.ts
@@ -1,6 +1,10 @@
 import { ValiError } from '../../error/index.ts';
 import type { BaseSchemaAsync, PipeAsync } from '../../types.ts';
-import { executePipeAsync, getErrorAndPipe } from '../../utils/index.ts';
+import {
+  executePipeAsync,
+  getErrorAndPipe,
+  getPipeInfo,
+} from '../../utils/index.ts';
 
 /**
  * Date schema async type.
@@ -74,7 +78,7 @@ export function dateAsync(
       }
 
       // Execute pipe and return output
-      return executePipeAsync(input, pipe, { ...info, reason: 'date' });
+      return executePipeAsync(input, pipe, getPipeInfo(info, 'date'));
     },
   };
 }

--- a/library/src/schemas/instance/instance.ts
+++ b/library/src/schemas/instance/instance.ts
@@ -1,6 +1,10 @@
 import { ValiError } from '../../error/index.ts';
 import type { BaseSchema, Pipe } from '../../types.ts';
-import { executePipe, getErrorAndPipe } from '../../utils/index.ts';
+import {
+  executePipe,
+  getErrorAndPipe,
+  getPipeInfo,
+} from '../../utils/index.ts';
 
 /**
  * Class enum type.
@@ -95,10 +99,7 @@ export function instance<TClass extends Class>(
       }
 
       // Execute pipe and return output
-      return executePipe(input, pipe, {
-        ...info,
-        reason: 'instance',
-      });
+      return executePipe(input, pipe, getPipeInfo(info, 'instance'));
     },
   };
 }

--- a/library/src/schemas/instance/instanceAsync.ts
+++ b/library/src/schemas/instance/instanceAsync.ts
@@ -1,6 +1,10 @@
 import { ValiError } from '../../error/index.ts';
 import type { BaseSchemaAsync, PipeAsync } from '../../types.ts';
-import { executePipeAsync, getErrorAndPipe } from '../../utils/index.ts';
+import {
+  executePipeAsync,
+  getErrorAndPipe,
+  getPipeInfo,
+} from '../../utils/index.ts';
 import { type Class } from './instance.ts';
 
 /**
@@ -91,10 +95,7 @@ export function instanceAsync<TClass extends Class>(
       }
 
       // Execute pipe and return output
-      return executePipeAsync(input, pipe, {
-        ...info,
-        reason: 'instance',
-      });
+      return executePipeAsync(input, pipe, getPipeInfo(info, 'instance'));
     },
   };
 }

--- a/library/src/schemas/map/map.ts
+++ b/library/src/schemas/map/map.ts
@@ -4,6 +4,7 @@ import {
   executePipe,
   getCurrentPath,
   getErrorAndPipe,
+  getPipeInfo,
 } from '../../utils/index.ts';
 import type { MapInput, MapOutput } from './types.ts';
 
@@ -156,7 +157,7 @@ export function map<TMapKey extends BaseSchema, TMapValue extends BaseSchema>(
       }
 
       // Execute pipe and return output
-      return executePipe(output, pipe, { ...info, reason: 'map' });
+      return executePipe(output, pipe, getPipeInfo(info, 'map'));
     },
   };
 }

--- a/library/src/schemas/map/mapAsync.ts
+++ b/library/src/schemas/map/mapAsync.ts
@@ -9,6 +9,7 @@ import {
   executePipeAsync,
   getCurrentPath,
   getErrorAndPipe,
+  getPipeInfo,
 } from '../../utils/index.ts';
 import type { MapInput, MapOutput } from './types.ts';
 
@@ -180,7 +181,7 @@ export function mapAsync<
       }
 
       // Execute pipe and return output
-      return executePipeAsync(output, pipe, { ...info, reason: 'map' });
+      return executePipeAsync(output, pipe, getPipeInfo(info, 'map'));
     },
   };
 }

--- a/library/src/schemas/number/number.ts
+++ b/library/src/schemas/number/number.ts
@@ -1,6 +1,10 @@
 import { ValiError } from '../../error/index.ts';
 import type { BaseSchema, Pipe } from '../../types.ts';
-import { executePipe, getErrorAndPipe } from '../../utils/index.ts';
+import {
+  executePipe,
+  getErrorAndPipe,
+  getPipeInfo,
+} from '../../utils/index.ts';
 
 /**
  * Number schema type.
@@ -71,7 +75,7 @@ export function number(
       }
 
       // Execute pipe and return output
-      return executePipe(input, pipe, { ...info, reason: 'number' });
+      return executePipe(input, pipe, getPipeInfo(info, 'number'));
     },
   };
 }

--- a/library/src/schemas/number/numberAsync.ts
+++ b/library/src/schemas/number/numberAsync.ts
@@ -1,6 +1,10 @@
 import { ValiError } from '../../error/index.ts';
 import type { BaseSchemaAsync, PipeAsync } from '../../types.ts';
-import { executePipeAsync, getErrorAndPipe } from '../../utils/index.ts';
+import {
+  executePipeAsync,
+  getErrorAndPipe,
+  getPipeInfo,
+} from '../../utils/index.ts';
 
 /**
  * Number schema async type.
@@ -77,7 +81,7 @@ export function numberAsync(
       }
 
       // Execute pipe and return output
-      return executePipeAsync(input, pipe, { ...info, reason: 'number' });
+      return executePipeAsync(input, pipe, getPipeInfo(info, 'number'));
     },
   };
 }

--- a/library/src/schemas/object/object.ts
+++ b/library/src/schemas/object/object.ts
@@ -4,6 +4,7 @@ import {
   executePipe,
   getCurrentPath,
   getErrorAndPipe,
+  getPipeInfo,
 } from '../../utils/index.ts';
 import type { ObjectOutput, ObjectInput } from './types.ts';
 
@@ -131,10 +132,11 @@ export function object<TObjectShape extends ObjectShape>(
       }
 
       // Execute pipe and return output
-      return executePipe(output as ObjectOutput<TObjectShape>, pipe, {
-        ...info,
-        reason: 'object',
-      });
+      return executePipe(
+        output as ObjectOutput<TObjectShape>,
+        pipe,
+        getPipeInfo(info, 'object')
+      );
     },
   };
 }

--- a/library/src/schemas/object/objectAsync.ts
+++ b/library/src/schemas/object/objectAsync.ts
@@ -4,6 +4,7 @@ import {
   executePipeAsync,
   getCurrentPath,
   getErrorAndPipe,
+  getPipeInfo,
 } from '../../utils/index.ts';
 import type { ObjectInput, ObjectOutput } from './types.ts';
 
@@ -141,10 +142,11 @@ export function objectAsync<TObjectShape extends ObjectShapeAsync>(
       }
 
       // Execute pipe and return output
-      return executePipeAsync(output as ObjectOutput<TObjectShape>, pipe, {
-        ...info,
-        reason: 'object',
-      });
+      return executePipeAsync(
+        output as ObjectOutput<TObjectShape>,
+        pipe,
+        getPipeInfo(info, 'object')
+      );
     },
   };
 }

--- a/library/src/schemas/record/record.ts
+++ b/library/src/schemas/record/record.ts
@@ -4,6 +4,7 @@ import {
   executePipe,
   getCurrentPath,
   getErrorAndPipe,
+  getPipeInfo,
 } from '../../utils/index.ts';
 import { type StringSchema, string } from '../string/index.ts';
 import type { RecordOutput, RecordInput } from './types.ts';
@@ -218,7 +219,7 @@ export function record<
       return executePipe(
         output as RecordOutput<TRecordKey, TRecordValue>,
         pipe,
-        { ...info, reason: 'record' }
+        getPipeInfo(info, 'record')
       );
     },
   };

--- a/library/src/schemas/record/recordAsync.ts
+++ b/library/src/schemas/record/recordAsync.ts
@@ -4,6 +4,7 @@ import {
   executePipeAsync,
   getCurrentPath,
   getErrorAndPipe,
+  getPipeInfo,
 } from '../../utils/index.ts';
 import {
   type StringSchema,
@@ -239,7 +240,7 @@ export function recordAsync<
       return executePipeAsync(
         output as RecordOutput<TRecordKey, TRecordValue>,
         pipe,
-        { ...info, reason: 'record' }
+        getPipeInfo(info, 'record')
       );
     },
   };

--- a/library/src/schemas/set/set.ts
+++ b/library/src/schemas/set/set.ts
@@ -4,6 +4,7 @@ import {
   executePipe,
   getCurrentPath,
   getErrorAndPipe,
+  getPipeInfo,
 } from '../../utils/index.ts';
 import type { SetInput, SetOutput } from './types.ts';
 
@@ -129,7 +130,7 @@ export function set<TSetValue extends BaseSchema>(
       }
 
       // Execute pipe and return output
-      return executePipe(output, pipe, { ...info, reason: 'set' });
+      return executePipe(output, pipe, getPipeInfo(info, 'set'));
     },
   };
 }

--- a/library/src/schemas/set/setAsync.ts
+++ b/library/src/schemas/set/setAsync.ts
@@ -4,6 +4,7 @@ import {
   executePipeAsync,
   getCurrentPath,
   getErrorAndPipe,
+  getPipeInfo,
 } from '../../utils/index.ts';
 import type { SetInput, SetOutput } from './types.ts';
 
@@ -130,7 +131,7 @@ export function setAsync<TSetValue extends BaseSchema | BaseSchemaAsync>(
       }
 
       // Execute pipe and return output
-      return executePipeAsync(output, pipe, { ...info, reason: 'set' });
+      return executePipeAsync(output, pipe, getPipeInfo(info, 'set'));
     },
   };
 }

--- a/library/src/schemas/special/special.ts
+++ b/library/src/schemas/special/special.ts
@@ -1,6 +1,10 @@
 import { ValiError } from '../../error/index.ts';
 import type { BaseSchema, Pipe } from '../../types.ts';
-import { executePipe, getErrorAndPipe } from '../../utils/index.ts';
+import {
+  executePipe,
+  getErrorAndPipe,
+  getPipeInfo,
+} from '../../utils/index.ts';
 
 /**
  * Special schema type.
@@ -84,7 +88,7 @@ export function special<TInput>(
       }
 
       // Execute pipe and return output
-      return executePipe(input as TInput, pipe, { ...info, reason: 'special' });
+      return executePipe(input as TInput, pipe, getPipeInfo(info, 'special'));
     },
   };
 }

--- a/library/src/schemas/special/specialAsync.ts
+++ b/library/src/schemas/special/specialAsync.ts
@@ -1,6 +1,10 @@
 import { ValiError } from '../../error/index.ts';
 import type { BaseSchemaAsync, PipeAsync } from '../../types.ts';
-import { executePipeAsync, getErrorAndPipe } from '../../utils/index.ts';
+import {
+  executePipeAsync,
+  getErrorAndPipe,
+  getPipeInfo,
+} from '../../utils/index.ts';
 
 /**
  * Special schema async type.
@@ -84,10 +88,11 @@ export function specialAsync<TInput>(
       }
 
       // Execute pipe and return output
-      return executePipeAsync(input as TInput, pipe, {
-        ...info,
-        reason: 'special',
-      });
+      return executePipeAsync(
+        input as TInput,
+        pipe,
+        getPipeInfo(info, 'special')
+      );
     },
   };
 }

--- a/library/src/schemas/string/string.ts
+++ b/library/src/schemas/string/string.ts
@@ -1,6 +1,10 @@
 import { ValiError } from '../../error/index.ts';
 import type { BaseSchema, Pipe } from '../../types.ts';
-import { executePipe, getErrorAndPipe } from '../../utils/index.ts';
+import {
+  executePipe,
+  getErrorAndPipe,
+  getPipeInfo,
+} from '../../utils/index.ts';
 
 /**
  * String schema type.
@@ -71,7 +75,7 @@ export function string(
       }
 
       // Execute pipe and return output
-      return executePipe(input, pipe, { ...info, reason: 'string' });
+      return executePipe(input, pipe, getPipeInfo(info, 'string'));
     },
   };
 }

--- a/library/src/schemas/string/stringAsync.ts
+++ b/library/src/schemas/string/stringAsync.ts
@@ -1,6 +1,10 @@
 import { ValiError } from '../../error/index.ts';
 import type { BaseSchemaAsync, PipeAsync } from '../../types.ts';
-import { executePipeAsync, getErrorAndPipe } from '../../utils/index.ts';
+import {
+  executePipeAsync,
+  getErrorAndPipe,
+  getPipeInfo,
+} from '../../utils/index.ts';
 
 /**
  * String schema async type.
@@ -77,7 +81,7 @@ export function stringAsync(
       }
 
       // Execute pipe and return output
-      return executePipeAsync(input, pipe, { ...info, reason: 'string' });
+      return executePipeAsync(input, pipe, getPipeInfo(info, 'string'));
     },
   };
 }

--- a/library/src/schemas/tuple/tuple.ts
+++ b/library/src/schemas/tuple/tuple.ts
@@ -4,6 +4,7 @@ import {
   executePipe,
   getCurrentPath,
   getErrorAndPipe,
+  getPipeInfo,
 } from '../../utils/index.ts';
 import type { TupleOutput, TupleInput } from './types.ts';
 
@@ -218,10 +219,11 @@ export function tuple<
       }
 
       // Execute pipe and return output
-      return executePipe(output as TupleOutput<TTupleItems, TTupleRest>, pipe, {
-        ...info,
-        reason: 'tuple',
-      });
+      return executePipe(
+        output as TupleOutput<TTupleItems, TTupleRest>,
+        pipe,
+        getPipeInfo(info, 'tuple')
+      );
     },
   };
 }

--- a/library/src/schemas/tuple/tupleAsync.ts
+++ b/library/src/schemas/tuple/tupleAsync.ts
@@ -4,6 +4,7 @@ import {
   executePipeAsync,
   getCurrentPath,
   getErrorAndPipe,
+  getPipeInfo,
 } from '../../utils/index.ts';
 import type { TupleInput, TupleOutput } from './types.ts';
 
@@ -229,10 +230,7 @@ export function tupleAsync<
       return executePipeAsync(
         output as TupleOutput<TTupleItems, TTupleRest>,
         pipe,
-        {
-          ...info,
-          reason: 'tuple',
-        }
+        getPipeInfo(info, 'tuple')
       );
     },
   };

--- a/library/src/schemas/unknown/unknown.ts
+++ b/library/src/schemas/unknown/unknown.ts
@@ -1,5 +1,5 @@
 import type { BaseSchema, Pipe } from '../../types.ts';
-import { executePipe } from '../../utils/index.ts';
+import { executePipe, getPipeInfo } from '../../utils/index.ts';
 
 /**
  * Unknown schema type.
@@ -36,7 +36,7 @@ export function unknown(pipe: Pipe<unknown> = []): UnknownSchema {
      * @returns The parsed output.
      */
     parse(input, info) {
-      return executePipe(input, pipe, { ...info, reason: 'unknown' });
+      return executePipe(input, pipe, getPipeInfo(info, 'unknown'));
     },
   };
 }

--- a/library/src/schemas/unknown/unknownAsync.ts
+++ b/library/src/schemas/unknown/unknownAsync.ts
@@ -1,5 +1,5 @@
 import type { BaseSchemaAsync, PipeAsync } from '../../types.ts';
-import { executePipeAsync } from '../../utils/index.ts';
+import { executePipeAsync, getPipeInfo } from '../../utils/index.ts';
 
 /**
  * Unknown schema async type.
@@ -41,7 +41,7 @@ export function unknownAsync(
      * @returns The parsed output.
      */
     async parse(input, info) {
-      return executePipeAsync(input, pipe, { ...info, reason: 'unknown' });
+      return executePipeAsync(input, pipe, getPipeInfo(info, 'unknown'));
     },
   };
 }

--- a/library/src/utils/getPipeInfo/getPipeInfo.test.ts
+++ b/library/src/utils/getPipeInfo/getPipeInfo.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'vitest';
+import { getPipeInfo } from './getPipeInfo.ts';
+
+describe('getPipeInfo', () => {
+  test('should return pipe info', () => {
+    expect(getPipeInfo(undefined, 'number')).toEqual({ reason: 'number' });
+    expect(getPipeInfo({ origin: 'value' }, 'string')).toEqual({
+      origin: 'value',
+      reason: 'string',
+    });
+  });
+});

--- a/library/src/utils/getPipeInfo/getPipeInfo.ts
+++ b/library/src/utils/getPipeInfo/getPipeInfo.ts
@@ -1,0 +1,25 @@
+import type { IssueReason } from '../../error/index.ts';
+import type { ParseInfo, ValidateInfo } from '../../types.ts';
+
+/**
+ * Returns the pipe info.
+ *
+ * @param info The parse info.
+ * @param reason The issue reason.
+ *
+ * @returns The pipe info.
+ */
+export function getPipeInfo(
+  info: ParseInfo | undefined,
+  reason: IssueReason
+): ValidateInfo {
+  // Hint: The pipe info is deliberately not constructed with the spread
+  // operator for performance reasons
+  return {
+    origin: info?.origin,
+    path: info?.path,
+    abortEarly: info?.abortEarly,
+    abortPipeEarly: info?.abortPipeEarly,
+    reason,
+  };
+}

--- a/library/src/utils/getPipeInfo/index.ts
+++ b/library/src/utils/getPipeInfo/index.ts
@@ -1,0 +1,1 @@
+export * from './getPipeInfo.ts';

--- a/library/src/utils/index.ts
+++ b/library/src/utils/index.ts
@@ -2,3 +2,26 @@ export * from './executePipe/index.ts';
 export * from './getCurrentPath/index.ts';
 export * from './getErrorAndPipe/index.ts';
 export * from './isLuhnAlgo/index.ts';
+import type { IssueReason } from '../index.ts';
+import type { ParseInfo, ValidateInfo } from '../types.ts';
+
+/**
+ * Construct ValidateInfo without using spread operator for performance reasons
+ *
+ * @param info The parse info
+ * @param reason The reason to be merged with the parse info
+ *
+ * @returns The merged valiate info
+ */
+export function getPipeInfo(
+  info: ParseInfo | undefined,
+  reason: IssueReason
+): ValidateInfo {
+  return {
+    origin: info?.origin,
+    path: info?.path,
+    abortEarly: info?.abortEarly,
+    abortPipeEarly: info?.abortPipeEarly,
+    reason,
+  };
+}

--- a/library/src/utils/index.ts
+++ b/library/src/utils/index.ts
@@ -1,27 +1,5 @@
 export * from './executePipe/index.ts';
 export * from './getCurrentPath/index.ts';
 export * from './getErrorAndPipe/index.ts';
+export * from './getPipeInfo/index.ts';
 export * from './isLuhnAlgo/index.ts';
-import type { IssueReason } from '../index.ts';
-import type { ParseInfo, ValidateInfo } from '../types.ts';
-
-/**
- * Construct ValidateInfo without using spread operator for performance reasons
- *
- * @param info The parse info
- * @param reason The reason to be merged with the parse info
- *
- * @returns The merged valiate info
- */
-export function getPipeInfo(
-  info: ParseInfo | undefined,
-  reason: IssueReason
-): ValidateInfo {
-  return {
-    origin: info?.origin,
-    path: info?.path,
-    abortEarly: info?.abortEarly,
-    abortPipeEarly: info?.abortPipeEarly,
-    reason,
-  };
-}


### PR DESCRIPTION
I found that removing the object spread operator greatly improve the runtime performance of `parse`. Without this PR (`main`: 506149a2de9755f91a033f340a42917b8457c82e), I confirmed that in many benchmarks, Valibot is much slower than Zod but after this PR, Valibot is mostly faster than Zod.

I created this PR so that people can run benchmarks and we can discuss the actual implementation details to move forward.

## Benchmarks
I used [this benchmark](https://github.com/fabian-hiller/valibot/issues/19#issue-1824216605) to confirm this PR makes a big impact at least for my environment (MacBook Air M2). I would appreciate if more people can confirm this. Note that I removed yup and Joi since they seemed to affect the benchmark results. We should make sure the benchmark is actually correct but I think **it's safe to say that Valibot can be actually faster than Zod with small tweaks like this PR**

- Before this PR (`main`: 506149a2de9755f91a033f340a42917b8457c82e)
```
: zod validate x 2,258,349 ops/sec ±1.14% (98 runs sampled)
: valibot validate x 713,707 ops/sec ±0.48% (93 runs sampled)
Fastest is zod validate
```

- After this PR (97ebba69c1cda0edabe9a4086054da3d1939edbf)
```
: zod validate x 2,289,850 ops/sec ±0.72% (101 runs sampled)
: valibot validate x 2,762,403 ops/sec ±0.07% (98 runs sampled)
Fastest is valibot validate
```

Note that I also tested this in https://github.com/moltar/typescript-runtime-type-benchmarks/pull/1112

## Backstory 
Recently I got amazed how Valibot is designed ❤️  ([Twitter thread in Japanese](https://twitter.com/naruaway/status/1687000165406904320)).

The implementation is really clean, modular, and simple. Since I am a huge fun of Zod and its bundle size is big, I was trying to invent special compiler for Zod to reduce the bundle size and it turned out that it was futile since Zod's implementation is hard to untangle and simplify.
So I just decided to use Valibot for my personal projects and I also want to support wider adoption for more serious production usage as well.

However, if we think of Valibot as "Zod replacement", runtime performance of `parse` is definitely a concern. For example, if we implement some validation logic in server side, we might suffer from DoS attack more often than when using Zod if the validation performance of Valibot is slower. Actually I expected Valibot is faster since the implementation is simpler than Zod. But it turned out that it's much slower than Zod in several benchmarks ([one example](https://github.com/fabian-hiller/valibot/issues/19#issue-1824216605)). I also tested several patterns locally and Zod was always much faster. After I played with Valibot codebase, I just found that we use the object spread operator in the hotpath of `parse` and removing that greatly improves the performance in my environment.


## Misc
I also tested some other things like caching object keys in `object.ts` and it looks like it's also improving the performance in some benchmarks. But I want to make sure we have good suite of benchmarks before discussing further on this. Reducing the object spread operator seems to have the biggest impact. 