### PR TITLE
Fix optional strict by not assigning undefined value to optional properties in object(Async) function

### DIFF
--- a/library/src/methods/strict/strict.test.ts
+++ b/library/src/methods/strict/strict.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { number, object, string } from '../../schemas/index.ts';
+import {number, object, optional, string} from '../../schemas/index.ts';
 import { parse } from '../parse/index.ts';
 import { strict } from './strict.ts';
 
@@ -15,6 +15,20 @@ describe('strict', () => {
     const input2 = { key1: 'test', key2: 123, key3: 'unknown' };
     expect(() => parse(schema, input2)).toThrowError(keysError);
     const input3 = { key1: 'test', key2: 123, key3: 'unknown', key4: 123 };
+    expect(() => parse(schema, input3)).toThrowError(keysError);
+  });
+
+  test('should not fail on optional properties', () => {
+    const schema = strict(object({ key1: string(), key2: optional(number()) }));
+
+    const input1 = { key1: 'test' };
+    const output1 = parse(schema, input1);
+    expect(output1).toEqual(input1);
+
+    const keysError = 'Invalid keys';
+    const input2 = { key1: 'test', key3: 'unknown' };
+    expect(() => parse(schema, input2)).toThrowError(keysError);
+    const input3 = { key1: 'test', key3: 'unknown', key4: 123 };
     expect(() => parse(schema, input3)).toThrowError(keysError);
   });
 });

--- a/library/src/methods/strict/strict.test.ts
+++ b/library/src/methods/strict/strict.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import {number, object, optional, string} from '../../schemas/index.ts';
+import { number, object, optional, string } from '../../schemas/index.ts';
 import { parse } from '../parse/index.ts';
 import { strict } from './strict.ts';
 

--- a/library/src/methods/strict/strictAsync.test.ts
+++ b/library/src/methods/strict/strictAsync.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'vitest';
-import {number, objectAsync, optionalAsync, string} from '../../schemas/index.ts';
+import {
+  number,
+  objectAsync,
+  optionalAsync,
+  string,
+} from '../../schemas/index.ts';
 import { parseAsync } from '../parse/index.ts';
 import { strictAsync } from './strictAsync.ts';
 
@@ -19,7 +24,9 @@ describe('strict', () => {
   });
 
   test('should not fail on optional properties', async () => {
-    const schema = strictAsync(objectAsync({ key1: string(), key2: optionalAsync(number()) }));
+    const schema = strictAsync(
+      objectAsync({ key1: string(), key2: optionalAsync(number()) })
+    );
 
     const input1 = { key1: 'test' };
     const output1 = await parseAsync(schema, input1);

--- a/library/src/methods/strict/strictAsync.test.ts
+++ b/library/src/methods/strict/strictAsync.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { number, objectAsync, string } from '../../schemas/index.ts';
+import {number, objectAsync, optionalAsync, string} from '../../schemas/index.ts';
 import { parseAsync } from '../parse/index.ts';
 import { strictAsync } from './strictAsync.ts';
 
@@ -15,6 +15,20 @@ describe('strict', () => {
     const input2 = { key1: 'test', key2: 123, key3: 'unknown' };
     await expect(parseAsync(schema, input2)).rejects.toThrowError(keysError);
     const input3 = { key1: 'test', key2: 123, key3: 'unknown', key4: 123 };
+    await expect(parseAsync(schema, input3)).rejects.toThrowError(keysError);
+  });
+
+  test('should not fail on optional properties', async () => {
+    const schema = strictAsync(objectAsync({ key1: string(), key2: optionalAsync(number()) }));
+
+    const input1 = { key1: 'test' };
+    const output1 = await parseAsync(schema, input1);
+    expect(output1).toEqual(input1);
+
+    const keysError = 'Invalid keys';
+    const input2 = { key1: 'test', key3: 'unknown' };
+    await expect(parseAsync(schema, input2)).rejects.toThrowError(keysError);
+    const input3 = { key1: 'test', key3: 'unknown', key4: 123 };
     await expect(parseAsync(schema, input3)).rejects.toThrowError(keysError);
   });
 });

--- a/library/src/schemas/object/object.test.ts
+++ b/library/src/schemas/object/object.test.ts
@@ -5,6 +5,7 @@ import { toCustom } from '../../transformations/index.ts';
 import { number } from '../number/index.ts';
 import { string } from '../string/index.ts';
 import { object } from './object.ts';
