### PR TITLE
Add `fallback` property to `fallback()` return value

### DIFF
--- a/library/src/methods/fallback/fallback.test.ts
+++ b/library/src/methods/fallback/fallback.test.ts
@@ -27,4 +27,9 @@ describe('fallback', () => {
     const output3 = parse(schema3, input2);
     expect(output3).toEqual(input2);
   });
+
+  test('should have fallback property', () => {
+    expect(schema1.fallback).toEqual('test');
+    expect(schema2.fallback).toEqual('test');
+  });
 });

--- a/library/src/methods/fallback/fallback.ts
+++ b/library/src/methods/fallback/fallback.ts
@@ -12,7 +12,7 @@ import type { FallbackInfo } from './types.ts';
  */
 export function fallback<TSchema extends BaseSchema>(
   schema: TSchema,
-  value: Output<TSchema> | ((info: FallbackInfo) => Output<TSchema>)
+  value: Output<TSchema> | ((info?: FallbackInfo) => Output<TSchema>)
 ): TSchema {
   return {
     ...schema,

--- a/library/src/methods/fallback/fallback.ts
+++ b/library/src/methods/fallback/fallback.ts
@@ -16,7 +16,8 @@ export function fallback<TSchema extends BaseSchema>(
 ): TSchema {
   return {
     ...schema,
-
+    fallback:
+      typeof value === 'function' ? (value as () => Output<TSchema>)() : value,
     /**
      * Parses unknown input based on its schema.
      *

--- a/library/src/methods/fallback/fallback.ts
+++ b/library/src/methods/fallback/fallback.ts
@@ -16,8 +16,16 @@ export function fallback<TSchema extends BaseSchema>(
 ): TSchema {
   return {
     ...schema,
-    fallback:
-      typeof value === 'function' ? (value as () => Output<TSchema>)() : value,
+
+    /**
+     * The fallback value
+     */
+    get fallback() {
+      return typeof value === 'function'
+        ? (value as () => Output<TSchema>)()
+        : value;
+    },
+
     /**
      * Parses unknown input based on its schema.
      *

--- a/library/src/methods/fallback/fallbackAsync.test.ts
+++ b/library/src/methods/fallback/fallbackAsync.test.ts
@@ -27,4 +27,9 @@ describe('fallbackAsync', () => {
     const output3 = await parseAsync(schema3, input2);
     expect(output3).toEqual(input2);
   });
+
+  test('should have fallback property', () => {
+    expect(schema1.fallback).toEqual('test');
+    expect(schema2.fallback).toEqual('test');
+  });
 });

--- a/library/src/methods/fallback/fallbackAsync.ts
+++ b/library/src/methods/fallback/fallbackAsync.ts
@@ -12,11 +12,12 @@ import type { FallbackInfo } from './types.ts';
  */
 export function fallbackAsync<TSchema extends BaseSchema | BaseSchemaAsync>(
   schema: TSchema,
-  value: Output<TSchema> | ((info: FallbackInfo) => Output<TSchema>)
+  value: Output<TSchema> | ((info?: FallbackInfo) => Output<TSchema>)
 ): TSchema {
   return {
     ...schema,
-
+    fallback:
+      typeof value === 'function' ? (value as () => Output<TSchema>)() : value,
     /**
      * Parses unknown input based on its schema.
      *

--- a/library/src/methods/fallback/fallbackAsync.ts
+++ b/library/src/methods/fallback/fallbackAsync.ts
@@ -16,8 +16,16 @@ export function fallbackAsync<TSchema extends BaseSchema | BaseSchemaAsync>(
 ): TSchema {
   return {
     ...schema,
-    fallback:
-      typeof value === 'function' ? (value as () => Output<TSchema>)() : value,
+
+    /**
+     * The fallback value
+     */
+    get fallback() {
+      return typeof value === 'function'
+        ? (value as () => Output<TSchema>)()
+        : value;
+    },
+
     /**
      * Parses unknown input based on its schema.
      *


### PR DESCRIPTION
- Make info arg optional
- Add `fallback` property to return value

Closes #174 