### PR TITLE
Allow additional properties in object schema and allow to block those additional properties via the strict method

### DIFF
--- a/library/src/methods/strict/strict.test.ts
+++ b/library/src/methods/strict/strict.test.ts
@@ -11,10 +11,9 @@ describe('strict', () => {
     const output1 = parse(schema, input1);
     expect(output1).toEqual(input1);
 
-    const keysError = 'Invalid keys';
     const input2 = { key1: 'test', key2: 123, key3: 'unknown' };
-    expect(() => parse(schema, input2)).toThrowError(keysError);
+    expect(() => parse(schema, input2)).toThrowError('Invalid keys: key3');
     const input3 = { key1: 'test', key2: 123, key3: 'unknown', key4: 123 };
-    expect(() => parse(schema, input3)).toThrowError(keysError);
+    expect(() => parse(schema, input3)).toThrowError('Invalid keys: key3, key4');
   });
 });

--- a/library/src/methods/strict/strict.test.ts
+++ b/library/src/methods/strict/strict.test.ts
@@ -14,7 +14,9 @@ describe('strict', () => {
     const input2 = { key1: 'test', key2: 123, key3: 'unknown' };
     expect(() => parse(schema, input2)).toThrowError('Invalid keys: key3');
     const input3 = { key1: 'test', key2: 123, key3: 'unknown', key4: 123 };
-    expect(() => parse(schema, input3)).toThrowError('Invalid keys: key3, key4');
+    expect(() => parse(schema, input3)).toThrowError(
+      'Invalid keys: key3, key4'
+    );
   });
 
   test('should return original issues', () => {

--- a/library/src/methods/strict/strict.test.ts
+++ b/library/src/methods/strict/strict.test.ts
@@ -16,4 +16,12 @@ describe('strict', () => {
     const input3 = { key1: 'test', key2: 123, key3: 'unknown', key4: 123 };
     expect(() => parse(schema, input3)).toThrowError('Invalid keys: key3, key4');
   });
+
+  test('should return original issues', () => {
+    const schema = strict(object({ key1: string(), key2: number() }));
+    const input = { key1: 'test', key2: 'test' };
+    const result = schema._parse(input);
+    expect(result.issues).toBeDefined();
+    expect(result.issues).toHaveLength(1);
+  });
 });

--- a/library/src/methods/strict/strict.ts
+++ b/library/src/methods/strict/strict.ts
@@ -27,12 +27,18 @@ export function strict<TSchema extends ObjectSchema<any>>(
      */
     _parse(input, info) {
       const result = schema._parse(input, info);
-      return !result.issues &&
-        // Check length of input and output keys
-        Object.keys(input as object).length !==
-          Object.keys(result.output).length
-        ? getIssues(info, 'object', 'strict', error || 'Invalid keys', input)
-        : result;
+      if (result.issues) {
+        return result;
+      }
+
+      const schemaKeys = Object.keys(schema.object);
+      const outputKeys = Object.keys(result.output);
+      const extraKeys = outputKeys.filter(k => !schemaKeys.includes(k));
+      if (extraKeys.length > 0) {
+        return getIssues(info, 'object', 'strict', error || `Invalid keys: ${extraKeys.join(', ')}`, input);
+      }
+
+      return result;
     },
   };
 }