+import { optional } from '../optional';
 
 describe('object', () => {
   test('should pass only objects', () => {
@@ -94,5 +95,13 @@ describe('object', () => {
     );
     expect(output1).toEqual(transformInput());
     expect(output2).toEqual(transformInput());
+  });
+
+  test('should not assign optional properties when value is undefined', () => {
+    const schema = object({ key1: string(), key2: optional(number()) });
+    const input = { key1: 'test' };
+    const result = parse(schema, input);
+    const outputEntries = Object.entries(result);
+    expect(outputEntries.length).toEqual(1);
   });
 });

--- a/library/src/schemas/object/object.ts
+++ b/library/src/schemas/object/object.ts
@@ -1,7 +1,7 @@
 import type { BaseSchema, Issues, Pipe } from '../../types.ts';
 import { executePipe, getDefaultArgs, getIssues } from '../../utils/index.ts';
 import type { ObjectOutput, ObjectInput, ObjectPathItem } from './types.ts';
-import {isOptional} from "../optional";
+import { isOptional } from '../optional';
 
 /**
  * Object shape type.

--- a/library/src/schemas/object/object.ts
+++ b/library/src/schemas/object/object.ts
@@ -1,6 +1,7 @@
 import type { BaseSchema, Issues, Pipe } from '../../types.ts';
 import { executePipe, getDefaultArgs, getIssues } from '../../utils/index.ts';
 import type { ObjectOutput, ObjectInput, ObjectPathItem } from './types.ts';
+import {isOptional} from "../optional";
 
 /**
  * Object shape type.
@@ -138,7 +139,7 @@ export function object<TObjectShape extends ObjectShape>(
           }
 
           // Otherwise, add value to object
-        } else {
+        } else if (result.output !== undefined || !isOptional(schema)) {
           output[key] = result.output;
         }
       }

--- a/library/src/schemas/object/objectAsync.test.ts
+++ b/library/src/schemas/object/objectAsync.test.ts
@@ -5,6 +5,7 @@ import { toCustom } from '../../transformations/index.ts';
 import { number } from '../number/index.ts';
 import { string, stringAsync } from '../string/index.ts';
 import { objectAsync } from './objectAsync.ts';
+import { optionalAsync } from '../optional';
 
 describe('objectAsync', () => {
   test('should pass only objects', async () => {
@@ -96,5 +97,16 @@ describe('objectAsync', () => {
     );
     expect(output1).toEqual(transformInput());
     expect(output2).toEqual(transformInput());
+  });
+
+  test('should not assign optional properties when value is undefined', async () => {
+    const schema = objectAsync({
+      key1: string(),
+      key2: optionalAsync(number()),
+    });
+    const input = { key1: 'test' };
+    const result = await parseAsync(schema, input);
+    const outputEntries = Object.entries(result);
+    expect(outputEntries.length).toEqual(1);
   });
 });

--- a/library/src/schemas/object/objectAsync.ts
+++ b/library/src/schemas/object/objectAsync.ts
@@ -10,6 +10,7 @@ import {
   getIssues,
 } from '../../utils/index.ts';
 import type { ObjectInput, ObjectOutput, ObjectPathItem } from './types.ts';
+import {isOptionalAsync} from "../optional";
 
 /**
  * Object shape async type.
@@ -155,7 +156,7 @@ export function objectAsync<TObjectShape extends ObjectShapeAsync>(
                 }
 
                 // Otherwise, add value to object
-              } else {
+              } else if (result.output !== undefined || !isOptionalAsync(schema)) {
                 output[key] = result.output;
               }
             }

--- a/library/src/schemas/object/objectAsync.ts
+++ b/library/src/schemas/object/objectAsync.ts
@@ -10,7 +10,7 @@ import {
   getIssues,
 } from '../../utils/index.ts';
 import type { ObjectInput, ObjectOutput, ObjectPathItem } from './types.ts';
-import {isOptionalAsync} from "../optional";
+import { isOptionalAsync } from '../optional';
 
 /**
  * Object shape async type.
@@ -156,7 +156,10 @@ export function objectAsync<TObjectShape extends ObjectShapeAsync>(
                 }
 
                 // Otherwise, add value to object
-              } else if (result.output !== undefined || !isOptionalAsync(schema)) {
+              } else if (
+                result.output !== undefined ||
+                !isOptionalAsync(schema)
+              ) {
                 output[key] = result.output;
               }
             }

--- a/library/src/schemas/optional/optional.ts
+++ b/library/src/schemas/optional/optional.ts
@@ -11,6 +11,10 @@ export type OptionalSchema<
   wrapped: TWrappedSchema;
 };
 
+export function isOptional(schema: BaseSchema): schema is OptionalSchema<any> {
+  return ((schema as unknown as { schema: string }).schema === 'optional');
+}
+
 /**
  * Creates a optional schema.
  *

--- a/library/src/schemas/optional/optional.ts
+++ b/library/src/schemas/optional/optional.ts
@@ -12,7 +12,7 @@ export type OptionalSchema<
 };
 
 export function isOptional(schema: BaseSchema): schema is OptionalSchema<any> {
-  return ((schema as unknown as { schema: string }).schema === 'optional');
+  return (schema as unknown as { schema: string }).schema === 'optional';
 }
 
 /**

--- a/library/src/schemas/optional/optionalAsync.ts
+++ b/library/src/schemas/optional/optionalAsync.ts
@@ -16,6 +16,10 @@ export type OptionalSchemaAsync<
   wrapped: TWrappedSchema;
 };
 
+export function isOptionalAsync(schema: BaseSchema | BaseSchemaAsync): schema is OptionalSchemaAsync<any> {
+  return ((schema as unknown as { schema: string }).schema === 'optional');
+}
+
 /**
  * Creates an async optional schema.
  *

--- a/library/src/schemas/optional/optionalAsync.ts
+++ b/library/src/schemas/optional/optionalAsync.ts
@@ -16,8 +16,10 @@ export type OptionalSchemaAsync<
   wrapped: TWrappedSchema;
 };
 
-export function isOptionalAsync(schema: BaseSchema | BaseSchemaAsync): schema is OptionalSchemaAsync<any> {
-  return ((schema as unknown as { schema: string }).schema === 'optional');
+export function isOptionalAsync(
+  schema: BaseSchema | BaseSchemaAsync
+): schema is OptionalSchemaAsync<any> {
+  return (schema as unknown as { schema: string }).schema === 'optional';
 }
 
 /**


### PR DESCRIPTION
This PR should fix the issue #131.
The main issue wasn't in the `strict()` (or `strictAsync()`) function but more in the `object()` (or `objectAsync()`) function that always assigned the value to a property even when the value was `undefined` and the property was "optional".
The PR fix both the `object()` and `objectAsync()` function by not assigning optional properties when the value is undefined. 