### PR TITLE
fix: change record keys types to optional

### DIFF
--- a/library/src/schemas/record/record.ts
+++ b/library/src/schemas/record/record.ts
@@ -21,10 +21,10 @@ export type RecordKey =
 export type RecordSchema<
   TRecordValue extends BaseSchema,
   TRecordKey extends RecordKey = StringSchema,
-  TOutput = RecordOutput<TRecordKey, TRecordValue>
+  TOutput = Partial<RecordOutput<TRecordKey, TRecordValue>>
 > = BaseSchema<RecordInput<TRecordKey, TRecordValue>, TOutput> & {
   schema: 'record';
-  record: { key: TRecordKey; value: TRecordValue };
+  record: { key?: TRecordKey; value: TRecordValue };
 };
 
 /**


### PR DESCRIPTION
Fix for  `record` type as it work in `Zod` implementation. This is a variouse of resolving follow [issue](https://github.com/fabian-hiller/valibot/issues/156)

```TS
const SOME_NAME = {
  FOO: "FOO", 
  BAR: "BAR"
} as const;

const ValibotSchema = record(nativeEnum(SOME_NAME), string());

type ValibotOutType = Output<typeof ValibotSchema>;

const valibotData: ValibotOutType  = {}; // here error with TS ->  "Type  {}  is missing the following properties from type  { FOO: string[]; BAR: string[]; } :  FOO, BAR"

valibotData[SOME_NAME.FOO] = 'SOME';
```
Expected, that `record(nativeEnum(SOME_NAME), string())` will get `Partial<Record<keyof typeof SOME_NAME, string>>` as it returns in `Zod` with follow code:
```TS
const ZodSchema = z.record(z.nativeEnum(SOME_NAME), z.string());
  
type ZodOutType = z.infer<typeof ZodSchema>;

const zodData: ZodOutType  = {}; // here all fine
zodData[SOME_NAME.FOO] = 'SOME'
