### PR TITLE
feat: add formData schema

### DIFF
--- a/library/src/schemas/formData/formData.test.ts
+++ b/library/src/schemas/formData/formData.test.ts
@@ -1,0 +1,483 @@
+import { describe, expect, test } from 'vitest';
+import { type ValiError } from '../../error/index.ts';
+import { parse } from '../../methods/index.ts';
+import type {
+  Output,
+  TypedSchemaResult,
+  UntypedSchemaResult,
+} from '../../types/index.ts';
+import { custom, minLength } from '../../validations/index.ts';
+import { array } from '../array/array.ts';
+import { boolean } from '../boolean/boolean.ts';
+import { date } from '../date/date.ts';
+import { instance } from '../instance/instance.ts';
+import { nullable } from '../nullable/nullable.ts';
+import { number } from '../number/index.ts';
+import { object } from '../object/object.ts';
+import { optional } from '../optional/optional.ts';
+import { string } from '../string/index.ts';
+import { formData } from './formData.ts';
+
+describe('formData', () => {
+  test('should pass only FormData', () => {
+    const schema = formData({ foo: string() });
+    const input = new FormData();
+    input.append('foo', 'bar');
+    const output = parse(schema, input);
+    expect(output).toEqual({ foo: 'bar' });
+
+    expect(() => parse(schema, {})).toThrowError();
+    expect(() => parse(schema, 123)).toThrowError();
+  });
+
+  test('should throw custom error', () => {
+    const error = 'Value is not a FormData!';
+    const schema = formData({ n: number() }, error);
+    expect(() => parse(schema, 123)).toThrowError(error);
+  });
+
+  test('should throw every issue', () => {
+    const schema = formData({ a: number(), b: string(), c: number() });
+    const input = new FormData();
+    input.append('a', 'x');
+    input.append('b', 'y');
+    input.append('c', 'z');
+    expect(() => parse(schema, input)).toThrowError();
+    try {
+      parse(schema, input);
+    } catch (error) {
+      expect((error as ValiError).issues.length).toBe(2);
+    }
+  });
+
+  test('should throw only first issue', () => {
+    const schema1 = formData({ a: number(), b: string(), c: number() });
+    const input1 = new FormData();
+    input1.append('a', 'x');
+    input1.append('b', 'y');
+    input1.append('c', 'z');
+    const config = { abortEarly: true };
+    expect(() => parse(schema1, input1, config)).toThrowError();
+    try {
+      parse(schema1, input1, config);
+    } catch (error) {
+      expect((error as ValiError).issues.length).toBe(1);
+    }
+
+    const schema2 = formData({ a: array(number()) });
+    const input2 = new FormData();
+    input2.append('a', '1');
+    input2.append('a', '2');
+    input2.append('a', 'x');
+    expect(() => parse(schema2, input2, config)).toThrowError();
+    try {
+      parse(schema2, input2, config);
+    } catch (error) {
+      expect((error as ValiError).issues.length).toBe(1);
+    }
+
+    const schema3 = formData({ a: array(number()) });
+    const input3 = new FormData();
+    input3.append('a.0', '1');
+    input3.append('a.1', '2');
+    input3.append('a.2', 'x');
+    expect(() => parse(schema3, input3, config)).toThrowError();
+    try {
+      parse(schema3, input3, config);
+    } catch (error) {
+      expect((error as ValiError).issues.length).toBe(1);
+    }
+  });
+
+  test('should return issue path', () => {
+    const schema1 = formData({ a: number() });
+    const input1 = new FormData();
+    input1.append('a', 'x');
+    const result1 = schema1._parse(input1);
+    expect(result1.issues?.[0].path).toEqual([
+      {
+        type: 'formData',
+        origin: 'value',
+        input: input1,
+        key: 'a',
+        value: 'x',
+      },
+    ]);
+
+    const schema2 = formData({ a: object({ b: number() }) });
+    const input2 = new FormData();
+    input2.append('a', 'x');
+    const result2 = schema2._parse(input2);
+    expect(result2.issues?.[0].path).toEqual([
+      {
+        type: 'formData',
+        origin: 'value',
+        input: input2,
+        key: 'a',
+        value: 'x',
+      },
+      {
+        type: 'formData',
+        origin: 'value',
+        input: input2,
+        key: 'a.b',
+        value: null,
+      },
+    ]);
+  });
+
+  test('should execute pipe', () => {
+    const inputError = 'Invalid input';
+
+    const schema1 = formData({ a: optional(string()), b: optional(string()) }, [
+      custom((input) => Object.keys(input).length === 1),
+    ]);
+    const input1 = new FormData();
+    input1.append('a', 'x');
+    const input2 = new FormData();
+    const input3 = new FormData();
+    input3.append('a', 'x');
+    input3.append('b', 'y');
+    const output1 = parse(schema1, input1);
+    expect(output1).toEqual({ a: 'x' });
+    expect(() => parse(schema1, input2)).toThrowError(inputError);
+    expect(() => parse(schema1, input3)).toThrowError(inputError);
+
+    const schema2 = formData(
+      { a: optional(string()), b: optional(string()) },
+      'Error',
+      [custom((input) => Object.keys(input).length === 1)]
+    );
+    const output2 = parse(schema2, input1);
+    expect(output2).toEqual({ a: 'x' });
+    expect(() => parse(schema2, input2)).toThrowError(inputError);
+    expect(() => parse(schema2, input3)).toThrowError(inputError);
+  });
+
+  test('should execute pipe if output is typed', () => {
+    const requirement1 = (input: { a: string }) =>
+      Object.keys(input).length > 10;
+    const schema1 = formData({ a: string([minLength(10)]) }, [
+      custom(requirement1),
+    ]);
+    const input1 = new FormData();
+    input1.append('a', '12345');
+    const result1 = schema1._parse(input1);
+    expect(result1).toEqual({
+      typed: true,
+      output: { a: '12345' },
+      issues: [
+        {
+          reason: 'string',
+          context: 'min_length',
+          expected: '>=10',
+          received: '5',
+          message: 'Invalid length: Expected >=10 but received 5',
+          input: '12345',
+          requirement: 10,
+          path: [
+            {
+              type: 'formData',
+              origin: 'value',
+              input: input1,
+              key: 'a',
+              value: '12345',
+            },
+          ],
+        },
+        {
+          reason: 'formData',
+          context: 'custom',
+          expected: null,
+          received: 'Object',
+          message: 'Invalid input: Received Object',
+          input: { a: '12345' },
+          requirement: requirement1,
+        },
+      ],
+    } satisfies TypedSchemaResult<Output<typeof schema1>>);
+
+    const requirement2 = (input: { a: string[] }) =>
+      Object.keys(input).length > 10;
+    const schema2 = formData({ a: array(string([minLength(10)])) }, [
+      custom(requirement2),
+    ]);
+    const input2 = new FormData();
+    input2.append('a', '123');
+    input2.append('a', '12345');
+    input2.append('a', '1234567890=');
+    const result2 = schema2._parse(input2);
+    expect(result2).toEqual({
+      typed: true,
+      output: { a: ['123', '12345', '1234567890='] },
+      issues: [
+        {
+          reason: 'string',
+          context: 'min_length',
+          expected: '>=10',
+          received: '3',
+          message: 'Invalid length: Expected >=10 but received 3',
+          input: '123',
+          requirement: 10,
+          path: [
+            {
+              type: 'formData',
+              origin: 'value',
+              input: input2,
+              key: 'a',
+              value: ['123', '12345', '1234567890='],
+            },
+          ],
+        },
+        {
+          reason: 'formData',
+          context: 'custom',
+          expected: null,
+          received: 'Object',
+          message: 'Invalid input: Received Object',
+          input: { a: ['123', '12345', '1234567890='] },
+          requirement: requirement2,
+        },
+      ],
+    } satisfies TypedSchemaResult<Output<typeof schema2>>);
+  });
+
+  test('should skip pipe if output is not typed', () => {
+    const schema1 = formData({ a: number() }, [
+      custom((input) => Object.keys(input).length > 10),
+    ]);
+    const input1 = new FormData();
+    input1.append('a', '$12345');
+    const result1 = schema1._parse(input1);
+    expect(result1).toEqual({
+      typed: false,
+      output: { a: '$12345' },
+      issues: [
+        {
+          reason: 'type',
+          context: 'number',
+          expected: 'number',
+          received: '"$12345"',
+          message: 'Invalid type: Expected number but received "$12345"',
+          input: '$12345',
+          path: [
+            {
+              type: 'formData',
+              origin: 'value',
+              input: input1,
+              key: 'a',
+              value: '$12345',
+            },
+          ],
+        },
+      ],
+    } satisfies UntypedSchemaResult);
+
+    const schema2 = formData({ a: array(number()) }, [
+      custom((input) => Object.keys(input).length > 10),
+    ]);
+    const input2 = new FormData();
+    input2.append('a', '123');
+    input2.append('a', '$12345');
+    input2.append('a', '$1234567890=');
+    const result2 = schema2._parse(input2);
+    expect(result2).toEqual({
+      typed: false,
+      output: { a: [123, '$12345', '$1234567890='] },
+      issues: [
+        {
+          reason: 'type',
+          context: 'number',
+          expected: 'number',
+          received: '"$12345"',
+          message: 'Invalid type: Expected number but received "$12345"',
+          input: '$12345',
+          path: [
+            {
+              type: 'formData',
+              origin: 'value',
+              input: input2,
+              key: 'a',
+              value: [123, '$12345', '$1234567890='],
+            },
+          ],
+        },
+      ],
+    } satisfies UntypedSchemaResult);
+  });
+
+  test('should accept object schema', () => {
+    const schema = formData(object({ a: object({ b: number() }) }));
+    const input = new FormData();
+    input.append('a.b', '123');
+    const result = schema._parse(input);
+    expect(result.output).toEqual({ a: { b: 123 } });
+  });
+
+  test('should decode array', () => {
+    const schema1 = formData({
+      a: array(number()),
+      b: array(number()),
+      c: array(array(number())),
+      d: array(object({ x: array(number()) })),
+      e: array(object({ x: array(number()) })),
+      f: nullable(array(number())),
+      g: optional(array(number())),
+    });
+    const input1 = new FormData();
+    input1.append('a', '1');
+    input1.append('a', '2');
+    input1.append('b.0', '3');
+    input1.append('b.1', '4');
+    input1.append('c.0', '5');
+    input1.append('c.0', '6');
+    input1.append('c.1', '7');
+    input1.append('c.1', '8');
+    input1.append('d.0.x', '9');
+    input1.append('e.0.x.0', '10');
+    input1.append('f', '');
+    const result1 = schema1._parse(input1);
+    expect(result1.output).toEqual({
+      a: [1, 2],
+      b: [3, 4],
+      c: [
+        [5, 6],
+        [7, 8],
+      ],
+      d: [{ x: [9] }],
+      e: [{ x: [10] }],
+      f: null,
+    });
+  });
+
+  test('should decode boolean', () => {
+    const schema1 = formData({
+      a: boolean(),
+      b: boolean(),
+      c: nullable(boolean()),
+      d: optional(boolean()),
+    });
+    const input1 = new FormData();
+    input1.append('a', 'true');
+    input1.append('b', 'false');
+    input1.append('c', '');
+    const result1 = schema1._parse(input1);
+    expect(result1.output).toEqual({ a: true, b: false, c: null });
+
+    const schema2 = formData({ a: boolean() });
+    const input2 = new FormData();
+    input2.append('a', 'x');
+    expect(() => parse(schema2, input2)).toThrowError(
+      'Invalid type: Expected boolean but received "x"'
+    );
+  });
+
+  test('should decode date', () => {
+    const schema1 = formData({
+      a: date(),
+      b: date(),
+      c: nullable(date()),
+      d: optional(date()),
+    });
+    const input1 = new FormData();
+    input1.append('a', '2021-01-01T00:00:00Z');
+    input1.append('b', '1609459200000');
+    input1.append('c', '');
+    const result1 = schema1._parse(input1);
+    expect(result1.output).toEqual({
+      a: new Date('2021-01-01T00:00:00Z'),
+      b: new Date('2021-01-01T00:00:00Z'),
+      c: null,
+    });
+
+    const schema2 = formData({ a: date() });
+    const input2 = new FormData();
+    input2.append('a', 'x');
+    expect(() => parse(schema2, input2)).toThrowError(
+      'Invalid type: Expected Date but received "x"'
+    );
+  });
+
+  test('should decode file', () => {
+    const value = new File(['foo'], 'bar.txt', { type: 'text/plain' });
+    const schema1 = formData({ a: instance(File) });
+    const input1 = new FormData();
+    input1.append('a', new Blob(['123']));
+    const result1 = schema1._parse(input1);
+    expect(result1.output).toEqual({ a: value });
+
+    const schema2 = formData({ a: instance(File) });
+    const input2 = new FormData();
+    input2.append('a', 'x');
+    expect(() => parse(schema2, input2)).toThrowError(
+      'Invalid type: Expected File but received "x"'
+    );
+  });
+
+  test('should decode number', () => {
+    const schema1 = formData({
+      a: number(),
+      b: number(),
+      c: nullable(number()),
+      d: optional(number()),
+    });
+    const input1 = new FormData();
+    input1.append('a', '123');
+    input1.append('b', '-4.56');
+    input1.append('c', '');
+    const result1 = schema1._parse(input1);
+    expect(result1.output).toEqual({ a: 123, b: -4.56, c: null });
+
+    const schema2 = formData({ a: number() });
+    const input2 = new FormData();
+    input2.append('a', 'x');
+    expect(() => parse(schema2, input2)).toThrowError(
+      'Invalid type: Expected number but received "x"'
+    );
+
+    const schema3 = formData({ a: number() });
+    const input3 = new FormData();
+    input3.append('a', 'NaN');
+    expect(() => parse(schema3, input3)).toThrowError(
+      'Invalid type: Expected number but received "NaN"'
+    );
+  });
+
+  test('should decode string', () => {
+    const schema1 = formData({
+      a: string(),
+      b: string(),
+      c: string(),
+      d: string(),
+      e: string(),
+      f: string(),
+      g: nullable(string()),
+      h: optional(string()),
+    });
+    const input1 = new FormData();
+    input1.append('a', 'x');
+    input1.append('b', '0');
+    input1.append('c', 'NaN');
+    input1.append('d', 'false');
+    input1.append('e', 'null');
+    input1.append('f', 'undefined');
+    input1.append('g', '');
+    const result1 = schema1._parse(input1);
+    expect(result1.output).toEqual({
+      a: 'x',
+      b: '0',
+      c: 'NaN',
+      d: 'false',
+      e: 'null',
+      f: 'undefined',
+      g: null,
+    });
+
+    const schema2 = formData({ a: string() });
+    const input2 = new FormData();
+    input2.append('a', new File(['foo'], 'bar.txt', { type: 'text/plain' }));
+    expect(() => parse(schema2, input2)).toThrowError(
+      'Invalid type: Expected string but received File'
+    );
+  });
+});