--- a/library/src/methods/strict/strict.ts
+++ b/library/src/methods/strict/strict.ts
@@ -33,9 +33,15 @@ export function strict<TSchema extends ObjectSchema<any>>(
 
       const schemaKeys = Object.keys(schema.object);
       const outputKeys = Object.keys(result.output);
-      const extraKeys = outputKeys.filter(k => !schemaKeys.includes(k));
+      const extraKeys = outputKeys.filter((k) => !schemaKeys.includes(k));
       if (extraKeys.length > 0) {
-        return getIssues(info, 'object', 'strict', error || `Invalid keys: ${extraKeys.join(', ')}`, input);
+        return getIssues(
+          info,
+          'object',
+          'strict',
+          error || `Invalid keys: ${extraKeys.join(', ')}`,
+          input
+        );
       }
 
       return result;

--- a/library/src/methods/strict/strictAsync.test.ts
+++ b/library/src/methods/strict/strictAsync.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import {number, objectAsync, string} from '../../schemas/index.ts';
+import { number, objectAsync, string } from '../../schemas/index.ts';
 import { parseAsync } from '../parse/index.ts';
 import { strictAsync } from './strictAsync.ts';
 
@@ -12,9 +12,13 @@ describe('strict', () => {
     expect(output1).toEqual(input1);
 
     const input2 = { key1: 'test', key2: 123, key3: 'unknown' };
-    await expect(parseAsync(schema, input2)).rejects.toThrowError('Invalid keys: key3');
+    await expect(parseAsync(schema, input2)).rejects.toThrowError(
+      'Invalid keys: key3'
+    );
     const input3 = { key1: 'test', key2: 123, key3: 'unknown', key4: 123 };
-    await expect(parseAsync(schema, input3)).rejects.toThrowError('Invalid keys: key3, key4');
+    await expect(parseAsync(schema, input3)).rejects.toThrowError(
+      'Invalid keys: key3, key4'
+    );
   });
 
   test('should return original issues', async () => {

--- a/library/src/methods/strict/strictAsync.test.ts
+++ b/library/src/methods/strict/strictAsync.test.ts
@@ -11,10 +11,9 @@ describe('strict', () => {
     const output1 = await parseAsync(schema, input1);
     expect(output1).toEqual(input1);
 
-    const keysError = 'Invalid keys';
     const input2 = { key1: 'test', key2: 123, key3: 'unknown' };
-    await expect(parseAsync(schema, input2)).rejects.toThrowError(keysError);
+    await expect(parseAsync(schema, input2)).rejects.toThrowError('Invalid keys: key3');
     const input3 = { key1: 'test', key2: 123, key3: 'unknown', key4: 123 };
-    await expect(parseAsync(schema, input3)).rejects.toThrowError(keysError);
+    await expect(parseAsync(schema, input3)).rejects.toThrowError('Invalid keys: key3, key4');
   });
 });

--- a/library/src/methods/strict/strictAsync.test.ts
+++ b/library/src/methods/strict/strictAsync.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { number, objectAsync, string } from '../../schemas/index.ts';
+import {number, objectAsync, string} from '../../schemas/index.ts';
 import { parseAsync } from '../parse/index.ts';
 import { strictAsync } from './strictAsync.ts';
 
@@ -15,5 +15,13 @@ describe('strict', () => {
     await expect(parseAsync(schema, input2)).rejects.toThrowError('Invalid keys: key3');
     const input3 = { key1: 'test', key2: 123, key3: 'unknown', key4: 123 };
     await expect(parseAsync(schema, input3)).rejects.toThrowError('Invalid keys: key3, key4');
+  });
+
+  test('should return original issues', async () => {
+    const schema = strictAsync(objectAsync({ key1: string(), key2: number() }));
+    const input = { key1: 'test', key2: 'test' };
+    const result = await schema._parse(input);
+    expect(result.issues).toBeDefined();
+    expect(result.issues).toHaveLength(1);
   });
 });

--- a/library/src/methods/strict/strictAsync.ts
+++ b/library/src/methods/strict/strictAsync.ts
@@ -27,12 +27,18 @@ export function strictAsync<TSchema extends ObjectSchemaAsync<any>>(
      */
     async _parse(input, info) {
       const result = await schema._parse(input, info);
-      return !result.issues &&
-        // Check length of input and output keys
-        Object.keys(input as object).length !==
-          Object.keys(result.output).length
-        ? getIssues(info, 'object', 'strict', error || 'Invalid keys', input)
-        : result;
+      if (result.issues) {
+        return result;
+      }
+
+      const schemaKeys = Object.keys(schema.object);
+      const outputKeys = Object.keys(result.output);
+      const extraKeys = outputKeys.filter(k => !schemaKeys.includes(k));
+      if (extraKeys.length > 0) {
+        return getIssues(info, 'object', 'strict', error || `Invalid keys: ${extraKeys.join(', ')}`, input);
+      }
+
+      return result;
     },
   };
 }

