### PR TITLE
feat: custom typeguard based validation

### DIFF
--- a/library/src/schemas/typeGuard/index.ts
+++ b/library/src/schemas/typeGuard/index.ts
@@ -1,0 +1,1 @@
+export * from './typeGuard.ts';

--- a/library/src/schemas/typeGuard/typeGuard.test.ts
+++ b/library/src/schemas/typeGuard/typeGuard.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vitest';
+import { parse } from '../../methods/index.ts';
+import { typeGuard } from './typeGuard.ts';
+
+describe('typeguard', () => {
+  type FooBar = 'foo' | 'bar'
+
+  function isFooBar(arg: any): arg is FooBar {
+    return ['foo', 'bar'].includes(arg)
+  }
+
+  test('should pass according to given typeguard', () => {
+    const schema = typeGuard(isFooBar);
+    const input = 'foo';
+    const output = parse(schema, input);
+    expect(output).toBe(input);
+    expect(() => parse(schema, 'baz')).toThrowError();
+  });
+});

--- a/library/src/schemas/typeGuard/typeGuard.ts
+++ b/library/src/schemas/typeGuard/typeGuard.ts
@@ -1,0 +1,33 @@
+import {
+  BaseSchema,
+  getIssues,
+} from "valibot";
+
+// https://stackoverflow.com/a/62097481/335243
+type TypeGuard<T> = T extends (x: any) => x is infer U ? T : never;
+
+type GuardedType<T> = T extends (x: any) => x is infer U ? U : never;
+
+export type TypeGuardSchema<T> = BaseSchema<boolean, GuardedType<T>> & {
+  schema: 'typeGuard';
+};
+
+export function typeGuard<T extends any>(guard: TypeGuard<T>): TypeGuardSchema<T> {
+  return {
+    schema: 'typeguard',
+    async: false,
+    _parse(input, info) {
+      if (!guard(input)) {
+        return getIssues(
+          info,
+          "type",
+          "typeGuard",
+          "Invalid type",
+          input
+        );
+      }
+
+      return { output: input as GuardedType<T> }
+    }
+  }
+}


### PR DESCRIPTION
The motivation is to allow users to pass their own type guards which is the ultimate form of freedom imho.

My usecase is that i want to validate country codes, an enum which i pull from an external repo (here: https://github.com/lukes/ISO-3166-Countries-with-Regional-Codes/blob/master/all/all.json)

I don't want to have a pass of authoring on that list to avoid introducing corruption of data, so I'd rather write a type guard instead such as:

```ts
import iso3166Data from './all.json'

type Alpha2 = typeof iso3166Data[number]['alpha-2']
const Alpha2Codes = iso3166Data.map(entry => entry['alpha-2'])

export const isAlpha2(arg: any): arg is Alpha2 => Alpha2Codes.includes(arg)
```

The proposed features would allow this:

```ts
const Alpha2Schema = typeGuard(isAlpha2),
const countryCode = parse(Alpha2Schema, 'FR') // typed as Alpha2
```

of course you may argue that i could use the typeguard directly, but i'm trying to validate a form using `object()`, so i'd need it as a schema.