--- a/library/src/schemas/formData/formData.ts
+++ b/library/src/schemas/formData/formData.ts
@@ -1,0 +1,263 @@
+import type {
+  BaseSchema,
+  ErrorMessage,
+  Pipe,
+  SchemaConfig,
+  SchemaIssues,
+} from '../../types/index.ts';
+import {
+  defaultArgs,
+  pipeResult,
+  schemaIssue,
+  schemaResult,
+} from '../../utils/index.ts';
+import type { ArraySchema } from '../array/array.ts';
+import {
+  object,
+  type ObjectEntries,
+  type ObjectSchema,
+} from '../object/object.ts';
+import type { ObjectOutput } from '../object/types.ts';
+import type { FormDataPathItem } from './types.ts';
+
+/**
+ * FormData schema type.
+ */
+export interface FormDataSchema<
+  TEntries extends ObjectEntries,
+  TOutput = ObjectOutput<TEntries, undefined>,
+> extends BaseSchema<FormData, TOutput> {
+  /**
+   * The schema type.
+   */
+  type: 'formData';
+  /**
+   * The object entries.
+   */
+  entries: TEntries | ObjectSchema<TEntries, undefined>;
+  /**
+   * The error message.
+   */
+  message: ErrorMessage | undefined;
+  /**
+   * The validation and transformation pipeline.
+   */
+  pipe: Pipe<TOutput> | undefined;
+}
+
+function decodeEntry(schema: BaseSchema, value: FormDataEntryValue | null) {
+  if (value === null) return undefined;
+  if (value === '') return null;
+  switch (schema.type) {
+    case 'boolean': {
+      if (value === 'true') return true;
+      if (value === 'false') return false;
+      return value;
+    }
+    case 'date': {
+      const number = Number(value);
+      if (!Number.isNaN(number)) return new Date(number);
+      const date = new Date(String(value));
+      return Number.isNaN(date.getTime()) ? value : date;
+    }
+    case 'number': {
+      const number = Number(value);
+      return Number.isNaN(number) ? value : number;
+    }
+    default: {
+      return value;
+    }
+  }
+}
+
+function decode(
+  schema: BaseSchema,
+  input: FormData,
+  key: string,
+  config?: SchemaConfig
+) {
+  let typed = true;
+  let issues: SchemaIssues | undefined;
+  let output: any;
+  switch (schema.type) {
+    case 'array': {
+      let arrayOutput: any[] | undefined;
+      const itemSchema = (schema as ArraySchema<BaseSchema>).item;
+      if (input.get(key) !== null) {
+        arrayOutput = [];
+        for (const item of input.getAll(key)) {
+          const value = decodeEntry(itemSchema, item);
+          const result = itemSchema._parse(value, config);
+          if (result.issues) {
+            if (!issues) issues = result.issues;
+            if (config?.abortEarly) {
+              typed = false;
+              break;
+            }
+          }
+          if (!result.typed) typed = false;
+          if (result.output !== undefined) arrayOutput.push(result.output);
+        }
+      } else {
+        let index = 0;
+        let result;
+        do {
+          const arrayKey = `${key}.${index}`;
+          result = decode(itemSchema, input, arrayKey, config);
+          if (result.issues) {
+            const pathItem: FormDataPathItem = {
+              type: 'formData',
+              origin: 'value',
+              input,
+              key: arrayKey,
+              value: result.output ?? input.get(arrayKey),
+            };
+            for (const issue of result.issues) {
+              if (issue.path) issue.path.unshift(pathItem);
+              else issue.path = [pathItem];
+              issues?.push(issue);
+            }
+            if (!issues) issues = result.issues;
+            if (config?.abortEarly) {
+              typed = false;
+              break;
+            }
+          }
+          if (!result.typed) typed = false;
+          if (result.output !== undefined) {
+            arrayOutput ??= [];
+            arrayOutput.push(result.output);
+          }
+          index++;
+        } while (result.output !== undefined);
+      }
+      output = arrayOutput;
+      break;
+    }
+    case 'object': {
+      let objectOutput: Record<string, any> | undefined;
+      const objectSchema = schema as ObjectSchema<
+        Record<string, BaseSchema>,
+        undefined
+      >;
+      for (const [objectKey, entrySchema] of Object.entries(
+        objectSchema.entries
+      )) {
+        const decodeKey = key ? `${key}.${objectKey}` : objectKey;
+        const result = decode(entrySchema, input, decodeKey, config);
+        if (result.output !== undefined) {
+          objectOutput ??= {};
+          objectOutput[objectKey] = result.output;
+        }
+        if (result.issues) {
+          const pathItem: FormDataPathItem = {
+            type: 'formData',
+            origin: 'value',
+            input,
+            key: decodeKey,
+            value: result.output ?? input.get(decodeKey),
+          };
+          for (const issue of result.issues) {
+            if (issue.path) issue.path.unshift(pathItem);
+            else issue.path = [pathItem];
+            issues?.push(issue);
+          }
+          if (!issues) issues = result.issues;
+          if (config?.abortEarly) {
+            typed = false;
+            break;
+          }
+        }
+        if (!result.typed) typed = false;
+      }
+      output = objectOutput;
+      break;
+    }
+    default: {
+      const value = decodeEntry(schema, input.get(key));
+      const result = schema._parse(value, config);
+      if (result.issues) issues = result.issues;
+      if (!result.typed) typed = false;
+      output = result.output;
+    }
+  }
+  return { typed, output, issues };
+}
+
+/**
+ * Creates a formData schema.
+ *
+ * @param entries The object entries.
+ * @param pipe A validation and transformation pipe.
+ *
+ * @returns A formData schema.
+ */
+export function formData<TEntries extends ObjectEntries>(
+  entries: TEntries | ObjectSchema<TEntries, undefined>,
+  pipe?: Pipe<ObjectOutput<TEntries, undefined>>
+): FormDataSchema<TEntries>;
+
+/**
+ * Creates a formData schema.
+ *
+ * @param entries The object entries.
+ * @param message The error message.
+ * @param pipe A validation and transformation pipe.
+ *
+ * @returns A formData schema.
+ */
+export function formData<TEntries extends ObjectEntries>(
+  entries: TEntries | ObjectSchema<TEntries, undefined>,
+  message?: ErrorMessage,
+  pipe?: Pipe<ObjectOutput<TEntries, undefined>>
+): FormDataSchema<TEntries>;
+
+export function formData<TEntries extends ObjectEntries>(
+  entries: TEntries | ObjectSchema<TEntries, undefined>,
+  arg2?: ErrorMessage | Pipe<ObjectOutput<TEntries, undefined>>,
+  arg3?: Pipe<ObjectOutput<TEntries, undefined>>
+): FormDataSchema<TEntries> {
+  // Get message and pipe argument
+  const [message, pipe] = defaultArgs(arg2, arg3);
+
+  // Create and return array schema
+  return {
+    type: 'formData',
+    expects: 'FormData',
+    async: false,
+    entries,
+    message,
+    pipe,
+    _parse(input, config) {
+      // If root type is valid, check nested types
+      if (input instanceof FormData) {
+        // Parse nested schema, decode and validate FormData against it
+        const schema =
+          entries.type === 'object'
+            ? (entries as ObjectSchema<TEntries, undefined>)
+            : object(entries as TEntries);
+        const result = decode(schema, input, '', config);
+
+        // If output is typed, return pipe result
+        if (result.typed) {
+          return pipeResult(
+            this,
+            (result.output || {}) as ObjectOutput<TEntries, undefined>,
+            config,
+            result.issues
+          );
+        }
+
+        // Otherwise, return untyped schema result
+        return schemaResult(
+          false,
+          result.output,
+          result.issues as SchemaIssues
+        );
+      }
+
+      // Otherwise, return schema issue
+      return schemaIssue(this, formData, input, config);
+    },
+  };
+}

