### PR TITLE
refactor(record): prefer arrays over sets for lookups of blocked keys

### DIFF
--- a/library/src/schemas/array/array.ts
+++ b/library/src/schemas/array/array.ts
@@ -108,7 +108,7 @@ export function array<TArrayItem extends BaseSchema>(
       const issues: Issue[] = [];
 
       // Parse schema of each array item
-      input.forEach((value, index) => {
+      for (const [index, value] of input.entries()) {
         try {
           output.push(
             item.parse(value, {
@@ -129,7 +129,7 @@ export function array<TArrayItem extends BaseSchema>(
           }
           issues.push(...(error as ValiError).issues);
         }
-      });
+      }
 
       // Throw error if there are issues
       if (issues.length) {

--- a/library/src/schemas/object/object.ts
+++ b/library/src/schemas/object/object.ts
@@ -108,7 +108,7 @@ export function object<TObjectShape extends ObjectShape>(
       const issues: Issue[] = [];
 
       // Parse schema of each key
-      Object.entries(object).forEach(([key, schema]) => {
+      for (const [key, schema] of Object.entries(object)) {
         try {
           const value = (input as Record<string, unknown>)[key];
           output[key] = schema.parse(value, {
@@ -123,7 +123,7 @@ export function object<TObjectShape extends ObjectShape>(
           }
           issues.push(...(error as ValiError).issues);
         }
-      });
+      }
 
       // Throw error if there are issues
       if (issues.length) {

--- a/library/src/schemas/record/record.ts
+++ b/library/src/schemas/record/record.ts
@@ -165,47 +165,49 @@ export function record<
       // Note: `Object.entries(...)` converts each key to a string
       Object.entries(input).forEach(([inputKey, inputValue]) => {
         // Exclude blocked keys to prevent prototype pollutions
-        if (!BLOCKED_KEYS.includes(inputKey)) {
-          // Get current path
-          const path = getCurrentPath(info, {
-            schema: 'record',
-            input,
-            key: inputKey,
-            value: inputValue,
-          });
+        if (BLOCKED_KEYS.includes(inputKey)) {
+          return;
+        }
 
-          // Parse key and get output
-          let outputKey: string | number | symbol | undefined;
-          try {
-            outputKey = key.parse(inputKey, { ...info, origin: 'key', path });
+        // Get current path
+        const path = getCurrentPath(info, {
+          schema: 'record',
+          input,
+          key: inputKey,
+          value: inputValue,
+        });
 
-            // Throw or fill issues in case of an error
-          } catch (error) {
-            if (info?.abortEarly) {
-              throw error;
-            }
-            issues.push(...(error as ValiError).issues);
+        // Parse key and get output
+        let outputKey: string | number | symbol | undefined;
+        try {
+          outputKey = key.parse(inputKey, { ...info, origin: 'key', path });
+
+          // Throw or fill issues in case of an error
+        } catch (error) {
+          if (info?.abortEarly) {
+            throw error;
           }
+          issues.push(...(error as ValiError).issues);
+        }
 
-          // Parse value and get output
-          let outputValue: [any] | undefined;
-          try {
-            // Note: Value is nested in array, so that also a falsy value further
-            // down can be recognized as valid value
-            outputValue = [value.parse(inputValue, { ...info, path })];
+        // Parse value and get output
+        let outputValue: [any] | undefined;
+        try {
+          // Note: Value is nested in array, so that also a falsy value further
+          // down can be recognized as valid value
+          outputValue = [value.parse(inputValue, { ...info, path })];
 
-            // Throw or fill issues in case of an error
-          } catch (error) {
-            if (info?.abortEarly) {
-              throw error;
-            }
-            issues.push(...(error as ValiError).issues);
+          // Throw or fill issues in case of an error
+        } catch (error) {
+          if (info?.abortEarly) {
+            throw error;
           }
+          issues.push(...(error as ValiError).issues);
+        }
 
-          // Set entry if output key and value is valid
-          if (outputKey && outputValue) {
-            output[outputKey] = outputValue[0];
-          }
+        // Set entry if output key and value is valid
+        if (outputKey && outputValue) {
+          output[outputKey] = outputValue[0];
         }
       });
 

--- a/library/src/schemas/record/record.ts
+++ b/library/src/schemas/record/record.ts
@@ -163,10 +163,10 @@ export function record<
 
       // Parse each key and value by schema
       // Note: `Object.entries(...)` converts each key to a string
-      Object.entries(input).forEach(([inputKey, inputValue]) => {
+      for (const [inputKey, inputValue] of Object.entries(input)) {
         // Exclude blocked keys to prevent prototype pollutions
         if (BLOCKED_KEYS.includes(inputKey)) {
-          return;
+          continue;
         }
 
         // Get current path
@@ -209,7 +209,7 @@ export function record<
         if (outputKey && outputValue) {
           output[outputKey] = outputValue[0];
         }
-      });
+      }
 
       // Throw error if there are issues
       if (issues.length) {

--- a/library/src/schemas/record/record.ts
+++ b/library/src/schemas/record/record.ts
@@ -165,7 +165,7 @@ export function record<
       // Note: `Object.entries(...)` converts each key to a string
       Object.entries(input).forEach(([inputKey, inputValue]) => {
         // Exclude blocked keys to prevent prototype pollutions
-        if (!BLOCKED_KEYS.has(inputKey)) {
+        if (!BLOCKED_KEYS.includes(inputKey)) {
           // Get current path
           const path = getCurrentPath(info, {
             schema: 'record',

--- a/library/src/schemas/record/recordAsync.ts
+++ b/library/src/schemas/record/recordAsync.ts
@@ -175,57 +175,59 @@ export function recordAsync<
         // Note: `Object.entries(...)` converts each key to a string
         Object.entries(input).map(async ([inputKey, inputValue]) => {
           // Exclude blocked keys to prevent prototype pollutions
-          if (!BLOCKED_KEYS.includes(inputKey)) {
-            // Get current path
-            const path = getCurrentPath(info, {
-              schema: 'record',
-              input,
-              key: inputKey,
-              value: inputValue,
-            });
+          if (BLOCKED_KEYS.includes(inputKey)) {
+            return;
+          }
 
-            const [outputKey, outputValue] = await Promise.all([
-              // Parse key and get output
-              (async () => {
-                try {
-                  return await key.parse(inputKey, {
-                    ...info,
-                    origin: 'key',
-                    path,
-                  });
+          // Get current path
+          const path = getCurrentPath(info, {
+            schema: 'record',
+            input,
+            key: inputKey,
+            value: inputValue,
+          });
 
-                  // Throw or fill issues in case of an error
-                } catch (error) {
-                  if (info?.abortEarly) {
-                    throw error;
-                  }
-                  issues.push(...(error as ValiError).issues);
+          const [outputKey, outputValue] = await Promise.all([
+            // Parse key and get output
+            (async () => {
+              try {
+                return await key.parse(inputKey, {
+                  ...info,
+                  origin: 'key',
+                  path,
+                });
+
+                // Throw or fill issues in case of an error
+              } catch (error) {
+                if (info?.abortEarly) {
+                  throw error;
                 }
-              })(),
+                issues.push(...(error as ValiError).issues);
+              }
+            })(),
 
-              // Parse value and get output
-              (async () => {
-                try {
-                  // Note: Value is nested in array, so that also a falsy value further
-                  // down can be recognized as valid value
-                  return [
-                    await value.parse(inputValue, { ...info, path }),
-                  ] as const;
+            // Parse value and get output
+            (async () => {
+              try {
+                // Note: Value is nested in array, so that also a falsy value further
+                // down can be recognized as valid value
+                return [
+                  await value.parse(inputValue, { ...info, path }),
+                ] as const;
 
-                  // Throw or fill issues in case of an error
-                } catch (error) {
-                  if (info?.abortEarly) {
-                    throw error;
-                  }
-                  issues.push(...(error as ValiError).issues);
+                // Throw or fill issues in case of an error
+              } catch (error) {
+                if (info?.abortEarly) {
+                  throw error;
                 }
-              })(),
-            ]);
+                issues.push(...(error as ValiError).issues);
+              }
+            })(),
+          ]);
 
-            // Set entry if output key and value is valid
-            if (outputKey && outputValue) {
-              output[outputKey] = outputValue[0];
-            }
+          // Set entry if output key and value is valid
+          if (outputKey && outputValue) {
+            output[outputKey] = outputValue[0];
           }
         })
       );

--- a/library/src/schemas/record/recordAsync.ts
+++ b/library/src/schemas/record/recordAsync.ts
@@ -175,7 +175,7 @@ export function recordAsync<
         // Note: `Object.entries(...)` converts each key to a string
         Object.entries(input).map(async ([inputKey, inputValue]) => {
           // Exclude blocked keys to prevent prototype pollutions
-          if (!BLOCKED_KEYS.has(inputKey)) {
+          if (!BLOCKED_KEYS.includes(inputKey)) {
             // Get current path
             const path = getCurrentPath(info, {
               schema: 'record',

--- a/library/src/schemas/record/values.ts
+++ b/library/src/schemas/record/values.ts
@@ -1,1 +1,1 @@
-export const BLOCKED_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+export const BLOCKED_KEYS = ['__proto__', 'prototype', 'constructor'];

--- a/library/src/schemas/tuple/tuple.ts
+++ b/library/src/schemas/tuple/tuple.ts
@@ -165,7 +165,7 @@ export function tuple<
       const issues: Issue[] = [];
 
       // Parse schema of each tuple item
-      items.forEach((schema, index) => {
+      for (const [index, schema] of items.entries()) {
         try {
           const value = input[index];
           output[index] = schema.parse(value, {
@@ -185,11 +185,11 @@ export function tuple<
           }
           issues.push(...(error as ValiError).issues);
         }
-      });
+      }
 
       // If necessary parse schema of each rest item
       if (rest) {
-        input.slice(items.length).forEach((value, index) => {
+        for (const [index, value] of input.slice(items.length).entries()) {
           try {
             const tupleIndex = items.length + index;
             output[tupleIndex] = rest.parse(value, {
@@ -209,7 +209,7 @@ export function tuple<
             }
             issues.push(...(error as ValiError).issues);
           }
-        });
+        }
       }
 
       // Throw error if there are issues

--- a/library/src/utils/executePipe/executePipe.ts
+++ b/library/src/utils/executePipe/executePipe.ts
@@ -20,7 +20,7 @@ export function executePipe<TValue>(
   const issues: Issue[] = [];
 
   // Execute any action of pipe
-  pipe.forEach((action) => {
+  for (const action of pipe) {
     try {
       output = action(output, info);
 
@@ -31,7 +31,7 @@ export function executePipe<TValue>(
       }
       issues.push(...(error as ValiError).issues);
     }
-  });
+  }
 
   // Throw error if there are issues
   if (issues.length) {


### PR DESCRIPTION
## Going from `Set` to `Array`

Following #67, this PR swaps the container of `BLOCKED_KEYS` from a `Set` into an `Array`. This is because although `Set#has` is $O(1)$, the constant coefficient for this is actually quite expensive due to underlying hashing algorithms. In comparison, the $O(n)$ function `Array#includes` should be faster **for small arrays** for the following reasons:

1. `Array#includes` is a built-in method which does not perform any hashing.
2. With its elements being collocated, arrays are typically friendlier to the CPU cache. This is not the case for sets whose elements are sparsely located in a buffer.

In the case of `BLOCKED_KEYS`, three elements are certainly sufficiently small to justify the linear search. See the discussion in https://github.com/fabian-hiller/valibot/pull/67#discussion_r1285232159 for more details and some benchmarks.

## Short-circuiting

Along the way, I also inverted the logic in the `forEach` loops to accommodate for short-circuiting and fewer indentations. Moreover, I converted a `forEach` loop in `record.ts` to a `for...of` loop because the latter is generally considered to be faster.