### PR TITLE
fix(ci): enable CI on pull requests

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -2,9 +2,8 @@ name: Node.js CI
 
 on:
   push:
-    branches: ['main']
+    branches: main
   pull_request:
-    branches: ['main']
 
 jobs:
   test:


### PR DESCRIPTION
Currently, CI does not run in all pull requests. In fact, the only time it runs is when the branch of the forked repository also happens to be named `main` (i.e., the default branch). Since it is generally a best practice to branch out of `main` even in a fork, resulting PRs back into Valibot does not trigger CI.

This PR simply removes the `main` branch restriction on the `pull_request` hook for GitHub Actions, thereby allowing the `node` workflow to run in PRs.