### PR TITLE
fix(typo): "pare data" => "parse data"

### DIFF
--- a/website/src/routes/guides/(main-concepts)/methods/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/methods/index.mdx
@@ -15,7 +15,7 @@ My schema methods either add additional functionality, simplify the handling or 
 
 Schema methods: <Link href="/api/coerce">`coerce`</Link>, <Link href="/api/coerceAsync">`coerceAsync`</Link>, <Link href="/api/is">`is`</Link>, <Link href="/api/parse">`parse`</Link>, <Link href="/api/parseAsync">`parseAsync`</Link>, <Link href="/api/safeParse">`safeParse`</Link>, <Link href="/api/safeParseAsync">`safeParseAsync`</Link>, <Link href="/api/transform">`transform`</Link>, <Link href="/api/transformAsync">`transformAsync`</Link>, <Link href="/api/unwrap">`unwrap`</Link>, <Link href="/api/useDefault">`useDefault`</Link>
 
-> For more on methods for validation, see the <Link href="/parse-data">pare data</Link> guide.
+> For more on methods for validation, see the <Link href="/parse-data">parse data</Link> guide.
 
 ### Coerce
 


### PR DESCRIPTION
fixed a small typo mistake