### PR TITLE
feat(rewrite-with-pipe): add includes action

### DIFF
--- a/library/src/actions/includes/includes.test-d.ts
+++ b/library/src/actions/includes/includes.test-d.ts
@@ -1,0 +1,90 @@
+import { describe, expectTypeOf, test } from 'vitest';
+import type { InferInput, InferIssue, InferOutput } from '../../types/index.ts';
+import { 
+  includes, 
+  type IncludesAction,
+  type IncludesIssue 
+} from './includes.ts';
+
+describe('includes', () => {
+  describe('should return action object', () => {
+    test('with undefined message', () => {
+      type Action = IncludesAction<string, "hello", undefined>;
+      expectTypeOf(includes<string, "hello">("hello")).toEqualTypeOf<Action>();
+      expectTypeOf(
+        includes<string, "hello", undefined>("hello", undefined)
+      ).toEqualTypeOf<Action>();
+    });
+
+    test('with string message', () => {
+      expectTypeOf(
+        includes<string, "hello", 'message'>("hello", 'message')
+      ).toEqualTypeOf<IncludesAction<string, "hello", 'message'>>();
+    });
+
+    test('with function message', () => {
+      expectTypeOf(
+        includes<string, "hello", () => string>("hello", () => 'message')
+      ).toEqualTypeOf<IncludesAction<string, "hello", () => string>>();
+    });
+  });
+
+  describe('should infer correct types', () => {
+    type Action = IncludesAction<string, "hello", undefined>;
+
+    test('of input', () => {
+      expectTypeOf<InferInput<Action>>().toEqualTypeOf<string>();
+    });
+
+    test('of output', () => {
+      expectTypeOf<InferOutput<Action>>().toEqualTypeOf<string>();
+    });
+
+    test('of issue', () => {
+      expectTypeOf<InferIssue<Action>>().toEqualTypeOf<
+        IncludesIssue<string, "hello">
+      >();
+    });
+  });
+
+  describe('should correctly relate input and requirement types', () => {
+    describe('when the input is a string', () => {
+      test('and the requirement is not a valid related type', () => {
+        // @ts-expect-error
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        type Action = IncludesAction<string, number, undefined>;
+      });
+
+      test('and the requirement is a valid related type', () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        type Action = IncludesAction<string, string, undefined>;
+      });
+    });
+
+    describe('when the input is an array', () => {
+      test('and the requirement is not a valid related type', () => {
+        // @ts-expect-error
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        type Action = IncludesAction<number[], string, undefined>;
+      });
+
+      test('and the requirement is a valid related type', () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        type Action = IncludesAction<number[], number, undefined>;
+      });
+    });
+
+    describe('when the input is a tuple', () => {
+      test('and the requirement is not a valid related type', () => {
+        // @ts-expect-error
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        type Action = IncludesAction<['hello', 1, true], string | number | boolean, undefined>;
+      });
+
+      test('and the requirement is a valid related type', () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        type Action = IncludesAction<['hello', 1, true], 'hello' | 1 | true, undefined>;
+      });
+    });
+  })
+});

