### PR TITLE
security: Mitigate Prototype Pollution Vulnerability

### DIFF
--- a/library/src/schemas/record/record.test.ts
+++ b/library/src/schemas/record/record.test.ts
@@ -6,6 +6,7 @@ import { number } from '../number/index.ts';
 import { string } from '../string/index.ts';
 import { union } from '../union/index.ts';
 import { record } from './record.ts';
+import {any} from "../any";
 
 describe('record', () => {
   test('should pass only objects', () => {
@@ -87,4 +88,14 @@ describe('record', () => {
     expect(output3).toEqual(transformInput());
     expect(output4).toEqual(transformInput());
   });
+
+
+  test("should not be vulnerable to prototype pollution", () => {
+    const schema = record(string(), any());
+    const input = JSON.parse('{"__proto__":{"polluted":"yes"}}');
+    expect(input.__proto__.polluted).toBe("yes");
+    expect(({} as any).polluted).toBeUndefined();
+    const parsed = parse(schema, input);
+    expect((parsed as any).polluted).toBeUndefined();
+  })
 });

--- a/library/src/schemas/record/record.ts
+++ b/library/src/schemas/record/record.ts
@@ -8,6 +8,8 @@ import {
 import { type StringSchema, string } from '../string/index.ts';
 import type { RecordOutput, RecordInput } from './types.ts';
 
+const BLOCKED_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+
 /**
  * Record key type.
  */
@@ -163,6 +165,13 @@ export function record<
       // Parse each key and value by schema
       // Note: `Object.entries(...)` converts each key to a string
       Object.entries(input).forEach(([inputKey, inputValue]) => {
+
+        // Check if key is blocked
+        if (BLOCKED_KEYS.has(inputKey)) {
+            return;
+        }
+
+
         // Get current path
         const path = getCurrentPath(info, {
           schema: 'record',


### PR DESCRIPTION
This pull request addresses a critical issue in the current record schema that makes it susceptible to prototype pollution. The vulnerability arises due to the lack of key validation, allowing certain keys to be exploited, leading to potential security risks.

To mitigate this vulnerability, I have implemented a key blacklisting mechanism. By doing so, specific keys prone to prototype pollution are disallowed within the record schema.