### PR TITLE
docs(api): Nullish related docs

### DIFF
--- a/website/src/routes/api/(schemas)/nullish/index.mdx
+++ b/website/src/routes/api/(schemas)/nullish/index.mdx
@@ -1,9 +1,145 @@
 ---
 title: nullish
+description: Creates a nullish schema.
 contributors:
   - fabian-hiller
+  - sqmasep
 ---
+
+import { Link } from '@builder.io/qwik-city';
+import { ApiList, Property } from '~/components';
+import { properties } from './properties';
 
 # nullish
 
-> The content of this page is not yet ready. Until then just use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/schemas/nullish/nullish.ts).
+Creates a nullish schema.
+
+```ts
+const Schema = nullish<TWrapped, TDefault>(wrapped, default_);
+```
+
+## Generics
+
+- `TWrapped` <Property {...properties.TWrapped} />
+- `TDefault` <Property {...properties.TDefault} />
+
+## Parameters
+
+- `wrapped` <Property {...properties.wrapped} />
+- `default_` {/* prettier-ignore */}<Property {...properties.default_}/>
+
+### Explanation
+
+With `nullish` the validation of your schema will pass `undefined` and `null` inputs, and if you specify a `default_` value, the schema will use it if the input is `undefined` or `null`.
+
+> Note that `nullish` accepts `undefined` and `null` as an input. If you want to accept only `null` inputs, use <Link href="../nullable/">`nullable`</Link>, and if you want to accept only `undefined` inputs, use <Link href="../optional/">`optional`</Link> instead. Also, if you want to set a default value for any invalid input, you should use <Link href="../fallback/">`fallback`</Link> instead.
+
+## Returns
+
+- `Schema` <Property {...properties.Schema} />
+
+## Examples
+
+The following examples show how `nullish` can be used.
+
+### Nullish string schema
+
+Schema that accepts `string`, `undefined` and `null`.
+
+```ts
+const NullishStringSchema = nullish(string(), "I'm the default!");
+```
+
+### Nullish date schema
+
+Schema that accepts `Date`, `undefined` and `null`.
+
+> By using a function as the `default_` parameter, the schema will return a new `Date` instance each time the input is `undefined` or `null`.
+
+```ts
+const NullishDateSchema = nullish(date(), () => new Date());
+```
+
+### Nullish entry schema
+
+Object schema with a nullish entry.
+
+```ts
+const NullishEntrySchema = object({
+  key: nullish(string()),
+});
+```
+
+### Unwrap nullish schema
+
+Use <Link href="../unwrap/">`unwrap`</Link> to undo the effect of `nullish`.
+
+```ts
+const NullishNumberSchema = nullish(number());
+const NumberSchema = unwrap(NullishNumberSchema);
+```
+
+## Related
+
+The following APIs can be combined with `nullish`.
+
+### Methods
+
+<ApiList
+  items={[
+    'brand',
+    'coerce',
+    'fallback',
+    'getDefault',
+    'getDefaults',
+    'getFallback',
+    'getFallbacks',
+    'is',
+    'parse',
+    'safeParse',
+    'transform',
+    'unwrap',
+  ]}
+/>
+
+### Schemas
+
+<ApiList
+  items={[
+    'any',
+    'array',
+    'bigint',
+    'blob',
+    'boolean',
+    'date',
+    'enum_',
+    'instance',
+    'intersect',
+    'literal',
+    'map',
+    'nan',
+    'never',
+    'nonNullable',
+    'nonNullish',
+    'nonOptional',
+    'null_',
+    'nullable',
+    'nullish',
+    'number',
+    'object',
+    'optional',
+    'picklist',
+    'record',
+    'recursive',
+    'set',
+    'special',
+    'string',
+    'symbol',
+    'tuple',
+    'undefined_',
+    'union',
+    'unknown',
+    'variant',
+    'void_',
+  ]}
+/>

