### PR TITLE
feat: Validate ISO timestamps with offsets

### DIFF
--- a/library/src/regex.ts
+++ b/library/src/regex.ts
@@ -79,7 +79,7 @@ export const ISO_TIME_SECOND_REGEX = /^(?:0\d|1\d|2[0-3])(?::[0-5]\d){2}$/u;
  * [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp regex.
  */
 export const ISO_TIMESTAMP_REGEX =
-  /^\d{4}-(?:0[1-9]|1[0-2])-(?:[12]\d|0[1-9]|3[01])T(?:0\d|1\d|2[0-3])(?::[0-5]\d){2}(?:\.\d{1,9})?Z$/u;
+  /^\d{4}-(?:0[1-9]|1[0-2])-(?:[12]\d|0[1-9]|3[01])T(?:0\d|1\d|2[0-3])(?::[0-5]\d){2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}(?::?\d{2})?)$/u;
 
 /**
  * [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) week regex.

--- a/library/src/validations/isoTimestamp/isoTimestamp.test.ts
+++ b/library/src/validations/isoTimestamp/isoTimestamp.test.ts
@@ -15,6 +15,25 @@ describe('isoTimestamp', () => {
     const value5 = '2024-01-16T16:00:34Z';
     expect(validate._parse(value5).output).toBe(value5);
 
+    const timestampsWithOffset = [
+      // '+hh:mm'
+      '0000-01-01T00:00:00.000+00:00',
+      // '+hhmm'
+      '0000-01-01T00:00:00.000+0000',
+      // '+hh'
+      '0000-01-01T00:00:00.000+00',
+      // '-hh:mm'
+      '0000-01-01T00:00:00.000-00:00',
+      // '-hhmm'
+      '0000-01-01T00:00:00.000-0000',
+      // '-hh'
+      '0000-01-01T00:00:00.000-00',
+    ];
+
+    for (const value of timestampsWithOffset) {
+      expect(validate._parse(value).output).toBe(value);
+    }
+
     expect(validate._parse('').issues).toBeTruthy();
     expect(validate._parse('2023-07-11T17:26:27.243').issues).toBeTruthy();
     expect(validate._parse('2023-07-1117:26:27.243Z').issues).toBeTruthy();
@@ -31,6 +50,14 @@ describe('isoTimestamp', () => {
     expect(
       validate._parse('0000-01-01T00:00:00.0000000000Z').issues
     ).toBeTruthy();
+    expect(validate._parse('0000-01-01T00:00:00.000+00:0').issues).toBeTruthy();
+    expect(validate._parse('0000-01-01T00:00:00.000+0:00').issues).toBeTruthy();
+    expect(validate._parse('0000-01-01T00:00:00.000+000').issues).toBeTruthy();
+    expect(
+      validate._parse('0000-01-01T00:00:00.000+00::00').issues
+    ).toBeTruthy();
+    expect(validate._parse('0000-01-01T00:00:00.000+00:').issues).toBeTruthy();
+    expect(validate._parse('0000-01-01T00:00:00.000+').issues).toBeTruthy();
   });
 
   test('should return custom error message', () => {

--- a/library/src/validations/isoTimestamp/isoTimestamp.ts
+++ b/library/src/validations/isoTimestamp/isoTimestamp.ts
@@ -20,7 +20,12 @@ export interface IsoTimestampValidation<TInput extends string>
 /**
  * Creates a pipeline validation action that validates a timestamp.
  *
- * Format: yyyy-mm-ddThh:mm:ss.sssZ
+ * Formats:
+ *
+ * - yyyy-mm-ddThh:mm:ss.sssZ
+ * - yyyy-mm-ddThh:mm:ss.sss±hh:mm
+ * - yyyy-mm-ddThh:mm:ss.sss±hhmm
+ * - yyyy-mm-ddThh:mm:ss.sss±hh
  *
  * Hint: To support timestamps with lower or higher accuracy, the millisecond
  * specification can be removed or contain up to 9 digits.


### PR DESCRIPTION
I've added a bunch of tests with both valid and invalid timestamps and updated the JSDoc to list all the allowed formats.

The regex is relatively permissive as it allows for any number in the offset. If something stricter is required, I can work on it, but I'm afraid it would explode in complexity. For example, a `00:00` offset is valid only if preceded by a `+` and not by `-`; the maximum offset should be ±12:00, etc.

Closes #495.