### PR TITLE
[i18n] Allow valibot v0.29 in peer dependencies

### DIFF
--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -34,7 +34,7 @@
     "valibot": "workspace:*"
   },
   "peerDependencies": {
-    "valibot": "^0.28.0"
+    "valibot": ">=0.29.0 <1"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
valibot v0.29.0 has been released but installing with `@valibot/i18n` causes peer dependency failure because the package requires v0.28.x. This pull request adds support of valibot v0.29.x to the i18n package.