### PR TITLE
feat(rewrite-with-pipe): add `isoTimeSecond` validation

### DIFF
--- a/library/src/actions/index.ts
+++ b/library/src/actions/index.ts
@@ -22,6 +22,7 @@ export * from './ipv6/index.ts';
 export * from './isoDate/index.ts';
 export * from './isoDateTime/index.ts';
 export * from './isoTime/index.ts';
+export * from './isoTimeSecond/index.ts';
 export * from './isoTimestamp/index.ts';
 export * from './length/index.ts';
 export * from './mac/index.ts';

--- a/library/src/actions/isoTime/isoTime.test.ts
+++ b/library/src/actions/isoTime/isoTime.test.ts
@@ -93,25 +93,24 @@ describe('isoTime', () => {
       expectActionIssue(action, baseIssue, ['+00:00', '-12:34', '+23:59']);
     });
 
-    test('for missing digits', () => {
-      expectActionIssue(action, baseIssue, ['0:00', '00:0', '1:23', '12:3']);
-    });
-
-    test('for too many digits', () => {
+    test('for invalid hour', () => {
       expectActionIssue(action, baseIssue, [
-        '00:000',
-        '000:00',
-        '12:345',
-        '123:45',
+        ':00', // missing digits
+        '0:00', // 1 digit
+        '000:00', // 3 digits
+        '24:00', // 24
+        '99:00', // 99
       ]);
     });
 
-    test('for hours greater than 23', () => {
-      expectActionIssue(action, baseIssue, ['24:00', '99:00']);
-    });
-
-    test('for minutes greater than 59', () => {
-      expectActionIssue(action, baseIssue, ['00:60', '00:99']);
+    test('for invalid minute', () => {
+      expectActionIssue(action, baseIssue, [
+        '00:', // missing digits
+        '00:0', // 1 digit
+        '00:000', // 3 digits
+        '00:60', // 60
+        '00:99', // 99
+      ]);
     });
   });
 });

--- a/library/src/actions/isoTimeSecond/index.ts
+++ b/library/src/actions/isoTimeSecond/index.ts
@@ -1,0 +1,1 @@
+export * from './isoTimeSecond.ts';

--- a/library/src/actions/isoTimeSecond/isoTimeSecond.test-d.ts
+++ b/library/src/actions/isoTimeSecond/isoTimeSecond.test-d.ts
@@ -1,0 +1,49 @@
+import { describe, expectTypeOf, test } from 'vitest';
+import type { InferInput, InferIssue, InferOutput } from '../../types/index.ts';
+import {
+  isoTimeSecond,
+  type IsoTimeSecondAction,
+  type IsoTimeSecondIssue,
+} from './isoTimeSecond.ts';
+
+describe('isoTimeSecond', () => {
+  describe('should return action object', () => {
+    test('with undefined message', () => {
+      type Action = IsoTimeSecondAction<string, undefined>;
+      expectTypeOf(isoTimeSecond<string>()).toEqualTypeOf<Action>();
+      expectTypeOf(
+        isoTimeSecond<string, undefined>(undefined)
+      ).toEqualTypeOf<Action>();
+    });
+
+    test('with string message', () => {
+      expectTypeOf(isoTimeSecond<string, 'message'>('message')).toEqualTypeOf<
+        IsoTimeSecondAction<string, 'message'>
+      >();
+    });
+
+    test('with function message', () => {
+      expectTypeOf(
+        isoTimeSecond<string, () => string>(() => 'message')
+      ).toEqualTypeOf<IsoTimeSecondAction<string, () => string>>();
+    });
+  });
+
+  describe('should infer correct types', () => {
+    type Action = IsoTimeSecondAction<string, undefined>;
+
+    test('of input', () => {
+      expectTypeOf<InferInput<Action>>().toEqualTypeOf<string>();
+    });
+
+    test('of output', () => {
+      expectTypeOf<InferOutput<Action>>().toEqualTypeOf<string>();
+    });
+
+    test('of issue', () => {
+      expectTypeOf<InferIssue<Action>>().toEqualTypeOf<
+        IsoTimeSecondIssue<string>
+      >();
+    });
+  });
+});

--- a/library/src/actions/isoTimeSecond/isoTimeSecond.test.ts
+++ b/library/src/actions/isoTimeSecond/isoTimeSecond.test.ts
@@ -55,7 +55,7 @@ describe('isoTimeSecond', () => {
       });
     });
 
-    test('for valid ISO times', () => {
+    test('for valid ISO time seconds', () => {
       expectNoActionIssue(action, ['00:00:00', '12:34:56', '23:59:59']);
     });
   });

