### PR TITLE
docs(api): Nullable related docs

### DIFF
--- a/website/src/routes/api/(schemas)/nullable/index.mdx
+++ b/website/src/routes/api/(schemas)/nullable/index.mdx
@@ -50,14 +50,14 @@ Schema that accepts `string` and `null`.
 const NullableStringSchema = nullable(string(), "I'm the default!");
 ```
 
-### Nullable URL schema
+### Nullable date schema
 
-Schema that accepts an URL and `null`.
+Schema that accepts `Date` and `null`.
 
-> By using a function as the `default_` parameter, the schema will return a new URL string each time the input is `undefined`.
+> By using a function as the `default_` parameter, the schema will return a new `Date` instance each time the input is `null`.
 
 ```ts
-const NullableUrlSchema = nullable(string([url()]), () => generateUrl());
+const NullableDateSchema = nullable(date(), () => new Date());
 ```
 
 ### Nullable entry schema

--- a/website/src/routes/api/(schemas)/nullable/index.mdx
+++ b/website/src/routes/api/(schemas)/nullable/index.mdx
@@ -1,9 +1,145 @@
 ---
 title: nullable
+description: Creates a nullable schema.
 contributors:
   - fabian-hiller
+  - sqmasep
 ---
+
+import { Link } from '@builder.io/qwik-city';
+import { ApiList, Property } from '~/components';
+import { properties } from './properties';
 
 # nullable
 
-> The content of this page is not yet ready. Until then just use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/schemas/nullable/nullable.ts).
+Creates a nullable schema.
+
+```ts
+const Schema = nullable<TWrapped, TDefault>(wrapped, default_);
+```
+
+## Generics
+
+- `TWrapped` <Property {...properties.TWrapped} />
+- `TDefault` <Property {...properties.TDefault} />
+
+## Parameters
+
+- `wrapped` <Property {...properties.wrapped} />
+- `default_` {/* prettier-ignore */}<Property {...properties.default_}/>
+
+### Explanation
+
+With `nullable` the validation of your schema will pass `null` inputs, and if you specify a `default_` value, the schema will use it if the input is `null`.
+
+> Note that `nullable` does not accept `undefined` as an input. If you want to accept `undefined` inputs, use <Link href="../optional/">`optional`</Link>, and if you want to accept `null` and `undefined` inputs, use <Link href="../nullish/">`nullish`</Link> instead. Also, if you want to set a default value for any invalid input, you should use <Link href="../fallback/">`fallback`</Link> instead.
+
+## Returns
+
+- `Schema` <Property {...properties.Schema} />
+
+## Examples
+
+The following examples show how `nullable` can be used.
+
+### Nullable string schema
+
+Schema that accepts `string` and `null`.
+
+```ts
+const NullableStringSchema = nullable(string(), "I'm the default!");
+```
+
+### Nullable URL schema
+
+Schema that accepts an URL and `null`.
+
+> By using a function as the `default_` parameter, the schema will return a new URL string each time the input is `undefined`.
+
+```ts
+const NullableUrlSchema = nullable(string([url()]), () => generateUrl());
+```
+
+### Nullable entry schema
+
+Object schema with a nullable entry.
+
+```ts
+const NullableEntrySchema = object({
+  key: nullable(string()),
+});
+```
+
+### Unwrap nullable schema
+
+Use <Link href="../unwrap/">`unwrap`</Link> to undo the effect of `nullable`.
+
+```ts
+const NullableNumberSchema = nullable(number());
+const NumberSchema = unwrap(NullableNumberSchema);
+```
+
+## Related
+
+The following APIs can be combined with `nullable`.
+
+### Methods
+
+<ApiList
+  items={[
+    'brand',
+    'coerce',
+    'fallback',
+    'getDefault',
+    'getDefaults',
+    'getFallback',
+    'getFallbacks',
+    'is',
+    'parse',
+    'safeParse',
+    'transform',
+    'unwrap',
+  ]}
+/>
+
+### Schemas
+
+<ApiList
+  items={[
+    'any',
+    'array',
+    'bigint',
+    'blob',
+    'boolean',
+    'date',
+    'enum_',
+    'instance',
+    'intersect',
+    'literal',
+    'map',
+    'nan',
+    'never',
+    'nonNullable',
+    'nonNullish',
+    'nonOptional',
+    'null_',
+    'nullable',
+    'nullish',
+    'number',
+    'object',
+    'optional',
+    'picklist',
+    'record',
+    'recursive',
+    'set',
+    'special',
+    'string',
+    'symbol',
+    'tuple',
+    'undefined_',
+    'union',
+    'unknown',
+    'variant',
+    'void_',
+  ]}
+/>

--- a/website/src/routes/api/(schemas)/nullable/properties.ts
+++ b/website/src/routes/api/(schemas)/nullable/properties.ts
@@ -1,0 +1,70 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TWrapped: {
+    type: {
+      type: 'custom',
+      name: 'BaseSchema',
+      href: '../BaseSchema/',
+    },
+  },
+  TDefault: {
+    type: [
+      {
+        type: 'custom',
+        name: 'Input',
+        href: '../Input/',
+        generics: [
+          {
+            type: 'custom',
+            name: 'TWrapped',
+          },
+        ],
+      },
+      {
+        type: 'function',
+        params: [],
+        return: [
+          {
+            type: 'custom',
+            name: 'Input',
+            href: '../Input/',
+            generics: [
+              {
+                type: 'custom',
+                name: 'TWrapped',
+              },
+            ],
+          },
+          'undefined',
+        ],
+      },
+      'undefined',
+    ],
+  },
+  wrapped: {
+    type: [
+      {
+        type: 'custom',
+        name: 'TWrapped',
+      },
+    ],
+  },
+  default_: {
+    type: [
+      {
+        type: 'custom',
+        name: 'TDefault',
+      },
+    ],
+  },
+  Schema: {
+    type: [
+      {
+        type: 'custom',
+        name: 'NullableSchema',
+        href: '../NullableSchema/',
+      },
+    ],
+  },
+};

--- a/website/src/routes/api/(types)/NullableSchema/index.mdx
+++ b/website/src/routes/api/(types)/NullableSchema/index.mdx
@@ -1,0 +1,21 @@
+---
+title: NullableSchema
+description: Nullable schema type.
+contributors:
+  - fabian-hiller
+  - sqmasep
+---
+
+import { Property } from '~/components';
+import { properties } from './properties';
+
+# NullableSchema
+
+Nullable schema type.
+
+## Definition
+
+- `NullableSchema` <Property {...properties.BaseSchema} />
+  - `type` <Property {...properties.type} />
+  - `wrapped` <Property {...properties.wrapped} />
+  - `default` <Property {...properties.default} />

--- a/website/src/routes/api/(types)/NullableSchema/properties.ts
+++ b/website/src/routes/api/(types)/NullableSchema/properties.ts
@@ -1,0 +1,65 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  BaseSchema: {
+    type: [
+      {
+        type: 'custom',
+        name: 'BaseSchema',
+        href: '../BaseSchema/',
+        generics: [
+          [
+            {
+              type: 'custom',
+              name: 'Input',
+              href: '../Input/',
+              generics: [
+                {
+                  type: 'custom',
+                  name: 'TWrapped',
+                },
+              ],
+            },
+            'undefined',
+          ],
+          {
+            type: 'custom',
+            name: 'TOutput',
+            default: [
+              {
+                type: 'custom',
+                name: 'Output',
+                href: '../Output/',
+                generics: [
+                  {
+                    type: 'custom',
+                    name: 'TWrapped',
+                  },
+                ],
+              },
+              'undefined',
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  type: {
+    type: {
+      type: 'string',
+      value: 'nullable',
+    },
+  },
+  wrapped: {
+    type: {
+      type: 'custom',
+      name: 'TWrapped',
+    },
+  },
+  default: {
+    type: {
+      type: 'custom',
+      name: 'TDefault',
+    },
+  },
+};

--- a/website/src/routes/api/menu.md
+++ b/website/src/routes/api/menu.md
@@ -209,6 +209,7 @@
 - [Issues](/api/Issues/)
 - [MapPathItem](/api/MapPathItem/)
 - [MaybeReadonly](/api/MaybeReadonly/)
+- [NullableSchema](/api/NullableSchema/)
 - [ObjectPathItem](/api/ObjectPathItem/)
 - [OptionalSchema](/api/OptionalSchema/)
 - [Output](/api/Output/)


### PR DESCRIPTION
Hi! As mentioned in #287, here is the nullable docs (which is basically a copy-paste of `optional`), with the same examples as we discussed on discord

Added:
- `api/(types)/NullableSchema`: `NullableSchema` type definition

Edited:
- `api/(schemas)/nullable`: `nullable` usage & examples
- `api/menu.md`: Added `NullableSchema` in the types section