### PR TITLE
docs(ecosystem): add mantine-form-valibot-resolver to ecosystem

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -12,6 +12,7 @@ contributors:
   - ZerNico
   - decs
   - logaretm
+  - Songkeys
 ---
 
 # Ecosystem
@@ -34,6 +35,7 @@ Use the button at the bottom left of this page to add your project to this ecosy
 
 ### Form libraries
 
+- [mantine-form-valibot-resolver](https://github.com/Songkeys/mantine-form-valibot-resolver): Valibot schema resolver for [@mantine/form](https://mantine.dev/form/use-form/)
 - [Modular Forms](https://modularforms.dev/): Modular and type-safe form library for SolidJS, Qwik, Preact and React
 - [React Hook Form](https://react-hook-form.com/): React Hooks for form state management and validation
 - [TanStack Form](https://tanstack.com/form): Powerful and type-safe form state management for the web


### PR DESCRIPTION
[`mantine-form-valibot-resolver`](https://github.com/Songkeys/mantine-form-valibot-resolver) is published to bring [`valibot`](https://github.com/fabian-hiller/valibot) to `@mantine/form`.

related: https://github.com/mantinedev/mantine/pull/5416