--- a/library/src/actions/isoTimeSecond/isoTimeSecond.test.ts
+++ b/library/src/actions/isoTimeSecond/isoTimeSecond.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'vitest';
+import { ISO_TIME_SECOND_REGEX } from '../../regex.ts';
+import { expectActionIssue } from '../../vitest/expectActionIssue.ts';
+import { expectNoActionIssue } from '../../vitest/expectNoActionIssue.ts';
+import {
+  isoTimeSecond,
+  type IsoTimeSecondAction,
+  type IsoTimeSecondIssue,
+} from './isoTimeSecond.ts';
+
+describe('isoTimeSecond', () => {
+  describe('should return action object', () => {
+    const baseAction: Omit<IsoTimeSecondAction<string, never>, 'message'> = {
+      kind: 'validation',
+      type: 'iso_time_second',
+      reference: isoTimeSecond,
+      expects: null,
+      requirement: ISO_TIME_SECOND_REGEX,
+      async: false,
+      _run: expect.any(Function),
+    };
+
+    test('with undefined message', () => {
+      const action: IsoTimeSecondAction<string, undefined> = {
+        ...baseAction,
+        message: undefined,
+      };
+      expect(isoTimeSecond()).toStrictEqual(action);
+      expect(isoTimeSecond(undefined)).toStrictEqual(action);
+    });
+
+    test('with string message', () => {
+      expect(isoTimeSecond('message')).toStrictEqual({
+        ...baseAction,
+        message: 'message',
+      } satisfies IsoTimeSecondAction<string, string>);
+    });
+
+    test('with function message', () => {
+      const message = () => 'message';
+      expect(isoTimeSecond(message)).toStrictEqual({
+        ...baseAction,
+        message,
+      } satisfies IsoTimeSecondAction<string, typeof message>);
+    });
+  });
+
+  describe('should return dataset without issues', () => {
+    const action = isoTimeSecond();
+
+    test('for untyped inputs', () => {
+      expect(action._run({ typed: false, value: null }, {})).toStrictEqual({
+        typed: false,
+        value: null,
+      });
+    });
+
+    test('for valid ISO times', () => {
+      expectNoActionIssue(action, ['00:00:00', '12:34:56', '23:59:59']);
+    });
+  });
+
+  describe('should return dataset with issues', () => {
+    const action = isoTimeSecond('message');
+    const baseIssue: Omit<IsoTimeSecondIssue<string>, 'input' | 'received'> = {
+      kind: 'validation',
+      type: 'iso_time_second',
+      expected: null,
+      message: 'message',
+      requirement: ISO_TIME_SECOND_REGEX,
+    };
+
+    test('for empty strings', () => {
+      expectActionIssue(action, baseIssue, ['', ' ', '\n']);
+    });
+
+    test('for blank spaces', () => {
+      expectActionIssue(action, baseIssue, [
+        ' 00:00:00',
+        '00:00:00 ',
+        ' 00:00:00 ',
+      ]);
+    });
+
+    test('for missing separators', () => {
+      expectActionIssue(action, baseIssue, ['0000:00', '00:0000', '000000']);
+    });
+
+    test('for double separators', () => {
+      expectActionIssue(action, baseIssue, [
+        '00::00:00',
+        '00:00::00',
+        '00::00::00',
+      ]);
+    });
+
+    test('for wrong separators', () => {
+      expectActionIssue(action, baseIssue, [
+        '00 00 00',
+        '00/00/00',
+        '00H00M00',
+        '00_00_00',
+        '00.00.00',
+      ]);
+    });
+
+    test('for mathematical signs', () => {
+      expectActionIssue(action, baseIssue, [
+        '+00:00:00',
+        '-12:34:56',
+        '+23:59:59',
+      ]);
+    });
+
+    test('for invalid hour', () => {
+      expectActionIssue(action, baseIssue, [
+        ':00:00', // missing digits
+        '0:00:00', // 1 digit
+        '000:00:00', // 3 digits
+        '24:00:00', // 24
+        '99:00:00', // 99
+      ]);
+    });
+
+    test('for invalid minute', () => {
+      expectActionIssue(action, baseIssue, [
+        '00::00', // missing digits
+        '00:0:00', // 1 digit
+        '00:000:00', // 3 digits
+        '00:60:00', // 60
+        '00:99:00', // 99
+      ]);
+    });
+
+    test('for invalid second', () => {
+      expectActionIssue(action, baseIssue, [
+        '00:00:', // missing digits
+        '00:00:0', // 1 digit
+        '00:00:000', // 3 digits
+        '00:00:60', // 60
+        '00:00:99', // 99
+      ]);
+    });
+  });
+});

