### PR TITLE
Add support for `input` as value in `v.recursive()` getter

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add `input` of schema to `getter` function of `recursive` and `recursiveAsync` schema (pull request #441)
+
 ## v0.28.1 (February 06, 2024)
 
 - Fix bug in `union` and `unionAsync` schema for transformed inputs (issue #420)

--- a/library/src/schemas/recursive/recursive.test.ts
+++ b/library/src/schemas/recursive/recursive.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { parse } from '../../methods/index.ts';
 import { minLength } from '../../validations/index.ts';
 import { string } from '../string/index.ts';
@@ -14,5 +14,13 @@ describe('recursive', () => {
     expect(() => parse(schema, 123n)).toThrowError();
     expect(() => parse(schema, null)).toThrowError();
     expect(() => parse(schema, {})).toThrowError();
+  });
+
+  test('should pass the input to the getter function as a parameter', () => {
+    const getter = vi.fn().mockReturnValue({ _parse: string()._parse })
+    const schema = recursive(getter);
+    const input = 'hello';
+    parse(schema, input);
+    expect(getter).toHaveBeenCalledWith(input);
   });
 });

--- a/library/src/schemas/recursive/recursive.test.ts
+++ b/library/src/schemas/recursive/recursive.test.ts
@@ -17,7 +17,7 @@ describe('recursive', () => {
   });
 
   test('should pass the input to the getter function as a parameter', () => {
-    const getter = vi.fn().mockReturnValue({ _parse: string()._parse })
+    const getter = vi.fn().mockReturnValue({ _parse: string()._parse });
     const schema = recursive(getter);
     const input = 'hello';
     parse(schema, input);

--- a/library/src/schemas/recursive/recursive.ts
+++ b/library/src/schemas/recursive/recursive.ts
@@ -4,7 +4,7 @@ import type { BaseSchema, Input, Output } from '../../types/index.ts';
  * Recursive schema type.
  */
 export type RecursiveSchema<
-  TGetter extends () => BaseSchema,
+  TGetter extends (input: unknown) => BaseSchema,
   TOutput = Output<ReturnType<TGetter>>
 > = BaseSchema<Input<ReturnType<TGetter>>, TOutput> & {
   /**
@@ -24,7 +24,7 @@ export type RecursiveSchema<
  *
  * @returns A recursive schema.
  */
-export function recursive<TGetter extends () => BaseSchema>(
+export function recursive<TGetter extends (input: unknown) => BaseSchema>(
   getter: TGetter
 ): RecursiveSchema<TGetter> {
   return {
@@ -33,7 +33,7 @@ export function recursive<TGetter extends () => BaseSchema>(
     async: false,
     getter,
     _parse(input, config) {
-      return this.getter()._parse(input, config);
+      return this.getter(input)._parse(input, config);
     },
   };
 }

--- a/library/src/schemas/recursive/recursiveAsync.test.ts
+++ b/library/src/schemas/recursive/recursiveAsync.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { parseAsync } from '../../methods/index.ts';
 import { minLength } from '../../validations/index.ts';
 import { stringAsync } from '../string/index.ts';
@@ -14,5 +14,13 @@ describe('recursiveAsync', () => {
     await expect(parseAsync(schema, 123n)).rejects.toThrowError();
     await expect(parseAsync(schema, null)).rejects.toThrowError();
     await expect(parseAsync(schema, {})).rejects.toThrowError();
+  });
+
+  test('should pass input to getter', async () => {
+    const getter = vi.fn().mockReturnValue({ _parse: stringAsync()._parse });
+    const schema = recursiveAsync(getter);
+    const input = 'hello';
+    await parseAsync(schema, input);
+    expect(getter).toHaveBeenCalledWith(input);
   });
 });

--- a/library/src/types/other.ts
+++ b/library/src/types/other.ts
@@ -10,7 +10,14 @@ export type ObjectKeys<
 /**
  * Maybe readonly type.
  */
-export type MaybeReadonly<T> = Readonly<T> | T;
+export type MaybeReadonly<T> = T | Readonly<T>;
+
+/**
+ * Maybe promise type.
+ *
+ * TODO: Refactor library with this type.
+ */
+export type MaybePromise<T> = T | Promise<T>;
 
 /**
  * Resolve type.

--- a/website/src/routes/api/(schemas)/recursive/properties.ts
+++ b/website/src/routes/api/(schemas)/recursive/properties.ts
@@ -5,7 +5,7 @@ export const properties: Record<string, PropertyProps> = {
     modifier: 'extends',
     type: {
       type: 'function',
-      params: [],
+      params: [{ name: 'input', type: 'unknown' }],
       return: {
         type: 'custom',
         name: 'BaseSchema',

--- a/website/src/routes/api/(types)/RecursiveSchema/properties.ts
+++ b/website/src/routes/api/(types)/RecursiveSchema/properties.ts
@@ -5,7 +5,7 @@ export const properties: Record<string, PropertyProps> = {
     modifier: 'extends',
     type: {
       type: 'function',
-      params: [],
+      params: [{ name: 'input', type: 'unknown' }],
       return: {
         type: 'custom',
         name: 'BaseSchema',


### PR DESCRIPTION
### Linked issue

Resolve #440 

### Description

Currently, when we aim to create a valibot schema that depends on real-time data, the following code snippet is a standard approach:

```ts
const input = {
  // Your input here
};

const schema = v.recursive(() => {
  if(input.type === 'A') {
    return v.object({
      foo: v.string()
    });
  }

  return v.object({
    Column: v.number()
  });
});

const output = v.parse(schema, input);
```

However, this method presents challenges in abstracting the schema effectively.

If the `v.recursive()` function could accept a parameter—specifically, the second parameter passed to `parse()`—we would be able to abstract the schema with greater ease, as shown below:

```ts
// schema.ts
const schema = v.recursive((input) => {
  if(input.type === 'A') {
    return v.object({
      foo: v.string()
    });
  }

  return v.object({
    Column: v.number()
  });
});

// validate.ts
const input = {
  // Your input here
};

const output = v.parse(schema, input);
```
