### PR TITLE
deno requires `.ts` prefix in-order for this to work

### DIFF
--- a/library/src/validations/ulid/ulid.ts
+++ b/library/src/validations/ulid/ulid.ts
@@ -1,5 +1,5 @@
-import type { ErrorMessage, PipeResult } from '../../types';
-import { getOutput, getPipeIssues } from '../../utils';
+import type { ErrorMessage, PipeResult } from '../../types.ts';
+import { getOutput, getPipeIssues } from '../../utils/index.ts';
 
 /**
  * Creates a validation functions that validates a [ULID](https://github.com/ulid/spec).


### PR DESCRIPTION
Seems that the import paths for the `ulid` module are different to the other validators and so there is a break in compatibility with Deno