### PR TITLE
Refused promise input to `parse`

### DIFF
--- a/library/src/methods/parse/parse.ts
+++ b/library/src/methods/parse/parse.ts
@@ -10,9 +10,9 @@ import type { BaseSchema, Output, ParseInfo } from '../../types/index.ts';
  *
  * @returns The parsed output.
  */
-export function parse<TSchema extends BaseSchema>(
+export function parse<TSchema extends BaseSchema, TInput>(
   schema: TSchema,
-  input: unknown,
+  input: TInput extends Promise<any> ? never : TInput,
   info?: Pick<ParseInfo, 'abortEarly' | 'abortPipeEarly' | 'skipPipe'>
 ): Output<TSchema> {
   const result = schema._parse(input, info);


### PR DESCRIPTION
I have faced to a problem to `parse` the promise value mistakenly several times.
And I came up with that the `parse` must not accept any promise values as input.
There must be no needs to `parse` the promise.