--- a/library/src/methods/strict/strictAsync.ts
+++ b/library/src/methods/strict/strictAsync.ts
@@ -33,9 +33,15 @@ export function strictAsync<TSchema extends ObjectSchemaAsync<any>>(
 
       const schemaKeys = Object.keys(schema.object);
       const outputKeys = Object.keys(result.output);
-      const extraKeys = outputKeys.filter(k => !schemaKeys.includes(k));
+      const extraKeys = outputKeys.filter((k) => !schemaKeys.includes(k));
       if (extraKeys.length > 0) {
-        return getIssues(info, 'object', 'strict', error || `Invalid keys: ${extraKeys.join(', ')}`, input);
+        return getIssues(
+          info,
+          'object',
+          'strict',
+          error || `Invalid keys: ${extraKeys.join(', ')}`,
+          input
+        );
       }
 
       return result;

--- a/library/src/schemas/object/object.test.ts
+++ b/library/src/schemas/object/object.test.ts
@@ -95,4 +95,11 @@ describe('object', () => {
     expect(output1).toEqual(transformInput());
     expect(output2).toEqual(transformInput());
   });
+
+  test('should allow additional properties', () => {
+    const schema = object({ key1: string(), key2: number() });
+    const input = { key1: 'test', key2: 123, key3: true };
+    const output = parse(schema, input);
+    expect(output).toEqual(input);
+  });
 });

--- a/library/src/schemas/object/object.ts
+++ b/library/src/schemas/object/object.ts
@@ -143,6 +143,12 @@ export function object<TObjectShape extends ObjectShape>(
         }
       }
 
+      const extraInputKeys = Object.keys(input).filter(k => !cachedEntries.map(e => e[0]).includes(k));
+      for (const key of extraInputKeys) {
+        const value = (input as Record<string, unknown>)[key];
+        output[key] = value;
+      }
+
       // Return issues or pipe result
       return issues
         ? { issues }

--- a/library/src/schemas/object/object.ts
+++ b/library/src/schemas/object/object.ts
@@ -143,7 +143,9 @@ export function object<TObjectShape extends ObjectShape>(
         }
       }
 
-      const extraInputKeys = Object.keys(input).filter(k => !cachedEntries.map(e => e[0]).includes(k));
+      const extraInputKeys = Object.keys(input).filter(
+        (k) => !cachedEntries.map((e) => e[0]).includes(k)
+      );
       for (const key of extraInputKeys) {
         const value = (input as Record<string, unknown>)[key];
         output[key] = value;

--- a/library/src/schemas/object/objectAsync.test.ts
+++ b/library/src/schemas/object/objectAsync.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { type ValiError } from '../../error/index.ts';
-import { parseAsync} from '../../methods/index.ts';
+import { parseAsync } from '../../methods/index.ts';
 import { toCustom } from '../../transformations/index.ts';
 import { number } from '../number/index.ts';
 import { string, stringAsync } from '../string/index.ts';

--- a/library/src/schemas/object/objectAsync.test.ts
+++ b/library/src/schemas/object/objectAsync.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { type ValiError } from '../../error/index.ts';
-import { parseAsync } from '../../methods/index.ts';
+import { parseAsync} from '../../methods/index.ts';
 import { toCustom } from '../../transformations/index.ts';
 import { number } from '../number/index.ts';
 import { string, stringAsync } from '../string/index.ts';
@@ -96,5 +96,12 @@ describe('objectAsync', () => {
     );
     expect(output1).toEqual(transformInput());
     expect(output2).toEqual(transformInput());
+  });
+
+  test('should allow additional properties', async () => {
+    const schema = objectAsync({ key1: string(), key2: number() });
+    const input = { key1: 'test', key2: 123, key3: true };
+    const output = await parseAsync(schema, input);
+    expect(output).toEqual(input);
   });
 });

--- a/library/src/schemas/object/objectAsync.ts
+++ b/library/src/schemas/object/objectAsync.ts
@@ -163,6 +163,12 @@ export function objectAsync<TObjectShape extends ObjectShapeAsync>(
         })
       ).catch(() => null);
 
+      const extraInputKeys = Object.keys(input).filter(k => !cachedEntries.map(e => e[0]).includes(k));
+      for (const key of extraInputKeys) {
+        const value = (input as Record<string, unknown>)[key];
+        output[key] = value;
+      }
+
       // Return issues or pipe result
       return issues
         ? { issues }

--- a/library/src/schemas/object/objectAsync.ts
+++ b/library/src/schemas/object/objectAsync.ts
@@ -163,7 +163,9 @@ export function objectAsync<TObjectShape extends ObjectShapeAsync>(
         })
       ).catch(() => null);
 
-      const extraInputKeys = Object.keys(input).filter(k => !cachedEntries.map(e => e[0]).includes(k));
+      const extraInputKeys = Object.keys(input).filter(
+        (k) => !cachedEntries.map((e) => e[0]).includes(k)
+      );
       for (const key of extraInputKeys) {
         const value = (input as Record<string, unknown>)[key];
         output[key] = value;


### PR DESCRIPTION
This PR implements the feature request #143 