### PR TITLE
fix(deno): avoid Node-style import resolution

### DIFF
--- a/library/src/methods/getFallback/types.ts
+++ b/library/src/methods/getFallback/types.ts
@@ -3,7 +3,7 @@ import type {
   SchemaWithFallback,
   SchemaWithFallbackAsync,
 } from '../fallback/index.ts';
-import type { SchemaWithMaybeFallback } from './getFallback';
+import type { SchemaWithMaybeFallback } from './getFallback.ts';
 import type { SchemaWithMaybeFallbackAsync } from './getFallbackAsync.ts';
 
 /**


### PR DESCRIPTION
This PR fixes the Deno version of this library by preferring `*.ts` imports rather than relying on the more implicit Node module resolution algorithm.