### PR TITLE
Add option to skip pipelines when parsing

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `skipPipe` option to skip execution of pipeline (pull request #164)
+
 ## v0.16.0 (September 16, 2023)
 
 - Add `ulid` validation (pull request #151)

--- a/library/src/methods/parse/parse.ts
+++ b/library/src/methods/parse/parse.ts
@@ -13,7 +13,7 @@ import type { BaseSchema, Output, ParseInfo } from '../../types.ts';
 export function parse<TSchema extends BaseSchema>(
   schema: TSchema,
   input: unknown,
-  info?: Pick<ParseInfo, 'abortEarly' | 'abortPipeEarly'>
+  info?: Pick<ParseInfo, 'abortEarly' | 'abortPipeEarly' | 'skipPipes'>
 ): Output<TSchema> {
   const result = schema._parse(input, info);
   if (result.issues) {

--- a/library/src/methods/parse/parse.ts
+++ b/library/src/methods/parse/parse.ts
@@ -13,7 +13,7 @@ import type { BaseSchema, Output, ParseInfo } from '../../types.ts';
 export function parse<TSchema extends BaseSchema>(
   schema: TSchema,
   input: unknown,
-  info?: Pick<ParseInfo, 'abortEarly' | 'abortPipeEarly' | 'skipPipes'>
+  info?: Pick<ParseInfo, 'abortEarly' | 'abortPipeEarly' | 'skipPipe'>
 ): Output<TSchema> {
   const result = schema._parse(input, info);
   if (result.issues) {

--- a/library/src/methods/parse/parseAsync.ts
+++ b/library/src/methods/parse/parseAsync.ts
@@ -18,7 +18,7 @@ import type {
 export async function parseAsync<TSchema extends BaseSchema | BaseSchemaAsync>(
   schema: TSchema,
   input: unknown,
-  info?: Pick<ParseInfo, 'abortEarly' | 'abortPipeEarly'>
+  info?: Pick<ParseInfo, 'abortEarly' | 'abortPipeEarly' | 'skipPipes'>
 ): Promise<Output<TSchema>> {
   const result = await schema._parse(input, info);
   if (result.issues) {

--- a/library/src/methods/parse/parseAsync.ts
+++ b/library/src/methods/parse/parseAsync.ts
@@ -18,7 +18,7 @@ import type {
 export async function parseAsync<TSchema extends BaseSchema | BaseSchemaAsync>(
   schema: TSchema,
   input: unknown,
-  info?: Pick<ParseInfo, 'abortEarly' | 'abortPipeEarly' | 'skipPipes'>
+  info?: Pick<ParseInfo, 'abortEarly' | 'abortPipeEarly' | 'skipPipe'>
 ): Promise<Output<TSchema>> {
   const result = await schema._parse(input, info);
   if (result.issues) {

--- a/library/src/methods/safeParse/safeParse.ts
+++ b/library/src/methods/safeParse/safeParse.ts
@@ -14,7 +14,7 @@ import type { SafeParseResult } from './types.ts';
 export function safeParse<TSchema extends BaseSchema>(
   schema: TSchema,
   input: unknown,
-  info?: Pick<ParseInfo, 'abortEarly' | 'abortPipeEarly'>
+  info?: Pick<ParseInfo, 'abortEarly' | 'abortPipeEarly' | 'skipPipes'>
 ): SafeParseResult<TSchema> {
   const result = schema._parse(input, info);
   return result.issues

--- a/library/src/methods/safeParse/safeParse.ts
+++ b/library/src/methods/safeParse/safeParse.ts
@@ -14,7 +14,7 @@ import type { SafeParseResult } from './types.ts';
 export function safeParse<TSchema extends BaseSchema>(
   schema: TSchema,
   input: unknown,
-  info?: Pick<ParseInfo, 'abortEarly' | 'abortPipeEarly' | 'skipPipes'>
+  info?: Pick<ParseInfo, 'abortEarly' | 'abortPipeEarly' | 'skipPipe'>
 ): SafeParseResult<TSchema> {
   const result = schema._parse(input, info);
   return result.issues

--- a/library/src/methods/safeParse/safeParseAsync.ts
+++ b/library/src/methods/safeParse/safeParseAsync.ts
@@ -16,7 +16,7 @@ export async function safeParseAsync<
 >(
   schema: TSchema,
   input: unknown,
-  info?: Pick<ParseInfo, 'abortEarly' | 'abortPipeEarly'>
+  info?: Pick<ParseInfo, 'abortEarly' | 'abortPipeEarly' | 'skipPipe'>
 ): Promise<SafeParseResult<TSchema>> {
   const result = await schema._parse(input, info);
   return result.issues

--- a/library/src/schemas/map/map.ts
+++ b/library/src/schemas/map/map.ts
@@ -111,6 +111,7 @@ export function map<TMapKey extends BaseSchema, TMapValue extends BaseSchema>(
           origin: 'key',
           abortEarly: info?.abortEarly,
           abortPipeEarly: info?.abortPipeEarly,
+          skipPipe: info?.skipPipe,
         });
 
         // If there are issues, capture them

--- a/library/src/schemas/map/mapAsync.ts
+++ b/library/src/schemas/map/mapAsync.ts
@@ -137,6 +137,7 @@ export function mapAsync<
                   origin,
                   abortEarly: info?.abortEarly,
                   abortPipeEarly: info?.abortPipeEarly,
+                  skipPipe: info?.skipPipe,
                 });
 
                 // If not aborted early, continue execution

--- a/library/src/schemas/record/record.ts
+++ b/library/src/schemas/record/record.ts
@@ -163,6 +163,7 @@ export function record<
             origin: 'key',
             abortEarly: info?.abortEarly,
             abortPipeEarly: info?.abortPipeEarly,
+            skipPipe: info?.skipPipe,
           });
 
           // If there are issues, capture them

--- a/library/src/schemas/record/recordAsync.ts
+++ b/library/src/schemas/record/recordAsync.ts
@@ -192,6 +192,7 @@ export function recordAsync<
                     origin,
                     abortEarly: info?.abortEarly,
                     abortPipeEarly: info?.abortPipeEarly,
+                    skipPipe: info?.skipPipe,
                   });
 
                   // If not aborted early, continue execution

--- a/library/src/types.ts
+++ b/library/src/types.ts
@@ -47,6 +47,7 @@ export type Issue = {
   issues?: Issues;
   abortEarly?: boolean;
   abortPipeEarly?: boolean;
+  skipPipe?: boolean;
 };
 
 /**
@@ -58,10 +59,8 @@ export type Issues = [Issue, ...Issue[]];
  * Parse info type.
  */
 export type ParseInfo = Partial<
-  Pick<Issue, 'origin' | 'abortEarly' | 'abortPipeEarly'>
-> & {
-  skipPipes?: boolean;
-};
+  Pick<Issue, 'origin' | 'abortEarly' | 'abortPipeEarly' | 'skipPipe'>
+>;
 
 /**
  * Path item type.

--- a/library/src/types.ts
+++ b/library/src/types.ts
@@ -59,7 +59,9 @@ export type Issues = [Issue, ...Issue[]];
  */
 export type ParseInfo = Partial<
   Pick<Issue, 'origin' | 'abortEarly' | 'abortPipeEarly'>
->;
+> & {
+  skipPipes?: boolean;
+};
 
 /**
  * Path item type.

--- a/library/src/utils/executePipe/executePipe.test.ts
+++ b/library/src/utils/executePipe/executePipe.test.ts
@@ -31,7 +31,7 @@ describe('executePipe', () => {
   });
 
   test('should skip the pipeline', () => {
-    const infoWithSkip = { ...info, skipPipes: true };
+    const infoWithSkip = { ...info, skipPipe: true };
     const pipe: Pipe<number> = [minValue(5)];
     expect(executePipe<number>(0, pipe, infoWithSkip, 'number').output).toBe(0);
   });

--- a/library/src/utils/executePipe/executePipe.test.ts
+++ b/library/src/utils/executePipe/executePipe.test.ts
@@ -29,4 +29,10 @@ describe('executePipe', () => {
       executePipe<number>(0, pipe, infoWithAbort, 'number').issues?.length
     ).toBe(1);
   });
+
+  test('should skip the pipeline', () => {
+    const infoWithSkip = { ...info, skipPipes: true };
+    const pipe: Pipe<number> = [minValue(5)];
+    expect(executePipe<number>(0, pipe, infoWithSkip, 'number').output).toBe(0);
+  });
 });

--- a/library/src/utils/executePipe/executePipe.ts
+++ b/library/src/utils/executePipe/executePipe.ts
@@ -26,7 +26,7 @@ export function executePipe<TValue>(
   reason: IssueReason
 ): _ParseResult<TValue> {
   // If pipe is empty, return input as output
-  if (!pipe || !pipe.length) {
+  if (parseInfo?.skipPipes || !pipe || !pipe.length) {
     return getOutput(input);
   }
 

--- a/library/src/utils/executePipe/executePipe.ts
+++ b/library/src/utils/executePipe/executePipe.ts
@@ -26,7 +26,7 @@ export function executePipe<TValue>(
   reason: IssueReason
 ): _ParseResult<TValue> {
   // If pipe is empty, return input as output
-  if (parseInfo?.skipPipes || !pipe || !pipe.length) {
+  if (!pipe || !pipe.length || parseInfo?.skipPipe) {
     return getOutput(input);
   }
 

--- a/library/src/utils/executePipe/executePipeAsync.test.ts
+++ b/library/src/utils/executePipe/executePipeAsync.test.ts
@@ -32,4 +32,12 @@ describe('executePipeAsync', () => {
         ?.length
     ).toBe(1);
   });
+
+  test('should skip the pipeline', async () => {
+    const infoWithSkip = { ...info, skipPipes: true };
+    const pipe: PipeAsync<number> = [minValue(5)];
+    expect(
+      (await executePipeAsync<number>(0, pipe, infoWithSkip, 'number')).output
+    ).toBe(0);
+  });
 });

--- a/library/src/utils/executePipe/executePipeAsync.test.ts
+++ b/library/src/utils/executePipe/executePipeAsync.test.ts
@@ -34,7 +34,7 @@ describe('executePipeAsync', () => {
   });
 
   test('should skip the pipeline', async () => {
-    const infoWithSkip = { ...info, skipPipes: true };
+    const infoWithSkip = { ...info, skipPipe: true };
     const pipe: PipeAsync<number> = [minValue(5)];
     expect(
       (await executePipeAsync<number>(0, pipe, infoWithSkip, 'number')).output

--- a/library/src/utils/executePipe/executePipeAsync.ts
+++ b/library/src/utils/executePipe/executePipeAsync.ts
@@ -26,7 +26,7 @@ export async function executePipeAsync<TValue>(
   reason: IssueReason
 ): Promise<_ParseResult<TValue>> {
   // If pipe is empty, return input as output
-  if (!pipe || !pipe.length) {
+  if (parseInfo?.skipPipes || !pipe || !pipe.length) {
     return getOutput(input);
   }
 

--- a/library/src/utils/executePipe/executePipeAsync.ts
+++ b/library/src/utils/executePipe/executePipeAsync.ts
@@ -26,7 +26,7 @@ export async function executePipeAsync<TValue>(
   reason: IssueReason
 ): Promise<_ParseResult<TValue>> {
   // If pipe is empty, return input as output
-  if (parseInfo?.skipPipes || !pipe || !pipe.length) {
+  if (!pipe || !pipe.length || parseInfo?.skipPipe) {
     return getOutput(input);
   }
 

--- a/library/src/utils/executePipe/utils/getIssue/getIssue.ts
+++ b/library/src/utils/executePipe/utils/getIssue/getIssue.ts
@@ -23,5 +23,6 @@ export function getIssue(
     path: issue.path,
     abortEarly: info?.abortEarly,
     abortPipeEarly: info?.abortPipeEarly,
+    skipPipe: info?.skipPipe,
   };
 }

--- a/library/src/utils/executePipe/utils/getPipeInfo/getPipeInfo.ts
+++ b/library/src/utils/executePipe/utils/getPipeInfo/getPipeInfo.ts
@@ -19,5 +19,6 @@ export function getPipeInfo(
     origin: info?.origin,
     abortEarly: info?.abortEarly,
     abortPipeEarly: info?.abortPipeEarly,
+    skipPipe: info?.skipPipe,
   };
 }

--- a/library/src/utils/getSchemaIssues/getSchemaIssues.ts
+++ b/library/src/utils/getSchemaIssues/getSchemaIssues.ts
@@ -33,6 +33,7 @@ export function getSchemaIssues(
         issues,
         abortEarly: info?.abortEarly,
         abortPipeEarly: info?.abortPipeEarly,
+        skipPipe: info?.skipPipe,
       },
     ],
   };

--- a/website/src/routes/guides/(main-concepts)/errors/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/errors/index.mdx
@@ -31,6 +31,7 @@ type Issue = {
   issues?: Issues;
   abortEarly?: boolean;
   abortPipeEarly?: boolean;
+  skipPipe?: boolean;
 };
 ```
 

--- a/website/src/routes/guides/(main-concepts)/parse-data/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/parse-data/index.mdx
@@ -64,9 +64,9 @@ if (is(EmailSchema, data)) {
 }
 ```
 
-## Abort early
+## Configuration
 
-By default, I collect each issue during validation to give you detailed feedback on why the input does not match the schema. If this is not required in your use case, you can control this behavior with `abortEarly` or `abortPipeEarly`.
+By default, I collect each issue during validation to give you detailed feedback on why the input does not match the schema. If this is not required in your use case, you can control this behavior with `abortEarly`, `abortPipeEarly` and `skipPipe`.
 
 ### Abort validation
 
@@ -104,6 +104,23 @@ try {
   const email = parse(EmailSchema, 'jane@example.com', {
     abortPipeEarly: true,
   });
+
+  // Handle errors if one occurs
+} catch (error) {
+  console.log(error);
+}
+```
+
+### Skip pipeline
+
+If you set `skipPipe` to `true` I skip every pipeline of a schema. This can be useful for forms, for example, to check only the data types of initial values and not the other details that are validated in the pipelines.
+
+```ts
+import { email, endsWith, parse, string } from 'valibot'; // 0.66 kB
+
+try {
+  const EmailSchema = string([email(), endsWith('@example.com')]);
+  const email = parse(EmailSchema, '', { skipPipe: true });
 
   // Handle errors if one occurs
 } catch (error) {


### PR DESCRIPTION
Firstly, thanks for Valibot 😊 It's a great library and I'm excited to use it in projects moving forward! 

## Overview

When validating a value, it would be useful to be able to confirm the type of the object without throwing if the values don't pass formatting checks. Valibot could support that by accepting an option to skip all pipeline checks when parsing.

For example: 

```ts
const schema = object({
  name: string(),
  email: string([email()]),
});

const initialValues: unknown = { name: '', email: '' };

parse(schema, initialValues); // will throw
parse(schema, initialValues, { skipPipes: true }); // won't throw
```

This could be really useful in circumstances such as initial form values, where we do care about the type of the values, but want to run formatting checks separately.

If I understand correctly, Valibot's rules for not transforming the data type inside pipelines means that this should work for any schema.

## Alternatives

Users could maintain two schemas: one for the type-level checks, one for the formatting. But that would be additional overhead, and cause issues if their Valibot schema is auto-generated.

## Notes

Please forgive me if this functionality already exists, or if I've overlooked a caveat here :) Also happy to rename the option too if another name is more appropriate.