--- a/library/src/actions/includes/includes.test.ts
+++ b/library/src/actions/includes/includes.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'vitest';
+import { 
+  includes,
+  type IncludesIssue, 
+  type IncludesAction 
+} from './includes.ts';
+import { expectActionIssue, expectNoActionIssue } from '../../vitest/index.ts';
+
+describe('includes', () => {
+  describe('should return action object', () => {
+    const baseAction: Omit<IncludesAction<string, 'hello', never>, 'message'> = {
+      kind: 'validation',
+      type: 'includes',
+      expects: `"hello"`,
+      requirement: 'hello',
+      async: false,
+      _run: expect.any(Function),
+    };
+
+    test('with undefined message', () => {
+      const action: IncludesAction<string, 'hello', undefined> = {
+        ...baseAction,
+        message: undefined,
+      };
+      expect(includes('hello')).toStrictEqual(action);
+      expect(includes('hello', undefined)).toStrictEqual(action);
+    });
+
+    test('with string message', () => {
+      const message = 'message';
+      expect(includes('hello', message)).toStrictEqual({
+        ...baseAction,
+        message,
+      } satisfies IncludesAction<string, 'hello', string>);
+    });
+
+    test('with function message', () => {
+      const message = () => 'message';
+      expect(includes('hello', message)).toStrictEqual({
+        ...baseAction,
+        message,
+      } satisfies IncludesAction<string, 'hello', typeof message>);
+    });
+  });
+
+  describe('should return no issue', () => {
+    const action = includes('foobar');
+
+    test('for untyped inputs', () => {
+      expect(action._run({ typed: false, value: null }, {})).toStrictEqual({
+        typed: false,
+        value: null,
+      });
+    });
+
+    test('for valid strings', () => {
+      expectNoActionIssue(action, ['foobar', '123foobar45', '123456foobar', 'foobarbaz123']);
+    });
+
+    test('for valid arrays', () => {
+      expectNoActionIssue(action, [['123', 'test', 'foobar', '456'], ['test123', 'foobar'], ['foobar'], ['foobar', 'hello']]);
+    });
+  });
+
+  describe('should return an issue', () => {
+    const actionRequirement = 'test123';
+    const actionMessage = 'message';
+    const action = includes(actionRequirement, actionMessage);
+    const baseIssue: Omit<IncludesIssue<string, 'test123'>, 'input' | 'received'> = {
+      kind: 'validation',
+      type: 'includes',
+      expected: `"${actionRequirement}"`,
+      message: actionMessage,
+      requirement: actionRequirement,
+    };
+
+    const issueGetReceived = () => `!"${actionRequirement}"`;
+
+    test('for invalid strings', () => {
+      expectActionIssue(
+        action,
+        baseIssue,
+        ['', 'foo', '1234'],
+        issueGetReceived
+      );
+    });
+
+    test('for invalid arrays', () => {
+      expectActionIssue(
+        action,
+        baseIssue,
+        [[], ['foo', 'bar'], [1, 2, 3, 4]],
+        issueGetReceived
+      );
+    });
+  });
+});

