### PR TITLE
Add `@gcornut/valibot-json-schema` to ecosystem

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -36,7 +36,7 @@ Use the button at the bottom left of this page to add your project to this ecosy
 ### Valibot to X
 
 - [TypeSchema](https://typeschema.com/): Universal adapter for schema validation
-- [@gcornut/valibot-json-schema](https://github.com/gcornut/valibot-json-schema): CLI & JS utility to convert valibot to JSON schema
+- [@gcornut/valibot-json-schema](https://github.com/gcornut/valibot-json-schema): CLI & JS utility to convert Valibot to JSON schema
 
 ### X to Valibot
 

--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -36,6 +36,7 @@ Use the button at the bottom left of this page to add your project to this ecosy
 ### Valibot to X
 
 - [TypeSchema](https://typeschema.com/): Universal adapter for schema validation
+- [@gcornut/valibot-json-schema](https://github.com/gcornut/valibot-json-schema): CLI & JS utility to convert valibot to JSON schema
 
 ### X to Valibot
 


### PR DESCRIPTION

Thanks to the last release and the better reflection API https://github.com/fabian-hiller/valibot/pull/211 I've been able to develop a pretty complete valibot to JSON schema CLI & JS library https://github.com/gcornut/valibot-json-schema/

