### PR TITLE
docs(api): add and fill symbol schema docs

### DIFF
--- a/website/src/routes/api/(schemas)/symbol/index.mdx
+++ b/website/src/routes/api/(schemas)/symbol/index.mdx
@@ -2,8 +2,88 @@
 title: symbol
 contributors:
   - fabian-hiller
+  - wout-junius
 ---
+
+import { ApiList, Property } from '~/components';
 
 # symbol
 
-> The content of this page is not yet ready. Until then just use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/schemas/symbol/symbol.ts).
+Creates a symbol schema.
+
+```ts
+// Symbol schema with an optional message
+const Schema = symbol(message);
+```
+
+## Parameters
+
+- `message` <Property {...properties.message} />
+
+### Explanation
+
+With `symbol` you can validate the data type of the input and with `pipe` you can transform and validate the further details of the bigint. If the input is not a symbol, you can use `message` to customize the error message.
+
+## Returns
+
+- `Schema` <Property {...properties.Schema} />
+
+## Examples
+
+The following examples show how `symbol` can be used.
+
+### Make a Symbol Schema whit custom error message
+
+```ts
+const schema = symbol('This is not a symbol');
+```
+
+### 
+
+## Related
+
+The following APIs can be combined with `symbol`.
+
+### Methods
+
+<ApiList
+  items={[
+    'brand',
+    'coerce',
+    'fallback',
+    'getDefault',
+    'getDefaults',
+    'getFallback',
+    'getFallbacks',
+    'is',
+    'parse',
+    'safeParse',
+    'transform',
+  ]}
+/>
+
+export const properties = {
+  message: {
+    type: [
+      {
+        type: 'custom',
+        name: 'ErrorMessage',
+        href: '../ErrorMessage/',
+      },
+      'undefined',
+    ],
+    default: {
+      type: 'string',
+      value: 'Invalid type',
+    },
+  },
+  Schema: {
+    type: [
+      {
+        type: 'custom',
+        name: 'SymbolSchema',
+        href: '../SymbolSchema/',
+      },
+    ],
+  },
+};

--- a/website/src/routes/api/(schemas)/symbol/index.mdx
+++ b/website/src/routes/api/(schemas)/symbol/index.mdx
@@ -1,8 +1,9 @@
 ---
 title: symbol
+description: Creates a symbol schema.
 contributors:
-  - fabian-hiller
   - wout-junius
+  - fabian-hiller
 ---
 
 import { ApiList, Property } from '~/components';
@@ -22,7 +23,7 @@ const Schema = symbol(message);
 
 ### Explanation
 
-With `symbol` you can validate the data type of the input and with `pipe` you can transform and validate the further details of the bigint. If the input is not a symbol, you can use `message` to customize the error message.
+With `symbol` you can validate the data type of the input. If it is not a symbol, you can use `message` to customize the error message.
 
 ## Returns
 
@@ -32,13 +33,13 @@ With `symbol` you can validate the data type of the input and with `pipe` you ca
 
 The following examples show how `symbol` can be used.
 
-### Make a Symbol Schema whit custom error message
+### Custom message
+
+Symbol schema with a custom error message.
 
 ```ts
-const schema = symbol('This is not a symbol');
+const schema = symbol('A symbol is required');
 ```
-
-### 
 
 ## Related
 

--- a/website/src/routes/api/(types)/SymbolSchema/index.mdx
+++ b/website/src/routes/api/(types)/SymbolSchema/index.mdx
@@ -1,0 +1,66 @@
+---
+title: SymbolSchema
+description: String schema type.
+contributors:
+  - wout-junius
+---
+
+import { Property } from '~/components';
+
+# SymbolSchema
+
+String schema type.
+
+## Definition
+
+- `SymbolSchema` <Property {...properties.BaseSchema} />
+  - `type` <Property {...properties.type} />
+  - `message` <Property {...properties.message} />
+  - `pipe` <Property {...properties.pipe} />
+
+export const properties = {
+  BaseSchema: {
+    type: [
+      {
+        type: 'custom',
+        name: 'BaseSchema',
+        href: '../BaseSchema/',
+        generics: [
+          'symbol',
+          {
+            type: 'custom',
+            name: 'TOutput',
+            default: 'string',
+          },
+        ],
+      },
+    ],
+  },
+  type: {
+    type: {
+      type: 'string',
+      value: 'symbol',
+    },
+  },
+  message: {
+    type: {
+      type: 'custom',
+      name: 'ErrorMessage',
+      href: '../ErrorMessage/',
+    },
+  },
+  pipe: {
+    type: [
+      {
+        type: 'custom',
+        name: 'Pipe',
+        href: '../Pipe/',
+        generics: [{
+            type: 'custom',
+            name: 'Symbol',
+        }],
+      },
+      'undefined',
+    ],
+  },
+};

--- a/website/src/routes/api/(types)/SymbolSchema/index.mdx
+++ b/website/src/routes/api/(types)/SymbolSchema/index.mdx
@@ -1,15 +1,16 @@
 ---
 title: SymbolSchema
-description: String schema type.
+description: Symbol schema type.
 contributors:
   - wout-junius
+  - fabian-hiller
 ---
 
 import { Property } from '~/components';
 
 # SymbolSchema
 
-String schema type.
+Symbol schema type.
 
 ## Definition
 
@@ -30,7 +31,7 @@ export const properties = {
           {
             type: 'custom',
             name: 'TOutput',
-            default: 'string',
+            default: 'symbol',
           },
         ],
       },
@@ -55,10 +56,7 @@ export const properties = {
         type: 'custom',
         name: 'Pipe',
         href: '../Pipe/',
-        generics: [{
-            type: 'custom',
-            name: 'Symbol',
-        }],
+        generics: ['symbol'],
       },
       'undefined',
     ],

--- a/website/src/routes/api/menu.md
+++ b/website/src/routes/api/menu.md
@@ -212,6 +212,7 @@
 - [SchemaResult](/api/SchemaResult/)
 - [SetPathItem](/api/SetPathItem/)
 - [StringSchema](/api/StringSchema/)
+- [SymbolSchema](/api/SymbolSchema/)
 - [TuplePathItem](/api/TuplePathItem/)
 - [TypedSchemaResult](/api/TypedSchemaResult/)
 - [UnknownPathItem](/api/UnknownPathItem/)


### PR DESCRIPTION
Implementing symbol schema docs as discussed in https://github.com/fabian-hiller/valibot/issues/287