--- a/website/src/routes/api/(schemas)/nullish/properties.ts
+++ b/website/src/routes/api/(schemas)/nullish/properties.ts
@@ -1,0 +1,70 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TWrapped: {
+    type: {
+      type: 'custom',
+      name: 'BaseSchema',
+      href: '../BaseSchema/',
+    },
+  },
+  TDefault: {
+    type: [
+      {
+        type: 'custom',
+        name: 'Input',
+        href: '../Input/',
+        generics: [
+          {
+            type: 'custom',
+            name: 'TWrapped',
+          },
+        ],
+      },
+      {
+        type: 'function',
+        params: [],
+        return: [
+          {
+            type: 'custom',
+            name: 'Input',
+            href: '../Input/',
+            generics: [
+              {
+                type: 'custom',
+                name: 'TWrapped',
+              },
+            ],
+          },
+          'undefined',
+        ],
+      },
+      'undefined',
+    ],
+  },
+  wrapped: {
+    type: [
+      {
+        type: 'custom',
+        name: 'TWrapped',
+      },
+    ],
+  },
+  default_: {
+    type: [
+      {
+        type: 'custom',
+        name: 'TDefault',
+      },
+    ],
+  },
+  Schema: {
+    type: [
+      {
+        type: 'custom',
+        name: 'NullishSchema',
+        href: '../NullishSchema/',
+      },
+    ],
+  },
+};

--- a/website/src/routes/api/(types)/NullishSchema/index.mdx
+++ b/website/src/routes/api/(types)/NullishSchema/index.mdx
@@ -1,0 +1,21 @@
+---
+title: NullishSchema
+description: Nullish schema type.
+contributors:
+  - fabian-hiller
+  - sqmasep
+---
+
+import { Property } from '~/components';
+import { properties } from './properties';
+
+# NullishSchema
+
+Nullish schema type.
+
+## Definition
+
+- `Nullish` <Property {...properties.BaseSchema} />
+  - `type` <Property {...properties.type} />
+  - `wrapped` <Property {...properties.wrapped} />
+  - `default` <Property {...properties.default} />

--- a/website/src/routes/api/(types)/NullishSchema/properties.ts
+++ b/website/src/routes/api/(types)/NullishSchema/properties.ts
@@ -20,6 +20,7 @@ export const properties: Record<string, PropertyProps> = {
                 },
               ],
             },
+            'null',
             'undefined',
           ],
           {
@@ -37,6 +38,7 @@ export const properties: Record<string, PropertyProps> = {
                   },
                 ],
               },
+              'null',
               'undefined',
             ],
           },

--- a/website/src/routes/api/(types)/NullishSchema/properties.ts
+++ b/website/src/routes/api/(types)/NullishSchema/properties.ts
@@ -1,0 +1,65 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  BaseSchema: {
+    type: [
+      {
+        type: 'custom',
+        name: 'BaseSchema',
+        href: '../BaseSchema/',
+        generics: [
+          [
+            {
+              type: 'custom',
+              name: 'Input',
+              href: '../Input/',
+              generics: [
+                {
+                  type: 'custom',
+                  name: 'TWrapped',
+                },
+              ],
+            },
+            'undefined',
+          ],
+          {
+            type: 'custom',
+            name: 'TOutput',
+            default: [
+              {
+                type: 'custom',
+                name: 'Output',
+                href: '../Output/',
+                generics: [
+                  {
+                    type: 'custom',
+                    name: 'TWrapped',
+                  },
+                ],
+              },
+              'undefined',
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  type: {
+    type: {
+      type: 'string',
+      value: 'nullish',
+    },
+  },
+  wrapped: {
+    type: {
+      type: 'custom',
+      name: 'TWrapped',
+    },
+  },
+  default: {
+    type: {
+      type: 'custom',
+      name: 'TDefault',
+    },
+  },
+};

--- a/website/src/routes/api/menu.md
+++ b/website/src/routes/api/menu.md
@@ -209,6 +209,7 @@
 - [Issues](/api/Issues/)
 - [MapPathItem](/api/MapPathItem/)
 - [MaybeReadonly](/api/MaybeReadonly/)
+- [NullishSchema](/api/NullishSchema/)
 - [ObjectPathItem](/api/ObjectPathItem/)
 - [OptionalSchema](/api/OptionalSchema/)
 - [Output](/api/Output/)


### PR DESCRIPTION
Hi (again)! As mentioned in #287, here is the nullish docs (which is basically a copy-paste of `optional`), with the same examples as we discussed on discord

Added:
- `api/(types)/NullishSchema`: `NullishSchema` type definition

Edited:
- `api/(schemas)/nullish`: `nullish` usage & examples
- `api/menu.md`: Added `NullishSchema` in the types section