### PR TITLE
Add new issue reason for non-matching variant key

### DIFF
--- a/library/src/schemas/variant/variant.test.ts
+++ b/library/src/schemas/variant/variant.test.ts
@@ -96,7 +96,7 @@ describe('variant', () => {
             input: { type: 'c', val: false },
           },
         ],
-        requirement: ['a', 'b'],
+        requirement: schema.options,
       },
     ]);
 
@@ -110,7 +110,7 @@ describe('variant', () => {
         input: undefined,
         origin: 'value',
         path: [{ type: 'object', key: 'type', value: undefined, input: {} }],
-        requirement: ['a', 'b'],
+        requirement: schema.options,
       },
     ]);
   });

--- a/library/src/schemas/variant/variant.ts
+++ b/library/src/schemas/variant/variant.ts
@@ -6,15 +6,13 @@ import type {
   Output,
 } from '../../types/index.ts';
 import { getSchemaIssues, getOutput, getIssues } from '../../utils/index.ts';
-import type { Literal } from '../literal/index.ts';
-import type { LiteralSchema } from '../literal/literal.ts';
 import type { ObjectPathItem, ObjectSchema } from '../object/index.ts';
 
 /**
  * Variant option type.
  */
 export type VariantOption<TKey extends string> =
-  | ObjectSchema<Record<TKey, LiteralSchema<Literal>>, any>
+  | ObjectSchema<Record<TKey, BaseSchema>, any>
   | (BaseSchema & {
       type: 'variant';
       options: VariantOptions<TKey>;
@@ -87,7 +85,6 @@ export function variant<
       // Create issues and output
       let issues: Issues | undefined;
       let output: [Record<string, any>] | undefined;
-      const requirement: Literal[] = [];
 
       // Create function to parse options recursively
       const parseOptions = (options: VariantOptions<TKey>) => {
@@ -95,9 +92,6 @@ export function variant<
           // If it is an object schema, parse discriminator key
           if (schema.type === 'object') {
             const variantKeySchema = schema.entries[this.key];
-
-            requirement.push(variantKeySchema.literal);
-
             const result = variantKeySchema._parse(
               (input as Record<TKey, unknown>)[this.key],
               info
@@ -163,7 +157,7 @@ export function variant<
         'Invalid variant key',
         inputRecord[this.key],
         undefined,
-        requirement
+        this.options
       );
       nonMatchingKeyIssues.issues[0].path = [pathItem];
       return nonMatchingKeyIssues;

--- a/library/src/schemas/variant/variantAsync.test.ts
+++ b/library/src/schemas/variant/variantAsync.test.ts
@@ -101,7 +101,7 @@ describe('variantAsync', () => {
             input: { type: 'c', val: false },
           },
         ],
-        requirement: ['a', 'b'],
+        requirement: schema.options,
       },
     ]);
 
@@ -118,7 +118,7 @@ describe('variantAsync', () => {
         input: undefined,
         origin: 'value',
         path: [{ type: 'object', key: 'type', value: undefined, input: {} }],
-        requirement: ['a', 'b'],
+        requirement: schema.options,
       },
     ]);
   });

--- a/library/src/types/issues.ts
+++ b/library/src/types/issues.ts
@@ -30,7 +30,8 @@ export type IssueReason =
   | 'tuple'
   | 'undefined'
   | 'unknown'
-  | 'type';
+  | 'type'
+  | 'invalid_variant_key';
 
 /**
  * Issue origin type.

--- a/library/src/utils/getSchemaIssues/getSchemaIssues.ts
+++ b/library/src/utils/getSchemaIssues/getSchemaIssues.ts
@@ -15,6 +15,7 @@ import { getErrorMessage } from '../getErrorMessage/getErrorMessage.ts';
  * @param message The error message.
  * @param input The input value.
  * @param issues The sub issues.
+ * @param requirement The requirement.
  *
  * @returns The schema result object.
  */
@@ -24,7 +25,8 @@ export function getSchemaIssues(
   validation: string,
   message: ErrorMessage,
   input: unknown,
-  issues?: Issues
+  issues?: Issues,
+  requirement?: unknown
 ): { issues: Issues } {
   // Note: The issue is deliberately not constructed with the spread operator
   // for performance reasons
@@ -40,6 +42,7 @@ export function getSchemaIssues(
         abortEarly: info?.abortEarly,
         abortPipeEarly: info?.abortPipeEarly,
         skipPipe: info?.skipPipe,
+        requirement,
       },
     ],
   };


### PR DESCRIPTION
Fixes #235.

This is a breaking change because with this change only literal schemas are allowed for the discriminator.