### PR TITLE
Skip pipeline when calling is()

### DIFF
--- a/library/src/methods/is/is.test.ts
+++ b/library/src/methods/is/is.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { number, object, string } from '../../schemas/index.ts';
+import { minLength } from '../../validations/index.ts';
 import { is } from './is.ts';
 
 describe('is', () => {
@@ -16,5 +17,9 @@ describe('is', () => {
     expect(is(string(), 123)).toBe(false);
     expect(is(number(), 'hello')).toBe(false);
     expect(is(object({ test: string() }), {})).toBe(false);
+  });
+
+  test('should skip pipelines', () => {
+    expect(is(string([minLength(1)]), '')).toBe(true);
   });
 });

--- a/library/src/methods/is/is.test.ts
+++ b/library/src/methods/is/is.test.ts
@@ -19,7 +19,8 @@ describe('is', () => {
     expect(is(object({ test: string() }), {})).toBe(false);
   });
 
-  test('should skip pipelines', () => {
-    expect(is(string([minLength(1)]), '')).toBe(true);
+  test('should accept parsing options', () => {
+    expect(is(string([minLength(1)]), '', { skipPipe: true })).toBe(true);
+    expect(is(string([minLength(1)]), '', { skipPipe: false })).toBe(false);
   });
 });

--- a/library/src/methods/is/is.ts
+++ b/library/src/methods/is/is.ts
@@ -1,4 +1,4 @@
-import type { BaseSchema, Input } from '../../types.ts';
+import type { BaseSchema, Input, ParseInfo } from '../../types.ts';
 
 /**
  * Checks if the input matches the scheme. By using a type predicate, this
@@ -6,12 +6,14 @@ import type { BaseSchema, Input } from '../../types.ts';
  *
  * @param schema The schema to be used.
  * @param input The input to be tested.
+ * @param info The optional parse info.
  *
  * @returns Whether the input matches the scheme.
  */
 export function is<TSchema extends BaseSchema>(
   schema: TSchema,
-  input: unknown
+  input: unknown,
+  info?: ParseInfo
 ): input is Input<TSchema> {
-  return !schema._parse(input, { abortEarly: true, skipPipe: true }).issues;
+  return !schema._parse(input, { abortEarly: true, ...info }).issues;
 }

--- a/library/src/methods/is/is.ts
+++ b/library/src/methods/is/is.ts
@@ -13,5 +13,5 @@ export function is<TSchema extends BaseSchema>(
   schema: TSchema,
   input: unknown
 ): input is Input<TSchema> {
-  return !schema._parse(input, { abortEarly: true }).issues;
+  return !schema._parse(input, { abortEarly: true, skipPipe: true }).issues;
 }

--- a/website/src/routes/guides/(main-concepts)/parse-data/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/parse-data/index.mdx
@@ -51,7 +51,7 @@ if (result.success) {
 
 Another way to validate data that can be useful in individual cases is to use a type guard. A type guard is an if-condition which, if `true`, sets the parsed data to the input type of a schema.
 
-If a type guard is used, the issues of the validation cannot be accessed. Also, pipelines are skipped, transformations have no effect and unknown keys of an object are not removed. Therefore, this approach is not as safe and powerful as the two previous ways. Also, it can currently only be used with syncronous schemas.
+If a type guard is used, the issues of the validation cannot be accessed. Also, transformations have no effect and unknown keys of an object are not removed. Therefore, this approach is not as safe and powerful as the two previous ways. Also, it can currently only be used with syncronous schemas.
 
 ```ts
 import { email, is, string } from 'valibot'; // 0.55 kB

--- a/website/src/routes/guides/(main-concepts)/parse-data/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/parse-data/index.mdx
@@ -51,7 +51,7 @@ if (result.success) {
 
 Another way to validate data that can be useful in individual cases is to use a type guard. A type guard is an if-condition which, if `true`, sets the parsed data to the input type of a schema.
 
-If a type guard is used, the issues of the validation cannot be accessed. Also, transformations have no effect and unknown keys of an object are not removed. Therefore, this approach is not as safe and powerful as the two previous ways. Also, it can currently only be used with syncronous schemas.
+If a type guard is used, the issues of the validation cannot be accessed. Also, pipelines are skipped, transformations have no effect and unknown keys of an object are not removed. Therefore, this approach is not as safe and powerful as the two previous ways. Also, it can currently only be used with syncronous schemas.
 
 ```ts
 import { email, is, string } from 'valibot'; // 0.55 kB


### PR DESCRIPTION
As `is()` is primarily designed for use as a type guard, it would make sense to skip pipelines during this check too 🙂

Currently: 

```ts
is(string([email()]), 'foo') // this check would fail, though types are correct
```

Proposed: 

```ts
is(string([email()]), 'foo') // this check would pass, as it's a string
```

## Notes

**This is a breaking change to `is()`**

Following on from #164.