### PR TITLE
feat(dot-notation): add partial implementation

### DIFF
--- a/library/src/registry/registry.ts
+++ b/library/src/registry/registry.ts
@@ -1,9 +1,5 @@
 import type { PipeItem } from '../types';
 
-// register  a validator function by it's name , it's validation function and the type of the schema it validates
-// you can register many validators for the same schema type
-// e.g. register('number', min) // min is the function to register and the name of the function is extracted to register it
-
 type Validator<Args extends unknown[], T> = (...args: Args) => PipeItem<T>;
 type RegistryItem = (...args: unknown[]) => unknown;
 

--- a/library/src/registry/registry.ts
+++ b/library/src/registry/registry.ts
@@ -1,0 +1,41 @@
+import type { PipeItem } from '../types';
+
+// register  a validator function by it's name , it's validation function and the type of the schema it validates
+// you can register many validators for the same schema type
+// e.g. register('number', min) // min is the function to register and the name of the function is extracted to register it
+
+type Validator<Args extends unknown[], T> = (...args: Args) => PipeItem<T>;
+type RegistryItem = (...args: unknown[]) => unknown;
+
+const registry: Record<string, Record<string, RegistryItem>> = {};
+
+export function register<Args extends unknown[], T>(
+  type: string,
+  validator: Validator<Args, T>
+) {
+  const name = validator.name;
+  if (!name) {
+    throw new Error('Cannot register anonymous function');
+  }
+  if (!registry[type]) {
+    registry[type] = {};
+  }
+
+  const mixin = function (...args: any[]) {
+    // @ts-expect-error 'this' is the owner of the mixin, it's unknown at this point for typescript
+    if (this._pipe === undefined) {
+      // @ts-expect-error
+      this._pipe = [];
+    }
+    // @ts-expect-error
+    this._pipe.push(validator(...args));
+    // @ts-expect-error
+    return this;
+  };
+
+  registry[type][name] = mixin;
+}
+
+export function mixinsOf(type: string) {
+  return registry[type];
+}

--- a/library/src/schemas/string/string.ts
+++ b/library/src/schemas/string/string.ts
@@ -1,3 +1,4 @@
+import { mixinsOf } from '../../registry/registry.ts';
 import type { BaseSchema, ErrorMessage, Pipe } from '../../types.ts';
 import {
   executePipe,
@@ -5,12 +6,20 @@ import {
   getSchemaIssues,
 } from '../../utils/index.ts';
 
+type SchemaValidators<TRegistry, TThis> = {
+  [K in keyof TRegistry]: (
+    ...args: Parameters<Extract<TRegistry[K], (...args: any) => any>>
+  ) => TThis;
+};
+
 /**
  * String schema type.
  */
-export type StringSchema<TOutput = string> = BaseSchema<string, TOutput> & {
+export interface StringSchema<TOutput = string>
+  extends BaseSchema<string, TOutput>,
+    SchemaValidators<StringRegistry, StringSchema<TOutput>> {
   schema: 'string';
-};
+}
 
 /**
  * Creates a string schema.
@@ -45,6 +54,8 @@ export function string(
      */
     schema: 'string',
 
+    _pipe: pipe,
+
     /**
      * Whether it's async.
      */
@@ -71,7 +82,11 @@ export function string(
       }
 
       // Execute pipe and return result
-      return executePipe(input, pipe, info, 'string');
+      return executePipe(input, this._pipe, info, 'string');
     },
+    ...(mixinsOf('string') as SchemaValidators<
+      StringRegistry,
+      StringSchema<string>
+    >),
   };
 }

--- a/library/src/types.ts
+++ b/library/src/types.ts
@@ -87,6 +87,7 @@ export type BaseSchema<TInput = any, TOutput = TInput> = {
   async: false;
   _parse(input: unknown, info?: ParseInfo): _ParseResult<TOutput>;
   _types?: { input: TInput; output: TOutput };
+  _pipe?: Pipe<TInput>;
 };
 
 /**
@@ -135,17 +136,20 @@ export type PipeResult<TOutput> =
       issues: Pick<Issue, 'validation' | 'message' | 'input' | 'path'>[];
     };
 
+export type PipeItem<TValue> = (value: TValue) => PipeResult<TValue>;
+export type PipeItemAsync<TValue> = (
+  value: TValue
+) => PipeResult<TValue> | Promise<PipeResult<TValue>>;
+
 /**
  * Validation and transformation pipe type.
  */
-export type Pipe<TValue> = ((value: TValue) => PipeResult<TValue>)[];
+export type Pipe<TValue> = PipeItem<TValue>[];
 
 /**
  * Async validation and transformation pipe type.
  */
-export type PipeAsync<TValue> = ((
-  value: TValue
-) => PipeResult<TValue> | Promise<PipeResult<TValue>>)[];
+export type PipeAsync<TValue> = PipeItemAsync<TValue>[];
 
 /**
  * Resolve type.

--- a/library/src/validations/email/email.test.ts
+++ b/library/src/validations/email/email.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { email } from './email.ts';
+import { string } from '../../schemas/string/index.ts';
+import { parse } from '../../methods/index.ts';
 
 describe('email', () => {
   test('should pass only emails', () => {
@@ -53,5 +55,16 @@ describe('email', () => {
     const error = 'Value is not an email!';
     const validate = email(error);
     expect(validate('test').issues?.[0].message).toBe(error);
+  });
+
+  test('should thow error when not registered', () => {
+    expect(() => string().email()).toThrowError();
+  });
+
+  test('should parse an email when registered', async () => {
+    await import('./registry.ts');
+    const schema = string().email();
+    expect(parse(schema, 'email@example.com')).toBe('email@example.com');
+    expect(() => parse(schema, 'email@example..com')).toThrowError();
   });
 });

--- a/library/src/validations/email/registry.ts
+++ b/library/src/validations/email/registry.ts
@@ -1,0 +1,10 @@
+import { email } from './email.ts';
+import { register } from '../../registry/registry.ts';
+
+declare global {
+  export interface StringRegistry {
+    email: typeof email;
+  }
+}
+
+register('string', email);

--- a/library/src/validations/emoji/registry.ts
+++ b/library/src/validations/emoji/registry.ts
@@ -1,0 +1,10 @@
+import { emoji } from './emoji.ts';
+import { register } from '../../registry/registry.ts';
+
+declare global {
+  export interface StringRegistry {
+    emoji: typeof emoji;
+  }
+}
+
+register('string', emoji);

--- a/library/src/validations/endsWith/registry.ts
+++ b/library/src/validations/endsWith/registry.ts
@@ -1,0 +1,10 @@
+import { endsWith } from './endsWith.ts';
+import { register } from '../../registry/registry.ts';
+
+declare global {
+  export interface StringRegistry {
+    endsWith: typeof endsWith;
+  }
+}
+
+register('string', endsWith);


### PR DESCRIPTION
Hello Fabian,

Like promised, here an example of how to add dot notation for valibot.
Users would need to add a registration step to register some notations.
a vite plugin could add them automatically if needed.

This is using:
- a type registry declared globally (interfaces are automatically overloaded by typescript).
- a runtime registry to add mixins at runtime

if you don't import the registry, you don't pay the cost and you don't have the dot notation.
so this would be optin for users that want it

if you want to explore more, happy to help make it a reality and improve DX, since this is a quick demo hack.
