### PR TITLE
docs: Fix variable name

### DIFF
--- a/website/src/routes/guides/(migration)/migrate-from-zod/index.mdx
+++ b/website/src/routes/guides/(migration)/migrate-from-zod/index.mdx
@@ -48,7 +48,7 @@ Due to the modular design of Valibot, also all other methods like `.parse` or `.
 const value = z.string().parse('foo');
 
 // To this
-const email = v.parse(v.string(), 'foo');
+const value = v.parse(v.string(), 'foo');
 ```
 
 ## Change names


### PR DESCRIPTION
I think the name of the variable `value` should not be changed here.