### PR TITLE
perf(object): cache object keys

### DIFF
--- a/library/src/schemas/object/object.ts
+++ b/library/src/schemas/object/object.ts
@@ -59,6 +59,9 @@ export function object<TObjectShape extends ObjectShape>(
   // Get error and pipe argument
   const { error, pipe } = getErrorAndPipe(arg2, arg3);
 
+  // Cache object keys for better .parse() performance
+  const objectKeys = Object.keys(object);
+
   // Create and return object schema
   return {
     /**
@@ -108,7 +111,8 @@ export function object<TObjectShape extends ObjectShape>(
       const issues: Issue[] = [];
 
       // Parse schema of each key
-      Object.entries(object).forEach(([key, schema]) => {
+      objectKeys.forEach((key) => {
+        const schema = object[key];
         try {
           const value = (input as Record<string, unknown>)[key];
           output[key] = schema.parse(value, {

--- a/library/src/schemas/object/objectAsync.ts
+++ b/library/src/schemas/object/objectAsync.ts
@@ -62,6 +62,9 @@ export function objectAsync<TObjectShape extends ObjectShapeAsync>(
   // Get error and pipe argument
   const { error, pipe } = getErrorAndPipe(arg2, arg3);
 
+  // Cache object keys for better .parse() performance
+  const objectKeys = Object.keys(object);
+
   // Create and return async object schema
   return {
     /**
@@ -112,7 +115,8 @@ export function objectAsync<TObjectShape extends ObjectShapeAsync>(
 
       // Parse schema of each key
       await Promise.all(
-        Object.entries(object).map(async ([key, schema]) => {
+        objectKeys.map(async (key) => {
+          const schema = object[key];
           try {
             const value = (input as Record<string, unknown>)[key];
             output[key] = await schema.parse(value, {


### PR DESCRIPTION
I confirmed that this improves parse performance since checking object keys is relatively expensive operation (probably similar reason as https://github.com/fabian-hiller/valibot/pull/46).

I'll add benchmark results later but the code change itself might be already acceptable. I think the only drawback of this change is slightly slower schema creation.

Note that Zod is [caching object keys here](https://github.com/colinhacks/zod/blob/78a409012a4dc34a455f5c4a7e028ca47c921e1b/src/types.ts#L2238-L2243) but the logic will run on the initial `parse` call. We can do the same thing but it will increase the code size. So far I personally prefer not having such a complicated logic.