--- a/library/src/actions/isoTimeSecond/isoTimeSecond.ts
+++ b/library/src/actions/isoTimeSecond/isoTimeSecond.ts
@@ -8,7 +8,7 @@ import type {
 import { _addIssue } from '../../utils/index.ts';
 
 /**
- * ISO time with seconds issue type.
+ * ISO time second issue type.
  */
 export interface IsoTimeSecondIssue<TInput extends string>
   extends BaseIssue<TInput> {
@@ -35,7 +35,7 @@ export interface IsoTimeSecondIssue<TInput extends string>
 }
 
 /**
- * ISO time with seconds action type.
+ * ISO time second action type.
  */
 export interface IsoTimeSecondAction<
   TInput extends string,
@@ -54,7 +54,7 @@ export interface IsoTimeSecondAction<
    */
   readonly expects: null;
   /**
-   * The ISO time with seconds regex.
+   * The ISO time second regex.
    */
   readonly requirement: RegExp;
   /**
@@ -64,11 +64,11 @@ export interface IsoTimeSecondAction<
 }
 
 /**
- * Creates an [ISO time with seconds](https://en.wikipedia.org/wiki/ISO_8601) validation action.
+ * Creates an [ISO time second](https://en.wikipedia.org/wiki/ISO_8601) validation action.
  *
  * Format: hh:mm:ss
  *
- * @returns An ISO time with seconds action.
+ * @returns An ISO time second action.
  */
 export function isoTimeSecond<TInput extends string>(): IsoTimeSecondAction<
   TInput,
@@ -76,13 +76,13 @@ export function isoTimeSecond<TInput extends string>(): IsoTimeSecondAction<
 >;
 
 /**
- * Creates an [ISO time with seconds](https://en.wikipedia.org/wiki/ISO_8601) validation action.
+ * Creates an [ISO time second](https://en.wikipedia.org/wiki/ISO_8601) validation action.
  *
  * Format: hh:mm:ss
  *
  * @param message The error message.
  *
- * @returns An ISO time with seconds action.
+ * @returns An ISO time second action.
  */
 export function isoTimeSecond<
   TInput extends string,

--- a/library/src/actions/isoTimeSecond/isoTimeSecond.ts
+++ b/library/src/actions/isoTimeSecond/isoTimeSecond.ts
@@ -1,0 +1,113 @@
+import { ISO_TIME_SECOND_REGEX } from '../../regex.ts';
+import type {
+  BaseIssue,
+  BaseValidation,
+  Dataset,
+  ErrorMessage,
+} from '../../types/index.ts';
+import { _addIssue } from '../../utils/index.ts';
+
+/**
+ * ISO time with seconds issue type.
+ */
+export interface IsoTimeSecondIssue<TInput extends string>
+  extends BaseIssue<TInput> {
+  /**
+   * The issue kind.
+   */
+  readonly kind: 'validation';
+  /**
+   * The issue type.
+   */
+  readonly type: 'iso_time_second';
+  /**
+   * The expected input.
+   */
+  readonly expected: null;
+  /**
+   * The received input.
+   */
+  readonly received: `"${string}"`;
+  /**
+   * The ISO time with seconds regex.
+   */
+  readonly requirement: RegExp;
+}
+
+/**
+ * ISO time with seconds action type.
+ */
+export interface IsoTimeSecondAction<
+  TInput extends string,
+  TMessage extends ErrorMessage<IsoTimeSecondIssue<TInput>> | undefined,
+> extends BaseValidation<TInput, TInput, IsoTimeSecondIssue<TInput>> {
+  /**
+   * The action type.
+   */
+  readonly type: 'iso_time_second';
+  /**
+   * The action reference.
+   */
+  readonly reference: typeof isoTimeSecond;
+  /**
+   * The expected property.
+   */
+  readonly expects: null;
+  /**
+   * The ISO time with seconds regex.
+   */
+  readonly requirement: RegExp;
+  /**
+   * The error message.
+   */
+  readonly message: TMessage;
+}
+
+/**
+ * Creates an [ISO time with seconds](https://en.wikipedia.org/wiki/ISO_8601) validation action.
+ *
+ * Format: hh:mm:ss
+ *
+ * @returns An ISO time with seconds action.
+ */
+export function isoTimeSecond<TInput extends string>(): IsoTimeSecondAction<
+  TInput,
+  undefined
+>;
+
+/**
+ * Creates an [ISO time with seconds](https://en.wikipedia.org/wiki/ISO_8601) validation action.
+ *
+ * Format: hh:mm:ss
+ *
+ * @param message The error message.
+ *
+ * @returns An ISO time with seconds action.
+ */
+export function isoTimeSecond<
+  TInput extends string,
+  const TMessage extends ErrorMessage<IsoTimeSecondIssue<TInput>> | undefined,
+>(message: TMessage): IsoTimeSecondAction<TInput, TMessage>;
+
+export function isoTimeSecond(
+  message?: ErrorMessage<IsoTimeSecondIssue<string>>
+): IsoTimeSecondAction<
+  string,
+  ErrorMessage<IsoTimeSecondIssue<string>> | undefined
+> {
+  return {
+    kind: 'validation',
+    type: 'iso_time_second',
+    reference: isoTimeSecond,
+    async: false,
+    expects: null,
+    requirement: ISO_TIME_SECOND_REGEX,
+    message,
+    _run(dataset, config) {
+      if (dataset.typed && !this.requirement.test(dataset.value)) {
+        _addIssue(this, 'time-second', dataset, config);
+      }
+      return dataset as Dataset<string, IsoTimeSecondIssue<string>>;
+    },
+  };
+}


### PR DESCRIPTION
Part of #502 