### PR TITLE
Fallback method

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the library will be documented in this file.
 > Note: The library has been revised and refactored. There is a migration guide in the [release notes](https://github.com/fabian-hiller/valibot/releases/tag/vX.X.X).
 
 - Add `getPipeInfo`, `getPathInfo` and `getIssue` util (pull request #46, #92, #93)
+- Add `fallback` and `fallbackAsync` method (pull request #103)
 - Expand `flatten` so that issues are also accepted as first argument
 - Change return type of `safeParse` and `safeParseAsync` method
 - Change error handling and refactor library to improve performance

--- a/library/src/methods/fallback/fallback.test.ts
+++ b/library/src/methods/fallback/fallback.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, expectTypeOf  } from 'vitest';
+import { describe, test, expect, expectTypeOf } from 'vitest';
 import { object, string, number } from '../../schemas/index.ts';
 import { minLength } from '../../validations/index.ts';
 import { Issue, Issues, parse, safeParse } from '../../index.ts';
@@ -9,7 +9,7 @@ describe('fallback', () => {
     const schema = fallback(string(), 'world');
     const output = parse(schema, 'hello');
     expect(output).toBe('hello');
-    expectTypeOf(output).toEqualTypeOf<string>()
+    expectTypeOf(output).toEqualTypeOf<string>();
   });
 
   test('should succeed to parse but return fallback value', () => {
@@ -24,33 +24,47 @@ describe('fallback', () => {
       data: number(),
     });
 
-    let issues: any
-    const fallbackValue = { text: 'hello world', data: 5 }
-    const schema = fallback(objectSchema, fallbackValue, (dataIssues) => { issues = dataIssues });
+    let issues: any;
+    const fallbackValue = { text: 'hello world', data: 5 };
+    const schema = fallback(objectSchema, fallbackValue, (dataIssues) => {
+      issues = dataIssues;
+    });
 
-    const data = { text: 'hello' }
+    const data = { text: 'hello' };
     const output = parse(schema, data);
-    expectTypeOf(output).toEqualTypeOf<{ text: string, data: number }>()
+    expectTypeOf(output).toEqualTypeOf<{ text: string; data: number }>();
     expect(output).toEqual(fallbackValue);
 
     expect(issues).lengthOf.above(0);
     //expect(issues).toEqual([  ]);
 
-    const result = safeParse(objectSchema, data)
-    expect(result.success).toBeFalsy()
-    expect((result as any).issues).toEqual(issues)
+    const result = safeParse(objectSchema, data);
+    expect(result.success).toBeFalsy();
+    expect((result as any).issues).toEqual(issues);
   });
 
   test('nested fallback', () => {
-    let warnings: any
-    const fallbackValue = { text: 'hello world', data: 5 }
-    const schema = fallback(object({
-      text: fallback(string([minLength(6)]), fallbackValue.text, (dataIssues) => { warnings = dataIssues }),
-      data: number(),
-    }), fallbackValue,(dataIssues) => { warnings = dataIssues });
+    let warnings: any;
+    const fallbackValue = { text: 'hello world', data: 5 };
+    const schema = fallback(
+      object({
+        text: fallback(
+          string([minLength(6)]),
+          fallbackValue.text,
+          (dataIssues) => {
+            warnings = dataIssues;
+          }
+        ),
+        data: number(),
+      }),
+      fallbackValue,
+      (dataIssues) => {
+        warnings = dataIssues;
+      }
+    );
 
     {
-      const data = { data: 2 }
+      const data = { data: 2 };
       const output = parse(schema, data);
       expect(output).toEqual({ ...data, text: fallbackValue.text });
 
@@ -59,7 +73,7 @@ describe('fallback', () => {
       //expect(issues).toEqual([  ]);
     }
 
-    warnings = []
+    warnings = [];
     {
       const output = parse(schema, {});
       expect(output).toEqual(fallbackValue);
@@ -70,27 +84,32 @@ describe('fallback', () => {
   });
 
   test('collect warnings', () => {
-    const warnings: Issue[] = []
-    const collect = (issues: Issues) => issues.forEach(value => warnings.push(value)) 
+    const warnings: Issue[] = [];
+    const collect = (issues: Issues) =>
+      issues.forEach((value) => warnings.push(value));
 
-    const fallbackValue = { text: 'hello world', data: 5 }
-    const schema = fallback(object({
-      text: fallback(string([minLength(6)]), fallbackValue.text, collect),
-      data: number(),
-    }), fallbackValue, collect);
+    const fallbackValue = { text: 'hello world', data: 5 };
+    const schema = fallback(
+      object({
+        text: fallback(string([minLength(6)]), fallbackValue.text, collect),
+        data: number(),
+      }),
+      fallbackValue,
+      collect
+    );
 
     {
-      const data = { data: 2 }
+      const data = { data: 2 };
       const output = parse(schema, data);
       expect(output).toEqual({ ...data, text: fallbackValue.text });
-      console.log(warnings)
-      console.log(warnings[0].path)
+      console.log(warnings);
+      console.log(warnings[0].path);
     }
 
     {
       const output = parse(schema, {});
       expect(output).toEqual(fallbackValue);
-      console.log(warnings)
+      console.log(warnings);
     }
 
     expect(warnings).toHaveLength(3);

--- a/library/src/methods/fallback/fallback.test.ts
+++ b/library/src/methods/fallback/fallback.test.ts
@@ -1,117 +1,30 @@
-import { describe, test, expect, expectTypeOf } from 'vitest';
-import { object, string, number } from '../../schemas/index.ts';
-import { minLength } from '../../validations/index.ts';
-import { Issue, Issues, parse, safeParse } from '../../index.ts';
+import { describe, expect, test } from 'vitest';
+import { object, string } from '../../schemas/index.ts';
+import { parse } from '../parse/index.ts';
 import { fallback } from './fallback.ts';
 
 describe('fallback', () => {
-  test('should parse normally', () => {
-    const schema = fallback(string(), 'world');
-    const output = parse(schema, 'hello');
-    expect(output).toBe('hello');
-    expectTypeOf(output).toEqualTypeOf<string>();
+  const schema1 = fallback(string(), 'test');
+  const schema2 = fallback(string(), () => 'test');
+  const schema3 = object({ key1: schema1, key2: schema2 });
+
+  test('should use default value', () => {
+    const output1 = parse(schema1, 123);
+    expect(output1).toBe('test');
+    const output2 = parse(schema2, 123);
+    expect(output2).toBe('test');
+    const output3 = parse(schema3, {});
+    expect(output3).toEqual({ key1: 'test', key2: 'test' });
   });
 
-  test('should succeed to parse but return fallback value', () => {
-    const schema = fallback(string([minLength(6)]), 'hello world');
-    const output = parse(schema, 'hello');
-    expect(output).toEqual('hello world');
-  });
-
-  test('should succeed, return fallback and issues need to match non-fallback ones', () => {
-    const objectSchema = object({
-      text: string([minLength(6)]),
-      data: number(),
-    });
-
-    let issues: any;
-    const fallbackValue = { text: 'hello world', data: 5 };
-    const schema = fallback(objectSchema, fallbackValue, (dataIssues) => {
-      issues = dataIssues;
-    });
-
-    const data = { text: 'hello' };
-    const output = parse(schema, data);
-    expectTypeOf(output).toEqualTypeOf<{ text: string; data: number }>();
-    expect(output).toEqual(fallbackValue);
-
-    expect(issues).lengthOf.above(0);
-    //expect(issues).toEqual([  ]);
-
-    const result = safeParse(objectSchema, data);
-    expect(result.success).toBeFalsy();
-    expect((result as any).issues).toEqual(issues);
-  });
-
-  test('nested fallback', () => {
-    let warnings: any;
-    const fallbackValue = { text: 'hello world', data: 5 };
-    const schema = fallback(
-      object({
-        text: fallback(
-          string([minLength(6)]),
-          fallbackValue.text,
-          (dataIssues) => {
-            warnings = dataIssues;
-          }
-        ),
-        data: number(),
-      }),
-      fallbackValue,
-      (dataIssues) => {
-        warnings = dataIssues;
-      }
-    );
-
-    {
-      const data = { data: 2 };
-      const output = parse(schema, data);
-      expect(output).toEqual({ ...data, text: fallbackValue.text });
-
-      expect(warnings).lengthOf.above(0);
-      expect(warnings).toHaveLength(1);
-      //expect(issues).toEqual([  ]);
-    }
-
-    warnings = [];
-    {
-      const output = parse(schema, {});
-      expect(output).toEqual(fallbackValue);
-
-      expect(warnings).lengthOf.above(0);
-      expect(warnings).toHaveLength(1);
-    }
-  });
-
-  test('collect warnings', () => {
-    const warnings: Issue[] = [];
-    const collect = (issues: Issues) =>
-      issues.forEach((value) => warnings.push(value));
-
-    const fallbackValue = { text: 'hello world', data: 5 };
-    const schema = fallback(
-      object({
-        text: fallback(string([minLength(6)]), fallbackValue.text, collect),
-        data: number(),
-      }),
-      fallbackValue,
-      collect
-    );
-
-    {
-      const data = { data: 2 };
-      const output = parse(schema, data);
-      expect(output).toEqual({ ...data, text: fallbackValue.text });
-      console.log(warnings);
-      console.log(warnings[0].path);
-    }
-
-    {
-      const output = parse(schema, {});
-      expect(output).toEqual(fallbackValue);
-      console.log(warnings);
-    }
-
-    expect(warnings).toHaveLength(3);
+  test('should not use default value', () => {
+    const input1 = 'hello';
+    const output1 = parse(schema1, input1);
+    expect(output1).toBe(input1);
+    const output2 = parse(schema2, input1);
+    expect(output2).toBe(input1);
+    const input2 = { key1: 'hello', key2: 'hello' };
+    const output3 = parse(schema3, input2);
+    expect(output3).toEqual(input2);
   });
 });

--- a/library/src/methods/fallback/fallback.test.ts
+++ b/library/src/methods/fallback/fallback.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect, expectTypeOf  } from 'vitest';
+import { object, string, number } from '../../schemas/index.ts';
+import { minLength } from '../../validations/index.ts';
+import { parse, safeParse } from '../../index.ts';
+import { fallback } from './fallback.ts';
+
+describe('fallback', () => {
+  test('should parse normally', () => {
+    const schema = fallback(string(), 'world');
+    const output = parse(schema, 'hello');
+    expect(output).toBe('hello');
+    expectTypeOf(output).toEqualTypeOf<string>()
+  });
+
+  test('should succeed to parse but return fallback value', () => {
+    const schema = fallback(string([minLength(6)]), 'hello world');
+    const output = parse(schema, 'hello');
+    expect(output).toEqual('hello world');
+  });
+
+  test('should succeed, return fallback and issues need to match non-fallback ones', () => {
+    const objectSchema = object({
+      text: string([minLength(6)]),
+      data: number(),
+    });
+
+    let issues: any
+    const fallbackValue = { text: 'hello world', data: 5 }
+    const schema = fallback(objectSchema, fallbackValue, (dataIssues) => { issues = dataIssues });
+
+    const data = { text: 'hello' }
+    const output = parse(schema, data);
+    expectTypeOf(output).toEqualTypeOf<{ text: string, data: number }>()
+    expect(output).toEqual(fallbackValue);
+
+    expect(issues).lengthOf.above(0);
+    //expect(issues).toEqual([  ]);
+
+    const result = safeParse(objectSchema, data)
+    expect(result.success).toBeFalsy()
+    expect((result as any).issues).toEqual(issues)
+  });
+});

--- a/library/src/methods/fallback/fallback.test.ts
+++ b/library/src/methods/fallback/fallback.test.ts
@@ -42,36 +42,36 @@ describe('fallback', () => {
   });
 
   test('nested fallback', () => {
-    let issues: any
+    let warnings: any
     const fallbackValue = { text: 'hello world', data: 5 }
     const schema = fallback(object({
-      text: fallback(string([minLength(6)]), fallbackValue.text, (dataIssues) => { issues = dataIssues }),
+      text: fallback(string([minLength(6)]), fallbackValue.text, (dataIssues) => { warnings = dataIssues }),
       data: number(),
-    }), fallbackValue,(dataIssues) => { issues = dataIssues });
+    }), fallbackValue,(dataIssues) => { warnings = dataIssues });
 
     {
       const data = { data: 2 }
       const output = parse(schema, data);
       expect(output).toEqual({ ...data, text: fallbackValue.text });
 
-      expect(issues).lengthOf.above(0);
-      expect(issues).toHaveLength(1);
+      expect(warnings).lengthOf.above(0);
+      expect(warnings).toHaveLength(1);
       //expect(issues).toEqual([  ]);
     }
 
-    issues = []
+    warnings = []
     {
       const output = parse(schema, {});
       expect(output).toEqual(fallbackValue);
 
-      expect(issues).lengthOf.above(0);
-      expect(issues).toHaveLength(1);
+      expect(warnings).lengthOf.above(0);
+      expect(warnings).toHaveLength(1);
     }
   });
 
   test('collect warnings', () => {
-    const issues: Issue[] = []
-    const collect = (newIssues: Issues) => newIssues.forEach(value => issues.push(value)) 
+    const warnings: Issue[] = []
+    const collect = (issues: Issues) => issues.forEach(value => warnings.push(value)) 
 
     const fallbackValue = { text: 'hello world', data: 5 }
     const schema = fallback(object({
@@ -83,13 +83,16 @@ describe('fallback', () => {
       const data = { data: 2 }
       const output = parse(schema, data);
       expect(output).toEqual({ ...data, text: fallbackValue.text });
+      console.log(warnings)
+      console.log(warnings[0].path)
     }
 
     {
       const output = parse(schema, {});
       expect(output).toEqual(fallbackValue);
+      console.log(warnings)
     }
 
-    expect(issues).toHaveLength(3);
+    expect(warnings).toHaveLength(3);
   });
 });

--- a/library/src/methods/fallback/fallback.test.ts
+++ b/library/src/methods/fallback/fallback.test.ts
@@ -40,4 +40,32 @@ describe('fallback', () => {
     expect(result.success).toBeFalsy()
     expect((result as any).issues).toEqual(issues)
   });
+
+  test('nested fallback', () => {
+    let issues: any
+    const fallbackValue = { text: 'hello world', data: 5 }
+    const schema = fallback(object({
+      text: fallback(string([minLength(6)]), fallbackValue.text, (dataIssues) => { issues = dataIssues }),
+      data: number(),
+    }), fallbackValue,(dataIssues) => { issues = dataIssues });
+
+    {
+      const data = { data: 2 }
+      const output = parse(schema, data);
+      expect(output).toEqual({ ...data, text: fallbackValue.text });
+
+      expect(issues).lengthOf.above(0);
+      expect(issues).toHaveLength(1);
+      //expect(issues).toEqual([  ]);
+    }
+
+    issues = []
+    {
+      const output = parse(schema, {});
+      expect(output).toEqual(fallbackValue);
+
+      expect(issues).lengthOf.above(0);
+      expect(issues).toHaveLength(1);
+    }
+  });
 });

--- a/library/src/methods/fallback/fallback.ts
+++ b/library/src/methods/fallback/fallback.ts
@@ -1,0 +1,44 @@
+import type {
+    BaseSchema,
+    Output,
+} from '../../types.ts';
+import { type Issues } from '../../error/index.ts';
+
+/**
+ * Returns a fallback value when validating the passed schema failed.
+ *
+ * @param schema The scheme to catch validation failures from.
+ * @param value The fallback value.
+ * @param logger A callback that receives the caught issues. Default: console.error
+ *
+ * @returns The passed schema.
+ */
+export function fallback<TSchema extends BaseSchema>(
+  schema: TSchema,
+  value: Output<TSchema>,
+  logger?: (err: Issues) => void
+): TSchema {
+  return {
+    ...schema,
+
+    /**
+     * Parses the input based on its schema.
+     * Tests the result for issues and prints them,
+     * with either console.error or the passed logger callback.
+     *
+     * @param input The input to be parsed.
+     * @param info The parse info.
+     *
+     * @returns The parsed output or if validation failed the fallback value.
+     */
+    _parse(input, info) {
+			const result = schema._parse(input, info);
+			if (!result.issues) {
+				return result.output as Output<TSchema>;
+			}
+
+			(logger ?? console.error)(result.issues);
+			return value;
+    },
+  };
+}

--- a/library/src/methods/fallback/fallback.ts
+++ b/library/src/methods/fallback/fallback.ts
@@ -34,11 +34,11 @@ export function fallback<TSchema extends BaseSchema>(
     _parse(input, info) {
 			const result = schema._parse(input, info);
 			if (!result.issues) {
-				return result.output as Output<TSchema>;
+				return result;
 			}
 
 			(logger ?? console.error)(result.issues);
-			return value;
+			return { output: value };
     },
   };
 }

--- a/library/src/methods/fallback/fallback.ts
+++ b/library/src/methods/fallback/fallback.ts
@@ -1,7 +1,4 @@
-import type {
-    BaseSchema,
-    Output,
-} from '../../types.ts';
+import type { BaseSchema, Output } from '../../types.ts';
 import { type Issues } from '../../error/index.ts';
 
 /**
@@ -32,13 +29,13 @@ export function fallback<TSchema extends BaseSchema>(
      * @returns The parsed output or if validation failed the fallback value.
      */
     _parse(input, info) {
-			const result = schema._parse(input, info);
-			if (!result.issues) {
-				return result;
-			}
+      const result = schema._parse(input, info);
+      if (!result.issues) {
+        return result;
+      }
 
-			(logger ?? console.error)(result.issues);
-			return { output: value };
+      (logger ?? console.error)(result.issues);
+      return { output: value };
     },
   };
 }

--- a/library/src/methods/fallback/fallbackAsync.test.ts
+++ b/library/src/methods/fallback/fallbackAsync.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect, expectTypeOf  } from 'vitest';
+import { objectAsync, stringAsync, numberAsync } from '../../schemas/index.ts';
+import { minLength } from '../../validations/index.ts';
+import { parseAsync, safeParseAsync } from '../../index.ts';
+import { fallbackAsync } from './fallbackAsync.ts';
+
+describe('fallbackAsync', () => {
+  test('should parseAsync normally', async () => {
+    const schema = fallbackAsync(stringAsync(), 'world');
+    const output = await parseAsync(schema, 'hello');
+    expect(output).toBe('hello');
+    expectTypeOf(output).toEqualTypeOf<string>()
+  });
+
+  test('should succeed to parseAsync but return fallback value', async () => {
+    const schema = fallbackAsync(stringAsync([minLength(6)]), 'hello world');
+    const output = await parseAsync(schema, 'hello');
+    expect(output).toEqual('hello world');
+  });
+
+  test('should succeed, return fallback and issues need to match non-fallback ones', async () => {
+    const objectSchema = objectAsync({
+      text: stringAsync([minLength(6)]),
+      data: numberAsync(),
+    });
+
+    let issues: any
+    const fallbackValue = { text: 'hello world', data: 5 }
+    const schema = fallbackAsync(objectSchema, fallbackValue, (dataIssues) => { issues = dataIssues });
+
+    const data = { text: 'hello' }
+    const output = await parseAsync(schema, data);
+    expectTypeOf(output).toEqualTypeOf<{ text: string, data: number }>()
+    expect(output).toEqual(fallbackValue);
+
+    expect(issues).lengthOf.above(0);
+    //expect(issues).toEqual([  ]);
+
+    const result = await safeParseAsync(objectSchema, data)
+    expect(result.success).toBeFalsy()
+    expect((result as any).issues).toEqual(issues)
+  });
+});

--- a/library/src/methods/fallback/fallbackAsync.test.ts
+++ b/library/src/methods/fallback/fallbackAsync.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, expectTypeOf  } from 'vitest';
+import { describe, test, expect, expectTypeOf } from 'vitest';
 import { objectAsync, stringAsync, numberAsync } from '../../schemas/index.ts';
 import { minLength } from '../../validations/index.ts';
 import { Issue, Issues, parseAsync, safeParseAsync } from '../../index.ts';
@@ -9,7 +9,7 @@ describe('fallbackAsync', () => {
     const schema = fallbackAsync(stringAsync(), 'world');
     const output = await parseAsync(schema, 'hello');
     expect(output).toBe('hello');
-    expectTypeOf(output).toEqualTypeOf<string>()
+    expectTypeOf(output).toEqualTypeOf<string>();
   });
 
   test('should succeed to parseAsync but return fallback value', async () => {
@@ -24,33 +24,47 @@ describe('fallbackAsync', () => {
       data: numberAsync(),
     });
 
-    let issues: any
-    const fallbackValue = { text: 'hello world', data: 5 }
-    const schema = fallbackAsync(objectSchema, fallbackValue, (dataIssues) => { issues = dataIssues });
+    let issues: any;
+    const fallbackValue = { text: 'hello world', data: 5 };
+    const schema = fallbackAsync(objectSchema, fallbackValue, (dataIssues) => {
+      issues = dataIssues;
+    });
 
-    const data = { text: 'hello' }
+    const data = { text: 'hello' };
     const output = await parseAsync(schema, data);
-    expectTypeOf(output).toEqualTypeOf<{ text: string, data: number }>()
+    expectTypeOf(output).toEqualTypeOf<{ text: string; data: number }>();
     expect(output).toEqual(fallbackValue);
 
     expect(issues).lengthOf.above(0);
     //expect(issues).toEqual([  ]);
 
-    const result = await safeParseAsync(objectSchema, data)
-    expect(result.success).toBeFalsy()
-    expect((result as any).issues).toEqual(issues)
+    const result = await safeParseAsync(objectSchema, data);
+    expect(result.success).toBeFalsy();
+    expect((result as any).issues).toEqual(issues);
   });
 
   test('nested fallback', async () => {
-    let issues: any
-    const fallbackValue = { text: 'hello world', data: 5 }
-    const schema = fallbackAsync(objectAsync({
-      text: fallbackAsync(stringAsync([minLength(6)]), fallbackValue.text, (dataIssues) => { issues = dataIssues }),
-      data: numberAsync(),
-    }), fallbackValue,(dataIssues) => { issues = dataIssues });
+    let issues: any;
+    const fallbackValue = { text: 'hello world', data: 5 };
+    const schema = fallbackAsync(
+      objectAsync({
+        text: fallbackAsync(
+          stringAsync([minLength(6)]),
+          fallbackValue.text,
+          (dataIssues) => {
+            issues = dataIssues;
+          }
+        ),
+        data: numberAsync(),
+      }),
+      fallbackValue,
+      (dataIssues) => {
+        issues = dataIssues;
+      }
+    );
 
     {
-      const data = { data: 2 }
+      const data = { data: 2 };
       const output = await parseAsync(schema, data);
       expect(output).toEqual({ ...data, text: fallbackValue.text });
 
@@ -59,7 +73,7 @@ describe('fallbackAsync', () => {
       //expect(issues).toEqual([  ]);
     }
 
-    issues = []
+    issues = [];
     {
       const output = await parseAsync(schema, {});
       expect(output).toEqual(fallbackValue);
@@ -70,17 +84,26 @@ describe('fallbackAsync', () => {
   });
 
   test('collect warnings', async () => {
-    const issues: Issue[] = []
-    const collect = (newIssues: Issues) => newIssues.forEach(value => issues.push(value)) 
+    const issues: Issue[] = [];
+    const collect = (newIssues: Issues) =>
+      newIssues.forEach((value) => issues.push(value));
 
-    const fallbackValue = { text: 'hello world', data: 5 }
-    const schema = fallbackAsync(objectAsync({
-      text: fallbackAsync(stringAsync([minLength(6)]), fallbackValue.text, collect),
-      data: numberAsync(),
-    }), fallbackValue, collect);
+    const fallbackValue = { text: 'hello world', data: 5 };
+    const schema = fallbackAsync(
+      objectAsync({
+        text: fallbackAsync(
+          stringAsync([minLength(6)]),
+          fallbackValue.text,
+          collect
+        ),
+        data: numberAsync(),
+      }),
+      fallbackValue,
+      collect
+    );
 
     {
-      const data = { data: 2 }
+      const data = { data: 2 };
       const output = await parseAsync(schema, data);
       expect(output).toEqual({ ...data, text: fallbackValue.text });
     }

--- a/library/src/methods/fallback/fallbackAsync.test.ts
+++ b/library/src/methods/fallback/fallbackAsync.test.ts
@@ -40,4 +40,32 @@ describe('fallbackAsync', () => {
     expect(result.success).toBeFalsy()
     expect((result as any).issues).toEqual(issues)
   });
+
+  test('nested fallback', async () => {
+    let issues: any
+    const fallbackValue = { text: 'hello world', data: 5 }
+    const schema = fallbackAsync(objectAsync({
+      text: fallbackAsync(stringAsync([minLength(6)]), fallbackValue.text, (dataIssues) => { issues = dataIssues }),
+      data: numberAsync(),
+    }), fallbackValue,(dataIssues) => { issues = dataIssues });
+
+    {
+      const data = { data: 2 }
+      const output = parseAsync(schema, data);
+      expect(output).toEqual({ ...data, text: fallbackValue.text });
+
+      expect(issues).lengthOf.above(0);
+      expect(issues).toHaveLength(1);
+      //expect(issues).toEqual([  ]);
+    }
+
+    issues = []
+    {
+      const output = parseAsync(schema, {});
+      expect(output).toEqual(fallbackValue);
+
+      expect(issues).lengthOf.above(0);
+      expect(issues).toHaveLength(1);
+    }
+  });
 });

--- a/library/src/methods/fallback/fallbackAsync.ts
+++ b/library/src/methods/fallback/fallbackAsync.ts
@@ -1,7 +1,4 @@
-import type {
-    BaseSchemaAsync,
-    Output,
-} from '../../types.ts';
+import type { BaseSchemaAsync, Output } from '../../types.ts';
 import { type Issues } from '../../error/index.ts';
 
 /**
@@ -20,7 +17,7 @@ export function fallbackAsync<TSchema extends BaseSchemaAsync>(
 ): TSchema {
   return {
     ...schema,
-    
+
     /**
      * Parses the input based on its schema.
      * Tests the result for issues and prints them,
@@ -32,13 +29,13 @@ export function fallbackAsync<TSchema extends BaseSchemaAsync>(
      * @returns The parsed output or if validation failed the fallback value.
      */
     async _parse(input, info) {
-			const result = await schema._parse(input, info);
-			if (!result.issues) {
-				return result;
-			}
+      const result = await schema._parse(input, info);
+      if (!result.issues) {
+        return result;
+      }
 
-			(logger ?? console.error)(result.issues);
-			return { output: value };
+      (logger ?? console.error)(result.issues);
+      return { output: value };
     },
   };
 }

--- a/library/src/methods/fallback/fallbackAsync.ts
+++ b/library/src/methods/fallback/fallbackAsync.ts
@@ -34,11 +34,11 @@ export function fallbackAsync<TSchema extends BaseSchemaAsync>(
     async _parse(input, info) {
 			const result = await schema._parse(input, info);
 			if (!result.issues) {
-				return result.output as Output<TSchema>;
+				return result;
 			}
 
 			(logger ?? console.error)(result.issues);
-			return value;
+			return { output: value };
     },
   };
 }

--- a/library/src/methods/fallback/fallbackAsync.ts
+++ b/library/src/methods/fallback/fallbackAsync.ts
@@ -1,41 +1,41 @@
-import type { BaseSchemaAsync, Output } from '../../types.ts';
-import { type Issues } from '../../error/index.ts';
+import type { BaseSchema, BaseSchemaAsync, Output } from '../../types.ts';
+import type { FallbackInfo } from './types.ts';
 
 /**
  * Returns a fallback value when validating the passed schema failed.
  *
- * @param schema The scheme to catch validation failures from.
+ * @param schema The schema to catch.
  * @param value The fallback value.
- * @param logger A callback that receives the caught issues. Default: console.error
  *
- * @returns The passed async schema.
+ * @returns The passed schema.
  */
-export function fallbackAsync<TSchema extends BaseSchemaAsync>(
+export function fallbackAsync<TSchema extends BaseSchema | BaseSchemaAsync>(
   schema: TSchema,
-  value: Output<TSchema>,
-  logger?: (err: Issues) => void
+  value: Output<TSchema> | ((info: FallbackInfo) => Output<TSchema>)
 ): TSchema {
   return {
     ...schema,
 
     /**
-     * Parses the input based on its schema.
-     * Tests the result for issues and prints them,
-     * with either console.error or the passed logger callback.
+     * Parses unknown input based on its schema.
      *
      * @param input The input to be parsed.
      * @param info The parse info.
      *
-     * @returns The parsed output or if validation failed the fallback value.
+     * @returns The parsed output.
      */
     async _parse(input, info) {
       const result = await schema._parse(input, info);
-      if (!result.issues) {
-        return result;
-      }
-
-      (logger ?? console.error)(result.issues);
-      return { output: value };
+      return {
+        output: result.issues
+          ? typeof value === 'function'
+            ? (value as (info: FallbackInfo) => Output<TSchema>)({
+                input,
+                issues: result.issues,
+              })
+            : value
+          : result.output,
+      };
     },
   };
 }

--- a/library/src/methods/fallback/fallbackAsync.ts
+++ b/library/src/methods/fallback/fallbackAsync.ts
@@ -1,0 +1,44 @@
+import type {
+    BaseSchemaAsync,
+    Output,
+} from '../../types.ts';
+import { type Issues } from '../../error/index.ts';
+
+/**
+ * Returns a fallback value when validating the passed schema failed.
+ *
+ * @param schema The scheme to catch validation failures from.
+ * @param value The fallback value.
+ * @param logger A callback that receives the caught issues. Default: console.error
+ *
+ * @returns The passed async schema.
+ */
+export function fallbackAsync<TSchema extends BaseSchemaAsync>(
+  schema: TSchema,
+  value: Output<TSchema>,
+  logger?: (err: Issues) => void
+): TSchema {
+  return {
+    ...schema,
+    
+    /**
+     * Parses the input based on its schema.
+     * Tests the result for issues and prints them,
+     * with either console.error or the passed logger callback.
+     *
+     * @param input The input to be parsed.
+     * @param info The parse info.
+     *
+     * @returns The parsed output or if validation failed the fallback value.
+     */
+    async _parse(input, info) {
+			const result = await schema._parse(input, info);
+			if (!result.issues) {
+				return result.output as Output<TSchema>;
+			}
+
+			(logger ?? console.error)(result.issues);
+			return value;
+    },
+  };
+}

--- a/library/src/methods/fallback/index.ts
+++ b/library/src/methods/fallback/index.ts
@@ -1,0 +1,2 @@
+export { fallback } from './fallback.ts';
+export { fallbackAsync } from './fallbackAsync.ts';

--- a/library/src/methods/fallback/types.ts
+++ b/library/src/methods/fallback/types.ts
@@ -1,0 +1,9 @@
+import type { Issues } from '../../error/index.ts';
+
+/**
+ * Fallback info type.
+ */
+export type FallbackInfo = {
+  input: unknown;
+  issues: Issues;
+};

--- a/library/src/methods/index.ts
+++ b/library/src/methods/index.ts
@@ -1,5 +1,6 @@
 export * from './brand/index.ts';
 export * from './coerce/index.ts';
+export * from './fallback/index.ts';
 export * from './is/index.ts';
 export * from './keyof/index.ts';
 export * from './merge/index.ts';

--- a/library/src/methods/withDefault/withDefault.test.ts
+++ b/library/src/methods/withDefault/withDefault.test.ts
@@ -4,19 +4,22 @@ import { parse } from '../parse/index.ts';
 import { withDefault } from './withDefault.ts';
 
 describe('withDefault', () => {
+  const schema1 = withDefault(string(), 'test');
+  const schema2 = object({ test: schema1 });
+
   test('should use default value', () => {
-    const schema1 = withDefault(string(), 'test');
     const output1 = parse(schema1, undefined);
     expect(output1).toBe('test');
-    const input1 = 'hello';
-    const output2 = parse(schema1, input1);
-    expect(output2).toBe(input1);
+    const output2 = parse(schema2, {});
+    expect(output2).toEqual({ test: 'test' });
+  });
 
-    const schema2 = object({ test: schema1 });
-    const output3 = parse(schema2, {});
-    expect(output3).toEqual({ test: 'test' });
+  test('should not use default value', () => {
+    const input1 = 'hello';
+    const output1 = parse(schema1, input1);
+    expect(output1).toBe(input1);
     const input2 = { test: 'hello' };
-    const output4 = parse(schema2, input2);
-    expect(output4).toEqual(input2);
+    const output2 = parse(schema2, input2);
+    expect(output2).toEqual(input2);
   });
 });

--- a/website/src/routes/api/(methods)/fallback/index.mdx
+++ b/website/src/routes/api/(methods)/fallback/index.mdx
@@ -4,4 +4,4 @@ title: fallback
 
 # fallback
 
-> The content of this page is not yet ready. Until then just use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/methods/coerce/coerce.ts).
+> The content of this page is not yet ready. Until then just use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/methods/fallback/fallback.ts).

--- a/website/src/routes/api/(methods)/fallback/index.mdx
+++ b/website/src/routes/api/(methods)/fallback/index.mdx
@@ -1,0 +1,7 @@
+---
+title: fallback
+---
+
+# fallback
+
+> The content of this page is not yet ready. Until then just use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/methods/coerce/coerce.ts).

--- a/website/src/routes/guides/(main-concepts)/methods/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/methods/index.mdx
@@ -60,6 +60,63 @@ const StringSchema = withDefault(string(), 'hello');
 const stringOutput = parse(StringSchema, undefined); // 'hello'
 ```
 
+### Fallback
+
+You can use <Link href="/api/fallback">`fallback`</Link> to catch validation issues and instead return a fallback value as output.
+
+```ts
+import { parse, fallback, string, minLength } from 'valibot'; // 0.44 kB ?
+
+const StringSchema = fallback(string([minLength(10)]), 'hello valibot')
+const stringOutput = parse(StringSchema, 'hello'); // 'hello valibot'
+```
+
+If you want to know when and what went wrong while validation, the <Link href="/api/fallback">`fallback`</Link> method has a additional but optional parameter.
+
+```ts
+logger?: (err: Issues) => void
+```
+
+Thanks to this callback it is possible to collect all of these warnings. Here's an easy example:
+
+```ts
+import { parse, fallback, object, string, number, minLength } from 'valibot'; // 0.44 kB ?
+import type { Issue, Issues } from 'valibot';
+
+const warnings: Issue[] = []
+const collect = (issues: Issues) => issues.forEach(value => warnings.push(value)) 
+
+const fallbackValue = { text: 'hello valibot', data: 5 }
+const schema = fallback(object({
+    text: fallback(string([minLength(10)]), fallbackValue.text, collect),
+    data: number(),
+}), fallbackValue, collect);
+
+const data = { data: 2 }
+parse(schema, data); // { text: 'hello valibot', data: 2 }
+console.log(warnings)
+/* [
+    {
+        reason: 'type',
+        validation: 'string',
+        origin: 'value',
+        message: 'Invalid type',
+        input: undefined,
+        path: [
+            {
+                schema: 'object',
+                input: { data: 2 },
+                key: 'text',
+                value: undefined
+            }
+        ]
+    }
+] */
+
+parse(schema, {}); // { text: 'hello valibot', data: 2 }
+console.log(warnings.length) // 3
+```
+
 ## Object methods
 
 My object methods make it easier for you to work with object schemas. They are strongly oriented towards the functionality of TypeScript.

--- a/website/src/routes/guides/(main-concepts)/methods/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/methods/index.mdx
@@ -62,59 +62,13 @@ const stringOutput = parse(StringSchema, undefined); // 'hello'
 
 ### Fallback
 
-You can use <Link href="/api/fallback">`fallback`</Link> to catch validation issues and instead return a fallback value as output.
+If an issue occurs while validating your schema, you can catch it with <Link href="/api/fallback">`fallback`</Link> to return a predefined value instead.
 
 ```ts
-import { parse, fallback, string, minLength } from 'valibot'; // 0.44 kB ?
+import { parse, fallback, string } from 'valibot'; // 0.44 kB
 
-const StringSchema = fallback(string([minLength(10)]), 'hello valibot')
-const stringOutput = parse(StringSchema, 'hello'); // 'hello valibot'
-```
-
-If you want to know when and what went wrong while validation, the <Link href="/api/fallback">`fallback`</Link> method has an additional but optional parameter.
-
-```ts
-logger?: (err: Issues) => void
-```
-
-Thanks to this callback it is possible to collect all of these warnings. Here's an easy example.
-
-```ts
-import { parse, fallback, object, string, number, minLength } from 'valibot'; // 0.44 kB ?
-import type { Issue, Issues } from 'valibot';
-
-const warnings: Issue[] = []
-const collect = (issues: Issues) => issues.forEach(value => warnings.push(value)) 
-
-const fallbackValue = { text: 'hello valibot', data: 5 }
-const schema = fallback(object({
-    text: fallback(string([minLength(10)]), fallbackValue.text, collect),
-    data: number(),
-}), fallbackValue, collect);
-
-const data = { data: 2 }
-parse(schema, data); // { text: 'hello valibot', data: 5 }
-console.log(warnings)
-/* [
-    {
-        reason: 'type',
-        validation: 'string',
-        origin: 'value',
-        message: 'Invalid type',
-        input: undefined,
-        path: [
-            {
-                schema: 'object',
-                input: { data: 2 },
-                key: 'text',
-                value: undefined
-            }
-        ]
-    }
-] */
-
-parse(schema, {}); // { text: 'hello valibot', data: 2 }
-console.log(warnings.length) // 3
+const StringSchema = fallback(string(), 'hello');
+const stringOutput = parse(StringSchema, 123); // 'hello'
 ```
 
 ## Object methods

--- a/website/src/routes/guides/(main-concepts)/methods/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/methods/index.mdx
@@ -71,13 +71,13 @@ const StringSchema = fallback(string([minLength(10)]), 'hello valibot')
 const stringOutput = parse(StringSchema, 'hello'); // 'hello valibot'
 ```
 
-If you want to know when and what went wrong while validation, the <Link href="/api/fallback">`fallback`</Link> method has a additional but optional parameter.
+If you want to know when and what went wrong while validation, the <Link href="/api/fallback">`fallback`</Link> method has an additional but optional parameter.
 
 ```ts
 logger?: (err: Issues) => void
 ```
 
-Thanks to this callback it is possible to collect all of these warnings. Here's an easy example:
+Thanks to this callback it is possible to collect all of these warnings. Here's an easy example.
 
 ```ts
 import { parse, fallback, object, string, number, minLength } from 'valibot'; // 0.44 kB ?
@@ -93,7 +93,7 @@ const schema = fallback(object({
 }), fallbackValue, collect);
 
 const data = { data: 2 }
-parse(schema, data); // { text: 'hello valibot', data: 2 }
+parse(schema, data); // { text: 'hello valibot', data: 5 }
 console.log(warnings)
 /* [
     {


### PR DESCRIPTION
Now that exceptions are gone, I can finally, properly implement the `fallback` method. #74 
Also added some tests.

Still not sure about the issues that are caught though. Adding a centralized way to collect these warning, just for fallback, is unnecessary. Printing or being able to receive them through the callback might work for now, but I did not try collecting them.