--- a/library/src/schemas/formData/formDataAsync.ts
+++ b/library/src/schemas/formData/formDataAsync.ts
@@ -1,0 +1,282 @@
+import type {
+  BaseSchemaAsync,
+  ErrorMessage,
+  PipeAsync,
+  SchemaConfig,
+  SchemaIssues,
+} from '../../types/index.ts';
+import {
+  defaultArgs,
+  pipeResultAsync,
+  schemaIssue,
+  schemaResult,
+} from '../../utils/index.ts';
+import type { ArraySchemaAsync } from '../array/arrayAsync.ts';
+import type {
+  ObjectEntriesAsync,
+  ObjectSchemaAsync,
+} from '../object/objectAsync.ts';
+import { objectAsync } from '../object/objectAsync.ts';
+import type { ObjectOutput } from '../object/types.ts';
+import type { FormDataPathItem } from './types.ts';
+
+/**
+ * FormDataAsync schema type.
+ */
+export interface FormDataAsyncSchema<
+  TEntries extends ObjectEntriesAsync,
+  TOutput = ObjectOutput<TEntries, undefined>,
+> extends BaseSchemaAsync<FormData, TOutput> {
+  /**
+   * The schema type.
+   */
+  type: 'formData';
+  /**
+   * The object entries.
+   */
+  entries: TEntries | ObjectSchemaAsync<TEntries, undefined>;
+  /**
+   * The error message.
+   */
+  message: ErrorMessage | undefined;
+  /**
+   * The validation and transformation pipeline.
+   */
+  pipe: PipeAsync<TOutput> | undefined;
+}
+
+function decodeEntry(
+  schema: BaseSchemaAsync,
+  value: FormDataEntryValue | null
+) {
+  if (value === null) return undefined;
+  if (value === '') return null;
+  switch (schema.type) {
+    case 'boolean': {
+      if (value === 'true') return true;
+      if (value === 'false') return false;
+      return value;
+    }
+    case 'date': {
+      const number = Number(value);
+      if (!Number.isNaN(number)) return new Date(number);
+      const date = new Date(String(value));
+      return Number.isNaN(date.getTime()) ? value : date;
+    }
+    case 'number': {
+      const number = Number(value);
+      return Number.isNaN(number) ? value : number;
+    }
+    default: {
+      return value;
+    }
+  }
+}
+
+async function decode(
+  schema: BaseSchemaAsync,
+  input: FormData,
+  key: string,
+  config?: SchemaConfig
+) {
+  let typed = true;
+  let issues: SchemaIssues | undefined;
+  let output: any;
+  switch (schema.type) {
+    case 'array': {
+      let arrayOutput: any[] = [];
+      const arraySchema = schema as ArraySchemaAsync<BaseSchemaAsync>;
+      const itemSchema = arraySchema.item;
+      const items = input.getAll(key);
+      if (items.length > 0) {
+        arrayOutput = Array(items.length);
+        await Promise.all(
+          items.map(async (item, index) => {
+            const value = decodeEntry(itemSchema, item);
+            const result = await itemSchema._parse(value, config);
+            if (issues && config?.abortEarly) throw null;
+            if (result.issues) {
+              if (!issues) issues = result.issues;
+              if (config?.abortEarly) {
+                typed = false;
+                throw null;
+              }
+            }
+            if (!result.typed) typed = false;
+            if (result.output !== undefined) arrayOutput[index] = result.output;
+          })
+        ).catch(() => null);
+      } else {
+        let index = 0;
+        let result;
+        do {
+          const arrayKey = `${key}.${index}`;
+          result = await decode(itemSchema, input, arrayKey, config);
+          if (result.issues) {
+            if (!issues) issues = result.issues;
+            if (config?.abortEarly) {
+              typed = false;
+              break;
+            }
+          }
+          if (!result.typed) typed = false;
+          if (result.output !== undefined) {
+            arrayOutput.push(result.output);
+          }
+          index++;
+        } while (result.output !== undefined && !result.issues);
+      }
+      if (arrayOutput.length === 0) {
+        issues = schemaIssue(arraySchema, formDataAsync, arrayOutput, config, {
+          issues,
+        }).issues;
+      } else {
+        output = arrayOutput;
+      }
+      break;
+    }
+    case 'object': {
+      let objectOutput: Record<string, any> | undefined;
+      const objectSchema = schema as ObjectSchemaAsync<
+        Record<string, BaseSchemaAsync>,
+        undefined
+      >;
+      await Promise.all(
+        Object.entries(objectSchema.entries).map(
+          async ([objectKey, entrySchema]) => {
+            const decodeKey = key ? `${key}.${objectKey}` : objectKey;
+            const result = await decode(entrySchema, input, decodeKey, config);
+            if (issues && config?.abortEarly) throw null;
+            if (result.output !== undefined) {
+              objectOutput ??= {};
+              objectOutput[objectKey] = result.output;
+            }
+            if (result.issues) {
+              const pathItem: FormDataPathItem = {
+                type: 'formData',
+                origin: 'value',
+                input,
+                key: decodeKey,
+                value: result.output ?? input.get(decodeKey),
+              };
+              for (const issue of result.issues) {
+                if (issue.path) issue.path.unshift(pathItem);
+                else issue.path = [pathItem];
+                issues?.push(issue);
+              }
+              if (!issues) issues = result.issues;
+              if (config?.abortEarly) {
+                typed = false;
+                throw null;
+              }
+            }
+            if (!result.typed) typed = false;
+          }
+        )
+      ).catch(() => null);
+      if (!objectOutput) {
+        if (key) {
+          issues = schemaIssue(
+            objectSchema,
+            formDataAsync,
+            objectOutput,
+            config,
+            {
+              issues,
+            }
+          ).issues;
+        } else {
+          objectOutput = {};
+        }
+      }
+      output = objectOutput;
+      break;
+    }
+    default: {
+      const value = decodeEntry(schema, input.get(key));
+      const result = await schema._parse(value, config);
+      if (result.issues) issues = result.issues;
+      if (!result.typed) typed = false;
+      output = result.output;
+    }
+  }
+  return { typed, output, issues };
+}
+
+/**
+ * Creates a formDataAsync schema.
+ *
+ * @param entries The object entries.
+ * @param pipe A validation and transformation pipe.
+ *
+ * @returns A formDataAsync schema.
+ */
+export function formDataAsync<TEntries extends ObjectEntriesAsync>(
+  entries: TEntries | ObjectSchemaAsync<TEntries, undefined>,
+  pipe?: PipeAsync<ObjectOutput<TEntries, undefined>>
+): FormDataAsyncSchema<TEntries>;
+
+/**
+ * Creates a formDataAsync schema.
+ *
+ * @param entries The object entries.
+ * @param message The error message.
+ * @param pipe A validation and transformation pipe.
+ *
+ * @returns A formDataAsync schema.
+ */
+export function formDataAsync<TEntries extends ObjectEntriesAsync>(
+  entries: TEntries | ObjectSchemaAsync<TEntries, undefined>,
+  message?: ErrorMessage,
+  pipe?: PipeAsync<ObjectOutput<TEntries, undefined>>
+): FormDataAsyncSchema<TEntries>;
+
+export function formDataAsync<TEntries extends ObjectEntriesAsync>(
+  entries: TEntries | ObjectSchemaAsync<TEntries, undefined>,
+  arg2?: ErrorMessage | PipeAsync<ObjectOutput<TEntries, undefined>>,
+  arg3?: PipeAsync<ObjectOutput<TEntries, undefined>>
+): FormDataAsyncSchema<TEntries> {
+  // Get message and pipe argument
+  const [message, pipe] = defaultArgs(arg2, arg3);
+
+  // Create and return array schema
+  return {
+    type: 'formData',
+    expects: 'FormData',
+    async: true,
+    entries,
+    message,
+    pipe,
+    async _parse(input, config) {
+      // If root type is valid, check nested types
+      if (input instanceof FormData) {
+        // Parse nested schema, decode and validate FormData against it
+        const schema =
+          entries.type === 'object'
+            ? (entries as ObjectSchemaAsync<TEntries, undefined>)
+            : objectAsync(entries as TEntries);
+        const result = await decode(schema, input, '', config);
+
+        // If output is typed, return pipe result
+        if (result.typed) {
+          return pipeResultAsync(
+            this,
+            result.output as ObjectOutput<TEntries, undefined>,
+            config,
+            result.issues
+          );
+        }
+
+        // Otherwise, return untyped schema result
+        return schemaResult(
+          false,
+          result.output,
+          result.issues as SchemaIssues
+        );
+      }
+
+      // Otherwise, return schema issue
+      return schemaIssue(this, formDataAsync, input, config);
+    },
+  };
+}

