### PR TITLE
doc(api): add `unknown()` related doc

### DIFF
--- a/website/src/routes/api/(schemas)/any/index.mdx
+++ b/website/src/routes/api/(schemas)/any/index.mdx
@@ -32,6 +32,8 @@ const Schema = any(pipe);
 
 The following APIs can be combined with `any`.
 
+### Schemas
+
 <ApiList
   items={[
     'array',

--- a/website/src/routes/api/(schemas)/bigint/index.mdx
+++ b/website/src/routes/api/(schemas)/bigint/index.mdx
@@ -58,6 +58,8 @@ const MaxBigintSchema = bigint([maxValue(999n)]);
 
 The following APIs can be combined with `bigint`.
 
+### Schemas
+
 <ApiList
   items={[
     'array',

--- a/website/src/routes/api/(schemas)/blob/index.mdx
+++ b/website/src/routes/api/(schemas)/blob/index.mdx
@@ -53,6 +53,8 @@ const ImageSchema = blob('Please select an image file.', [
 
 The following APIs can be combined with `blob`.
 
+### Schemas
+
 <ApiList
   items={[
     'array',

--- a/website/src/routes/api/(schemas)/boolean/index.mdx
+++ b/website/src/routes/api/(schemas)/boolean/index.mdx
@@ -54,6 +54,8 @@ const BooleanSchema = boolean('A boolean is required');
 
 The following APIs can be combined with `boolean`.
 
+### Schemas
+
 <ApiList
   items={[
     'array',

--- a/website/src/routes/api/(schemas)/date/index.mdx
+++ b/website/src/routes/api/(schemas)/date/index.mdx
@@ -62,6 +62,8 @@ const DateRangeSchema = date([
 
 The following APIs can be combined with `date`.
 
+### Schemas
+
 <ApiList
   items={[
     'array',

--- a/website/src/routes/api/(schemas)/enum_/index.mdx
+++ b/website/src/routes/api/(schemas)/enum_/index.mdx
@@ -55,6 +55,8 @@ const DirectionSchema = enum_(Direction, 'Invalid direction');
 
 The following APIs can be combined with `enum_`.
 
+### Schemas
+
 <ApiList
   items={[
     'array',

--- a/website/src/routes/api/(schemas)/instance/index.mdx
+++ b/website/src/routes/api/(schemas)/instance/index.mdx
@@ -66,6 +66,8 @@ const FileSchema = instance(File, [
 
 The following APIs can be combined with `instance`.
 
+### Schemas
+
 <ApiList
   items={[
     'array',

--- a/website/src/routes/api/(schemas)/picklist/index.mdx
+++ b/website/src/routes/api/(schemas)/picklist/index.mdx
@@ -71,6 +71,8 @@ const CountrySchema = picklist(
 
 The following APIs can be combined with `enum_`.
 
+### Schemas
+
 <ApiList
   items={[
     'array',

--- a/website/src/routes/api/(schemas)/string/index.mdx
+++ b/website/src/routes/api/(schemas)/string/index.mdx
@@ -79,6 +79,8 @@ const UrlSchema = string('A URL must be string.', [
 
 The following APIs can be combined with `string`.
 
+### Schemas
+
 <ApiList
   items={[
     'array',

--- a/website/src/routes/api/(schemas)/symbol/index.mdx
+++ b/website/src/routes/api/(schemas)/symbol/index.mdx
@@ -47,6 +47,8 @@ const schema = symbol('A symbol is required');
 
 The following APIs can be combined with `symbol`.
 
+### Schemas
+
 <ApiList
   items={[
     'array',

--- a/website/src/routes/api/(schemas)/unknown/index.mdx
+++ b/website/src/routes/api/(schemas)/unknown/index.mdx
@@ -1,10 +1,81 @@
 ---
 title: unknown
+description: Creates a unknown schema.
 source: /schemas/unknown/unknown.ts
 contributors:
   - fabian-hiller
+  - mwskwong
 ---
+
+import { Link } from '@builder.io/qwik-city';
+import { ApiList, Property } from '~/components';
+import { properties } from './properties';
 
 # unknown
 
-> The content of this page is not yet ready. Until then, please use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/schemas/unknown/unknown.ts) or take a look at [issue #287](https://github.com/fabian-hiller/valibot/issues/287) to help us extend the API reference.
+Creates a unknown schema.
+
+```ts
+// Unknown schema with an optional pipe
+const Schema = unknown(pipe);
+```
+
+## Parameters
+
+- `pipe` <Property {...properties.pipe} />
+
+### Explanation
+
+With `pipe` you can transform and validate the further details of the unknown data.
+
+> Warning: Usage of this function is typcially **discouraged** because it provides no validation logic. Only use it if the data is truely unknown beforehand.
+
+## Returns
+
+- `Schema` <Property {...properties.Schema} />
+
+## Related
+
+The following APIs can be combined with `unknwon`.
+
+<ApiList
+  items={[
+    'array',
+    'intersect',
+    'map',
+    'nonNullable',
+    'nonNullish',
+    'nonOptional',
+    'nullable',
+    'nullish',
+    'object',
+    'optional',
+    'record',
+    'recursive',
+    'set',
+    'tuple',
+    'union',
+  ]}
+/>
+
+### Methods
+
+<ApiList
+  items={[
+    'brand',
+    'coerce',
+    'fallback',
+    'getDefault',
+    'getDefaults',
+    'getFallback',
+    'getFallbacks',
+    'is',
+    'parse',
+    'safeParse',
+    'transform',
+  ]}
+/>
+
+### Transformations
+
+<ApiList items={['toCustom']} />

--- a/website/src/routes/api/(schemas)/unknown/index.mdx
+++ b/website/src/routes/api/(schemas)/unknown/index.mdx
@@ -1,25 +1,23 @@
 ---
 title: unknown
-description: Creates a unknown schema.
+description: Creates an unknown schema.
 source: /schemas/unknown/unknown.ts
 contributors:
   - fabian-hiller
   - mwskwong
 ---
 
-import { Link } from '@builder.io/qwik-city';
 import { ApiList, Property } from '~/components';
 import { properties } from './properties';
 
 # unknown
 
-Creates a unknown schema.
+Creates an unknown schema.
+
+> Use this schema function only if the data is truly unknown. Otherwise, use the other more specific schema functions that describe the data exactly.
 
 ```ts
-// Unknown schema with an optional pipe
 const Schema = unknown(pipe);
-// const UnknownOutput: unknown
-const UnknownOutput = Output<typeof Schema>;
 ```
 
 ## Parameters
@@ -30,8 +28,6 @@ const UnknownOutput = Output<typeof Schema>;
 
 With `pipe` you can transform and validate the further details of the unknown data.
 
-> Warning: Usage of this function is typcially **discouraged** because it provides no validation logic. Only use it if the data is truely unknown beforehand.
-
 ## Returns
 
 - `Schema` <Property {...properties.Schema} />
@@ -39,6 +35,8 @@ With `pipe` you can transform and validate the further details of the unknown da
 ## Related
 
 The following APIs can be combined with `unknwon`.
+
+### Schemas
 
 <ApiList
   items={[
@@ -80,4 +78,75 @@ The following APIs can be combined with `unknwon`.
 
 ### Transformations
 
-<ApiList items={['toCustom']} />
+<ApiList
+  items={[
+    'toCustom',
+    'toLowerCase',
+    'toMaxValue',
+    'toMinValue',
+    'toTrimmed',
+    'toTrimmedEnd',
+    'toTrimmedStart',
+    'toUpperCase',
+  ]}
+/>
+
+### Validations
+
+<ApiList
+  items={[
+    'bic',
+    'bytes',
+    'creditCard',
+    'cuid2',
+    'custom',
+    'decimal',
+    'email',
+    'emoji',
+    'endsWith',
+    'excludes',
+    'finite',
+    'hash',
+    'hexadecimal',
+    'hexColor',
+    'imei',
+    'includes',
+    'integer',
+    'ip',
+    'ipv4',
+    'ipv6',
+    'isoDate',
+    'isoDateTime',
+    'isoTime',
+    'isoTimeSecond',
+    'isoTimestamp',
+    'isoWeek',
+    'length',
+    'mac',
+    'mac48',
+    'mac64',
+    'maxBytes',
+    'maxLength',
+    'maxSize',
+    'maxValue',
+    'mimeType',
+    'minBytes',
+    'minLength',
+    'minSize',
+    'minValue',
+    'multipleOf',
+    'notBytes',
+    'notLength',
+    'notSize',
+    'notValue',
+    'octal',
+    'regex',
+    'safeInteger',
+    'size',
+    'startsWith',
+    'ulid',
+    'url',
+    'uuid',
+    'value',
+  ]}
+/>

--- a/website/src/routes/api/(schemas)/unknown/index.mdx
+++ b/website/src/routes/api/(schemas)/unknown/index.mdx
@@ -18,6 +18,8 @@ Creates a unknown schema.
 ```ts
 // Unknown schema with an optional pipe
 const Schema = unknown(pipe);
+// const UnknownOutput: unknown
+const UnknownOutput = Output<typeof Schema>;
 ```
 
 ## Parameters

--- a/website/src/routes/api/(schemas)/unknown/properties.ts
+++ b/website/src/routes/api/(schemas)/unknown/properties.ts
@@ -1,0 +1,24 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  pipe: {
+    type: [
+      {
+        type: 'custom',
+        name: 'Pipe',
+        href: '../Pipe/',
+        generics: ['unknown'],
+      },
+      'undefined',
+    ],
+  },
+  Schema: {
+    type: [
+      {
+        type: 'custom',
+        name: 'UnknownSchema',
+        href: '../UnknownSchema/',
+      },
+    ],
+  },
+};

--- a/website/src/routes/api/(types)/UnknownSchema/index.mdx
+++ b/website/src/routes/api/(types)/UnknownSchema/index.mdx
@@ -1,0 +1,19 @@
+---
+title: UnknownSchema
+description: Unknown schema type.
+contributors:
+  - mwskwong
+---
+
+import { Property } from '~/components';
+import { properties } from './properties';
+
+# UnknownSchema
+
+Unknown schema type.
+
+## Definition
+
+- `UnknownSchema` <Property {...properties.BaseSchema} />
+  - `type` <Property {...properties.type} />
+  - `pipe` <Property {...properties.pipe} />

--- a/website/src/routes/api/(types)/UnknownSchema/properties.ts
+++ b/website/src/routes/api/(types)/UnknownSchema/properties.ts
@@ -1,0 +1,38 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  BaseSchema: {
+    type: [
+      {
+        type: 'custom',
+        name: 'BaseSchema',
+        href: '../BaseSchema/',
+        generics: [
+          'unknown',
+          {
+            type: 'custom',
+            name: 'TOutput',
+            default: 'unknown',
+          },
+        ],
+      },
+    ],
+  },
+  type: {
+    type: {
+      type: 'string',
+      value: 'unknown',
+    },
+  },
+  pipe: {
+    type: [
+      {
+        type: 'custom',
+        name: 'Pipe',
+        href: '../Pipe/',
+        generics: ['unknown'],
+      },
+      'undefined',
+    ],
+  },
+};

--- a/website/src/routes/api/menu.md
+++ b/website/src/routes/api/menu.md
@@ -238,6 +238,7 @@
 - [TypedSchemaResult](/api/TypedSchemaResult/)
 - [UndefinedSchema](/api/UndefinedSchema/)
 - [UnknownPathItem](/api/UnknownPathItem/)
+- [UnknownSchema](/api/UnknownSchema/)
 - [UntypedSchemaResult](/api/UntypedSchemaResult/)
 - [ValidActionResult](/api/ValidActionResult/)
 - [VoidSchema](/api/VoidSchema/)


### PR DESCRIPTION
Parent issue: https://github.com/fabian-hiller/valibot/issues/287

Created by referencing the `string()` doc. See if this is in the right direction. And whether I have missed anything on the related API part.