### PR TITLE
test: Add PoC for typescript version integration test

### DIFF
--- a/library/tests/integration.test.ts
+++ b/library/tests/integration.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+describe('Integration', () => {
+  test.each([
+    ['4.9.5', false],
+    ['5.0.2', true],
+  ])(
+    'with TypeScript version %s should work: %s',
+    async (tsVersion, expectSuccess) => {
+      const npx = spawnSync('npx', [
+        '--yes',
+        '--package',
+        `typescript@${tsVersion}`,
+        'tsc',
+        '--noEmit',
+        '--target',
+        'ES6',
+        join(__dirname, 'testscript.ts'),
+      ]);
+
+      const npxOutput = npx.output.toString();
+      const containsError = npxOutput.includes('error TS');
+      if (expectSuccess) {
+        expect(containsError).toBeFalsy();
+      } else {
+        expect(containsError).toBeTruthy();
+      }
+    }
+  );
+});

--- a/library/tests/integration.test.ts
+++ b/library/tests/integration.test.ts
@@ -2,31 +2,31 @@ import { describe, expect, test } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 describe('Integration', () => {
-	test.each([
-		['4.9.5', false],
-		['5.0.2', true],
-	])(
-		'with TypeScript version %s should work: %s',
-		(tsVersion, expectSuccess) => {
-			const npx = spawnSync('pnpm', [
-				'--package',
-				`typescript@${tsVersion}`,
-				'--silent',
-				'dlx',
-				'tsc',
-				'--noEmit',
-				'--target',
-				'ES6',
-				join(__dirname, 'testscript.ts'),
-			]);
+  test.each([
+    ['4.9.5', false],
+    ['5.0.2', true],
+  ])(
+    'with TypeScript version %s should work: %s',
+    (tsVersion, expectSuccess) => {
+      const npx = spawnSync('pnpm', [
+        '--package',
+        `typescript@${tsVersion}`,
+        '--silent',
+        'dlx',
+        'tsc',
+        '--noEmit',
+        '--target',
+        'ES6',
+        join(__dirname, 'testscript.ts'),
+      ]);
 
-			const npxOutput = npx.output.toString();
-			const containsError = npxOutput.includes('error TS');
-			if (expectSuccess) {
-				expect(containsError).toBeFalsy();
-			} else {
-				expect(containsError).toBeTruthy();
-			}
-		}
-	);
+      const npxOutput = npx.output.toString();
+      const containsError = npxOutput.includes('error TS');
+      if (expectSuccess) {
+        expect(containsError).toBeFalsy();
+      } else {
+        expect(containsError).toBeTruthy();
+      }
+    }
+  );
 });

--- a/library/tests/integration.test.ts
+++ b/library/tests/integration.test.ts
@@ -2,30 +2,31 @@ import { describe, expect, test } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 describe('Integration', () => {
-  test.each([
-    ['4.9.5', false],
-    ['5.0.2', true],
-  ])(
-    'with TypeScript version %s should work: %s',
-    async (tsVersion, expectSuccess) => {
-      const npx = spawnSync('npx', [
-        '--yes',
-        '--package',
-        `typescript@${tsVersion}`,
-        'tsc',
-        '--noEmit',
-        '--target',
-        'ES6',
-        join(__dirname, 'testscript.ts'),
-      ]);
+	test.each([
+		['4.9.5', false],
+		['5.0.2', true],
+	])(
+		'with TypeScript version %s should work: %s',
+		(tsVersion, expectSuccess) => {
+			const npx = spawnSync('pnpm', [
+				'--package',
+				`typescript@${tsVersion}`,
+				'--silent',
+				'dlx',
+				'tsc',
+				'--noEmit',
+				'--target',
+				'ES6',
+				join(__dirname, 'testscript.ts'),
+			]);
 
-      const npxOutput = npx.output.toString();
-      const containsError = npxOutput.includes('error TS');
-      if (expectSuccess) {
-        expect(containsError).toBeFalsy();
-      } else {
-        expect(containsError).toBeTruthy();
-      }
-    }
-  );
+			const npxOutput = npx.output.toString();
+			const containsError = npxOutput.includes('error TS');
+			if (expectSuccess) {
+				expect(containsError).toBeFalsy();
+			} else {
+				expect(containsError).toBeTruthy();
+			}
+		}
+	);
 });

--- a/library/tests/testscript.ts
+++ b/library/tests/testscript.ts
@@ -1,0 +1,1 @@
+import * as v from '../dist/index.js';


### PR DESCRIPTION
Addresses #351 

I included 4.9.5 to show the cutoff version.

I would suggest to exclude this version test from regular test runs and instead only run it periodically (say, once a day) in CI.