### PR TITLE
docs: added missing transform to imports

### DIFF
--- a/website/src/routes/guides/(main-concepts)/infer-types/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/infer-types/index.mdx
@@ -31,7 +31,7 @@ type LoginInput = Input<typeof LoginSchema>; // { email: string; password: strin
 The output type differs from the input type only if you use <Link href="/api/transform">`transform`</Link> to transform the input of a schema after validation. The output type always corresponds to the return value of the <Link href="/api/parse">`parse`</Link> method. To infer it, you use the utility type <Link href="/api/Output">`Output`</Link>.
 
 ```ts
-import { object, type Output, string } from 'valibot'; // 0.59 kB
+import { object, type Output, string, transform } from 'valibot'; // 0.59 kB
 import { hashPassword } from '~/utils';
 
 const LoginSchema = transform(

--- a/website/src/routes/guides/(main-concepts)/infer-types/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/infer-types/index.mdx
@@ -31,7 +31,7 @@ type LoginInput = Input<typeof LoginSchema>; // { email: string; password: strin
 The output type differs from the input type only if you use <Link href="/api/transform">`transform`</Link> to transform the input of a schema after validation. The output type always corresponds to the return value of the <Link href="/api/parse">`parse`</Link> method. To infer it, you use the utility type <Link href="/api/Output">`Output`</Link>.
 
 ```ts
-import { object, type Output, string, transform } from 'valibot'; // 0.59 kB
+import { object, type Output, string, transform } from 'valibot'; // 0.63 kB
 import { hashPassword } from '~/utils';
 
 const LoginSchema = transform(


### PR DESCRIPTION
Fixed missing import, as it seems like it's a custom function and not a part of valibot