### PR TITLE
Refactor to simplify `null` or `undefined` checks

### DIFF
--- a/library/src/schemas/nonNullish/nonNullish.ts
+++ b/library/src/schemas/nonNullish/nonNullish.ts
@@ -43,7 +43,7 @@ export function nonNullish<TWrapped extends BaseSchema>(
     message,
     _parse(input, config) {
       // In input is `null` or `undefined`, return schema issue
-      if (input === null || input === undefined) {
+      if (input == null) {
         return schemaIssue(this, nonNullish, input, config);
       }
 

--- a/library/src/schemas/nonNullish/nonNullishAsync.ts
+++ b/library/src/schemas/nonNullish/nonNullishAsync.ts
@@ -47,7 +47,7 @@ export function nonNullishAsync<TWrapped extends BaseSchema | BaseSchemaAsync>(
     message,
     async _parse(input, config) {
       // In input is `null` or `undefined`, return schema issue
-      if (input === null || input === undefined) {
+      if (input == null) {
         return schemaIssue(this, nonNullishAsync, input, config);
       }
 

--- a/library/src/schemas/nullish/nullish.ts
+++ b/library/src/schemas/nullish/nullish.ts
@@ -72,7 +72,7 @@ export function nullish<
     _parse(input, config) {
       // If input is `null` or `undefined`, return typed schema result or
       // override it with default value
-      if (input === null || input === undefined) {
+      if (input == null) {
         const override = getDefault(this);
         if (override === undefined) {
           return schemaResult(true, input);

--- a/library/src/schemas/nullish/nullishAsync.ts
+++ b/library/src/schemas/nullish/nullishAsync.ts
@@ -85,7 +85,7 @@ export function nullishAsync<
     async _parse(input, config) {
       // If input is `null` or `undefined`, return typed schema result or
       // override it with default value
-      if (input === null || input === undefined) {
+      if (input == null) {
         const override = await getDefaultAsync(this);
         if (override === undefined) {
           return schemaResult(true, input);


### PR DESCRIPTION
Currently, the methods `nonNullish`, `nonNullishAsync`, `nullish`, and `nullishAsync` determine if `input` is `null` or `undefined` using the following approach:

```ts
input === null || input === undefined
```

According to the ECMAScript specification mentioned in:

[13.11.1 Runtime Semantics: Evaluation](https://tc39.es/ecma262/#sec-equality-operators-runtime-semantics-evaluation)
EqualityExpression : EqualityExpression == RelationalExpression
1. Let lref be ? Evaluation of EqualityExpression.
2. Let lval be ? GetValue(lref).
3. Let rref be ? Evaluation of RelationalExpression.
4. Let rval be ? GetValue(rref).
5. Return ? IsLooselyEqual(rval, lval).

The specification for IsLooselyEqual is as follows:

[7.2.14 IsLooselyEqual ( x, y )](https://tc39.es/ecma262/#sec-islooselyequal)
The abstract operation IsLooselyEqual takes arguments x (an ECMAScript language value) and y (an ECMAScript language value) and returns either a normal completion containing a Boolean or a throw completion. It provides the semantics for the == operator. It performs the following steps when called:

1. If Type(x) is Type(y), then
  a. Return IsStrictlyEqual(x, y).
2. If x is null and y is undefined, return true.
3. If x is undefined and y is null, return true.
...ellipsis

In points two and three, we find that using `null == undefined` yields `true`. Therefore, we can simplify our check as follows:

```diff
- input === null || input === undefined
+ input == null
```

It perhaps makes the code more concise. If there are any concerns, we are eager to hear your thoughts.