### PR TITLE
docs(recursive): add category example + include imports for easy copy…

### DIFF
--- a/website/src/routes/api/(schemas)/recursive/index.mdx
+++ b/website/src/routes/api/(schemas)/recursive/index.mdx
@@ -58,6 +58,43 @@ const BinaryTreeSchema: BaseSchema<BinaryTree> = object({
 });
 ```
 
+### Category schema
+
+Recursive schema to validate an object with categories and subcategories.
+
+```ts
+import type { BaseSchema, Output } from "valibot";
+import { array, merge, object, parse, recursive, string } from "valibot";
+
+const baseCategorySchema = object({
+  name: string(),
+});
+
+type Category = Output<typeof baseCategorySchema> & {
+  subcategories: Category[];
+};
+
+const categorySchema: BaseSchema<Category> = merge([
+  baseCategorySchema,
+  object({ subcategories: recursive(() => array(categorySchema)) }),
+]);
+
+const result = parse(categorySchema, {
+  name: "People",
+  subcategories: [
+    {
+      name: "Politicians",
+      subcategories: [
+        {
+          name: "Presidents",
+          subcategories: [],
+        },
+      ],
+    },
+  ],
+});
+```
+
 ## Related
 
 The following APIs can be combined with `recursive`.


### PR DESCRIPTION
in this PR I add a new example for `recursive`. Imports are included to allow quick copy/paste, otherwise the user has to include one by one. Also it gives a better idea of the real amount of imports it's going to be required

the example is the one mentioned in #72 

does this sound interesting to be added? in the end I think _it is_ because it's a more "feets on the ground" example comparing it to something like a binary tree example (the only current one)