### PR TITLE
chore(i18n): change PR link to russian translation

### DIFF
--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -14,7 +14,7 @@ The official i18n translations for Valibot. See the [internationalization guide]
 | French (fr)     | [#418][pr-418-url] | ✅     |
 | Japanese (ja)   | [#431][pr-431-url] | ✅     |
 | Korean (kr)     | [#429][pr-429-url] | ✅     |
-| Russian (ru)    | [#434][pr-429-url] | ✅     |
+| Russian (ru)    | [#434][pr-434-url] | ✅     |
 | Slovenian (sl)  | [#422][pr-422-url] | ✅     |
 | Ukrainian (uk)  | [#423][pr-423-url] | ✅     |
 


### PR DESCRIPTION
Thanks for adding link to PR with russian translation! However, despite the issue number is correct, the link leads to another PR. This PR changes the path to the correct one