--- a/library/src/schemas/formData/index.ts
+++ b/library/src/schemas/formData/index.ts
@@ -1,0 +1,2 @@
+export * from './formData.ts';
+export * from './types.ts';

--- a/library/src/schemas/formData/index.ts
+++ b/library/src/schemas/formData/index.ts
@@ -1,2 +1,3 @@
 export * from './formData.ts';
+export * from './formDataAsync.ts';
 export * from './types.ts';

--- a/library/src/schemas/formData/types.ts
+++ b/library/src/schemas/formData/types.ts
@@ -1,0 +1,10 @@
+/**
+ * FormData path item type.
+ */
+export interface FormDataPathItem {
+  type: 'formData';
+  origin: 'value';
+  input: FormData;
+  key: string;
+  value: any;
+}

--- a/library/src/schemas/index.ts
+++ b/library/src/schemas/index.ts
@@ -5,6 +5,7 @@ export * from './blob/index.ts';
 export * from './boolean/index.ts';
 export * from './date/index.ts';
 export * from './enum/index.ts';
+export * from './formData/index.ts';
 export * from './instance/index.ts';
 export * from './intersect/index.ts';
 export * from './lazy/index.ts';

--- a/library/src/types/issues.ts
+++ b/library/src/types/issues.ts
@@ -1,5 +1,6 @@
 import type {
   ArrayPathItem,
+  FormDataPathItem,
   MapPathItem,
   ObjectPathItem,
   RecordPathItem,
@@ -19,6 +20,7 @@ export type IssueReason =
   | 'blob'
   | 'boolean'
   | 'date'
+  | 'formData'
   | 'intersect'
   | 'function'
   | 'instance'
@@ -53,6 +55,7 @@ export interface UnknownPathItem {
  */
 export type PathItem =
   | ArrayPathItem
+  | FormDataPathItem
   | MapPathItem
   | ObjectPathItem
   | RecordPathItem


### PR DESCRIPTION
Fixes https://github.com/fabian-hiller/valibot/issues/81, implements the suggestion from https://github.com/fabian-hiller/decode-formdata/issues/10.

This PR introduces a new formData schema that enables the extraction and validation of required FormData directly from the server. Here’s how it works:

For example, if you send the following FormData to the server:
```html
<form enctype="multipart/form-data" method="post">
  <input name="title" type="text" value="Red apple" />
  <input name="price" type="number" value="0.89" />
  <input name="created" type="date" value="2024-04-12T07:00:00.000Z" />
  <input name="active" type="checkbox" value="true" />
  <input name="tags" type="text" value="fruit" />
  <input name="tags" type="text" value="healthy" />
  <input name="tags" type="text" value="sweet" />
  <input name="images.0.title" type="text" value="Close up of an apple" />
  <input name="images.0.created" type="date" value="2024-04-12T07:01:00.000Z" />
  <input name="images.0.file" type="file" value="a.jpg" />
  <input name="images.0.tags" type="text" value="foo" />
  <input name="images.0.tags" type="text" value="bar" />
  <input name="images.1.title" type="text" value="Our fruit fields at Lake Constance" />
  <input name="images.1.created" type="date" value="2024-04-12T07:02:00.000Z" />
  <input name="images.1.file" type="file" value="b.jpg" />
  <input name="images.1.tags" type="text" value="baz" />
</form>
```
You can now define a validation schema like this:
```ts
import * as v from 'valibot';

const MySchema = v.formData({
  title: v.string(),
  price: v.number(),
  created: v.date(),
  active: v.boolean(),
  tags: v.array(v.string()),
  images: v.array(
    v.object({
      title: v.string(),
      created: v.date(),
      file: v.blob(),
      tags: v.array(v.string())
    })
  ),
});
```
You can use this schema to extract and validate the required info:
```ts
import { parse } from 'valibot'

async function server(formData: FormData) {
  const data = parse(MySchema, formData)
}
```
This will give you validated and typed form data like this:
```ts
const data = {
  title: 'Red apple',
  price: 0.89,
  created: Date,
  active: true,
  tags: ['fruit', 'healthy', 'sweet'],
  images: [
    {
      title: 'Close up of an apple',
      created: Date,
      file: File,
      tags: ['foo', 'bar'],
    },
    {
      title: 'Our fruit fields at Lake Constance',
      created: Date,
      file: File,
      tags: ['baz'],
    },
  ],
}
```

This PR streamlines the way we handle and validate `FormData` from the client, ensuring the data is correctly typed and validated upon reception.