### PR TITLE
docs: add Hono to ecosystem page

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -17,7 +17,7 @@ Use the button at the bottom left of this page to add your project to this ecosy
 
 ### API libraries
 
-- No entry yet - be quick to be the first
+- [Hono](https://hono.dev/): Ultrafast web framework for the Edges
 
 ### Form libraries
 


### PR DESCRIPTION
Hono now includes support for Valibot (https://github.com/honojs/middleware/pull/102) so we should add it to the list.

Thanks for your work!