--- a/library/src/actions/includes/includes.ts
+++ b/library/src/actions/includes/includes.ts
@@ -1,0 +1,150 @@
+import type { BaseIssue, BaseValidation, ErrorMessage } from '../../types/index.ts';
+import { _addIssue, _stringify } from '../../utils/index.ts';
+
+type IncludesInput = string | unknown[];
+
+type IncludesRequirement<TInput extends IncludesInput> =
+  TInput extends unknown[] ? TInput[number] : TInput;
+
+type IncludesType = 'includes';
+
+/**
+ * Includes issue type.
+ */
+export interface IncludesIssue<
+  TInput extends IncludesInput,
+  TRequirement extends IncludesRequirement<TInput>,
+> extends BaseIssue<TInput> {
+  /**
+   * The issue kind.
+   */
+  readonly kind: 'validation';
+  /**
+   * The issue type.
+   */
+  readonly type: IncludesType;
+  /**
+   * The expected input.
+   */ 
+  readonly expected: string;
+  /**
+   * The content to be included.
+   */
+  readonly requirement: TRequirement;
+}
+
+/**
+ * Includes action type.
+ */
+export interface IncludesAction<
+  TInput extends IncludesInput,
+  TRequirement extends IncludesRequirement<TInput>,
+  TMessage extends
+    | ErrorMessage<IncludesIssue<TInput, TRequirement>>
+    | undefined,
+> extends BaseValidation<TInput, TInput, IncludesIssue<TInput, TRequirement>> {
+  /**
+   * The action type.
+   */
+  readonly type: IncludesType;
+  /**
+   * The expected property.
+   */
+  readonly expects: string;
+  /**
+   * The content to be included.
+   */
+  readonly requirement: TRequirement;
+  /**
+   * The error message.
+   */
+  readonly message: TMessage;
+}
+
+/**
+ * Creates a pipeline validation action that validates the content of a string
+ * or array.
+ *
+ * @param requirement The content to be included.
+ *
+ * @returns A validation action.
+ */
+export function includes<
+  TInput extends IncludesInput,
+  const TRequirement extends IncludesRequirement<TInput>,
+>(requirement: TRequirement): IncludesAction<TInput, TRequirement, undefined>;
+
+/**
+ * Creates a pipeline validation action that validates the content of a string
+ * or array.
+ *
+ * @param requirement The content to be included.
+ * @param message The error message.
+ * 
+ * @returns A validation action.
+ */
+export function includes<
+  TInput extends IncludesInput,
+  const TRequirement extends IncludesRequirement<TInput>,
+  const TMessage extends
+    | ErrorMessage<IncludesIssue<TInput, TRequirement>>
+    | undefined,
+>(
+  requirement: TRequirement,
+  message: TMessage
+): IncludesAction<TInput, TRequirement, TMessage>;
+
+export function includes<
+  TInput extends IncludesInput,
+  const TRequirement extends IncludesRequirement<TInput>
+>(
+  requirement: TRequirement,
+  message?: ErrorMessage<IncludesIssue<TInput, TRequirement>>
+): IncludesAction<
+  TInput, 
+  TRequirement, 
+  ErrorMessage<IncludesIssue<TInput, TRequirement>> | undefined
+> {
+  const expects = _stringify(requirement);
+  return {
+    kind: 'validation',
+    type: 'includes',
+    async: false,
+    expects,
+    message,
+    requirement,
+    _run(dataset, config) {
+      if (dataset.typed) {
+        // Cannot execute: `dataset.value.includes(this.requirement)` without a compiler error. 
+        // Reason: 
+        //     `this.requirement` is assigned a type conditionally based on `TInput`.
+        //     Even if `this.requirement` is not assigned a type conditionally, 
+        //         `this.requrement` will be set to `unknown` as `TInput[number]` can be anything.
+        // The old implementation worked because: type TRequirement = any | string = any
+
+        // Safe hacky workaround: 
+        //     `dataset.value.includes(this.requirement as IncludesRequirement<string>)`.
+        // But bad for code readability
+
+        // Preferred workaround: Smartly narrow the types before performing runtime checks.
+        const datasetValue = dataset.value;
+        let includesRequirement: boolean;
+        if (Array.isArray(datasetValue)) {
+          includesRequirement = datasetValue.includes(this.requirement);
+        } 
+        else if (typeof this.requirement === 'string') {
+          includesRequirement = datasetValue.includes(this.requirement);
+        } else {
+          // Let the code register an issue for this unreachable block
+          includesRequirement = false; 
+        }
+        if (!includesRequirement) {
+          _addIssue(this, includes, 'content', dataset, config, { 
+            received: `!${expects}` 
+          });
+        }
+      }
+      return dataset;
+    },
+  };
+}

--- a/library/src/actions/includes/index.ts
+++ b/library/src/actions/includes/index.ts
@@ -1,0 +1,1 @@
+export * from "./includes.ts";

--- a/library/src/actions/index.ts
+++ b/library/src/actions/index.ts
@@ -9,3 +9,4 @@ export * from './trim/index.ts';
 export * from './trimEnd/index.ts';
 export * from './trimStart/index.ts';
 export * from './url/index.ts';
+export * from "./includes/includes.ts";


### PR DESCRIPTION
There are a few things done differently which are summarized in the points below:

1. The `IncludesInput` type is inside the `includes` action file rather than in a shared types file like for `LengthInput`. I assume `LengthInput` will be reused for `minLength` and `maxLength` and therefore it makes sense to include it in the shared type file. I don't think `IncludesInput` will be reused for any other action.

2. The `_run` method of the action is handled differently because of the change in types of the parameters. Read the code comments for a detailed explanation.

3. The type tests contains a block that checks if the action function can relate input and requirement types properly. I am not sure if the written type tests for the block are ideal. Let me know if I should follow any good practices for these types of tests.