### PR TITLE
feat(rewrite-with-pipe): add `isoWeek` action

### DIFF
--- a/library/src/actions/index.ts
+++ b/library/src/actions/index.ts
@@ -23,6 +23,7 @@ export * from './isoDate/index.ts';
 export * from './isoDateTime/index.ts';
 export * from './isoTime/index.ts';
 export * from './isoTimestamp/index.ts';
+export * from './isoWeek/index.ts';
 export * from './length/index.ts';
 export * from './mac/index.ts';
 export * from './mac48/index.ts';

--- a/library/src/actions/isoWeek/index.ts
+++ b/library/src/actions/isoWeek/index.ts
@@ -1,0 +1,1 @@
+export * from './isoWeek.ts';

--- a/library/src/actions/isoWeek/isoWeek.test-d.ts
+++ b/library/src/actions/isoWeek/isoWeek.test-d.ts
@@ -1,0 +1,43 @@
+import { describe, expectTypeOf, test } from 'vitest';
+import type { InferInput, InferIssue, InferOutput } from '../../types/index.ts';
+import { isoWeek, type IsoWeekAction, type IsoWeekIssue } from './isoWeek.ts';
+
+describe('isoWeek', () => {
+  describe('should return action object', () => {
+    test('with undefined message', () => {
+      type Action = IsoWeekAction<string, undefined>;
+      expectTypeOf(isoWeek<string>()).toEqualTypeOf<Action>();
+      expectTypeOf(
+        isoWeek<string, undefined>(undefined)
+      ).toEqualTypeOf<Action>();
+    });
+
+    test('with string message', () => {
+      expectTypeOf(isoWeek<string, 'message'>('message')).toEqualTypeOf<
+        IsoWeekAction<string, 'message'>
+      >();
+    });
+
+    test('with function message', () => {
+      expectTypeOf(
+        isoWeek<string, () => string>(() => 'message')
+      ).toEqualTypeOf<IsoWeekAction<string, () => string>>();
+    });
+  });
+
+  describe('should infer correct types', () => {
+    type Action = IsoWeekAction<string, undefined>;
+
+    test('of input', () => {
+      expectTypeOf<InferInput<Action>>().toEqualTypeOf<string>();
+    });
+
+    test('of output', () => {
+      expectTypeOf<InferOutput<Action>>().toEqualTypeOf<string>();
+    });
+
+    test('of issue', () => {
+      expectTypeOf<InferIssue<Action>>().toEqualTypeOf<IsoWeekIssue<string>>();
+    });
+  });
+});

--- a/library/src/actions/isoWeek/isoWeek.test.ts
+++ b/library/src/actions/isoWeek/isoWeek.test.ts
@@ -56,7 +56,7 @@ describe('isoWeek', () => {
     });
 
     test('for valid ISO date times', () => {
-      expectNoActionIssue(action, ['0000-W01', '9999-W24', '2023-W53']);
+      expectNoActionIssue(action, ['0000-W01', '2023-W29', '9999-W53']);
     });
   });
 
@@ -88,12 +88,15 @@ describe('isoWeek', () => {
 
     test('for wrong separators', () => {
       expectActionIssue(action, baseIssue, [
+        '0000- 01',
         '0000-A01',
         '0000-Z01',
         '0000-w01',
         '0000.W01',
+        '0000–W01',
+        '0000 W01',
         '0000/W01',
-        '0000__01',
+        '0000_W01',
       ]);
     });
 
@@ -113,7 +116,7 @@ describe('isoWeek', () => {
         '0000-W0', // 1 digit
         '0000-W000', // 3 digits
         '0000-W00', // 00
-        '0000-W54', // 54 FIXME: - 2012 had 54 distinct weeks
+        '0000-W54', // 54
         '0000-W99', // 99
       ]);
     });

--- a/library/src/actions/isoWeek/isoWeek.test.ts
+++ b/library/src/actions/isoWeek/isoWeek.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'vitest';
+import { ISO_WEEK_REGEX } from '../../regex.ts';
+import { expectActionIssue } from '../../vitest/expectActionIssue.ts';
+import { expectNoActionIssue } from '../../vitest/expectNoActionIssue.ts';
+import {
+  isoWeek,
+  type IsoWeekIssue as IsoWeek,
+  type IsoWeekAction,
+} from './isoWeek.ts';
+
+describe('isoWeek', () => {
+  describe('should return action object', () => {
+    const baseAction: Omit<IsoWeekAction<string, never>, 'message'> = {
+      kind: 'validation',
+      type: 'iso_week',
+      reference: isoWeek,
+      expects: null,
+      requirement: ISO_WEEK_REGEX,
+      async: false,
+      _run: expect.any(Function),
+    };
+
+    test('with undefined message', () => {
+      const action: IsoWeekAction<string, undefined> = {
+        ...baseAction,
+        message: undefined,
+      };
+      expect(isoWeek()).toStrictEqual(action);
+      expect(isoWeek(undefined)).toStrictEqual(action);
+    });
+
+    test('with string message', () => {
+      expect(isoWeek('message')).toStrictEqual({
+        ...baseAction,
+        message: 'message',
+      } satisfies IsoWeekAction<string, string>);
+    });
+
+    test('with function message', () => {
+      const message = () => 'message';
+      expect(isoWeek(message)).toStrictEqual({
+        ...baseAction,
+        message,
+      } satisfies IsoWeekAction<string, typeof message>);
+    });
+  });
+
+  describe('should return dataset without issues', () => {
+    const action = isoWeek();
+
+    test('for untyped inputs', () => {
+      expect(action._run({ typed: false, value: null }, {})).toStrictEqual({
+        typed: false,
+        value: null,
+      });
+    });
+
+    test('for valid ISO date times', () => {
+      expectNoActionIssue(action, ['0000-W01', '9999-W24', '2023-W53']);
+    });
+  });
+
+  describe('should return dataset with issues', () => {
+    const action = isoWeek('message');
+    const baseIssue: Omit<IsoWeek<string>, 'input' | 'received'> = {
+      kind: 'validation',
+      type: 'iso_week',
+      expected: null,
+      message: 'message',
+      requirement: ISO_WEEK_REGEX,
+    };
+
+    test('for empty strings', () => {
+      expectActionIssue(action, baseIssue, ['', ' ', '\n']);
+    });
+
+    test('for blank spaces', () => {
+      expectActionIssue(action, baseIssue, [
+        ' 0000-W01',
+        '0000-W01 ',
+        ' 0000-W01 ',
+      ]);
+    });
+
+    test('for missing seperators', () => {
+      expectActionIssue(action, baseIssue, ['0000-01', '0000W01', '000001']);
+    });
+
+    test('for wrong separators', () => {
+      expectActionIssue(action, baseIssue, [
+        '0000-A01',
+        '0000-Z01',
+        '0000-w01',
+        '0000.W01',
+        '0000/W01',
+        '0000__01',
+      ]);
+    });
+
+    test('for invalid year', () => {
+      expectActionIssue(action, baseIssue, [
+        '-W01', // missing digits
+        '0-W01', // 1 digit
+        '00-W01', // 2 digit
+        '000-W01', // 3 digits
+        '00000-W01', // 5 digits
+      ]);
+    });
+
+    test('for invalid weeks', () => {
+      expectActionIssue(action, baseIssue, [
+        '0000-W', // missing digits
+        '0000-W0', // 1 digit
+        '0000-W000', // 3 digits
+        '0000-W00', // 00
+        '0000-W54', // 54 FIXME: - 2012 had 54 distinct weeks
+        '0000-W99', // 99
+      ]);
+    });
+  });
+});

--- a/library/src/actions/isoWeek/isoWeek.ts
+++ b/library/src/actions/isoWeek/isoWeek.ts
@@ -65,11 +65,10 @@ export interface IsoWeekAction<
 /**
  * Creates an [ISO week](https://en.wikipedia.org/wiki/ISO_8601) validation action.
  *
- * Format: yyyy-mm-ddThh:mm
+ * Format: yyyy-Www
  *
- * Hint: The regex used cannot validate the maximum number of days based on
- * year and month. For example, "2023-06-31T00:00" is valid although June has only
- * 30 days.
+ * Hint: The regex used cannot validate the maximum number of weeks based on
+ * the year. For example, "2021W53" is valid although 2021 has only 52 weeks.
  *
  * @returns An ISO week action.
  */
@@ -83,8 +82,8 @@ export function isoWeek<TInput extends string>(): IsoWeekAction<
  *
  * Format: yyyy-Www
  *
- * Hint: The regex used cannot validate the maximum number of weeks in a year.
- * For example, "2021W53" is valid although 2023 has only 52 weeks.
+ * Hint: The regex used cannot validate the maximum number of weeks based on
+ * the year. For example, "2021W53" is valid although 2021 has only 52 weeks.
  *
  * @param message The error message.
  *
@@ -108,7 +107,7 @@ export function isoWeek(
     message,
     _run(dataset, config) {
       if (dataset.typed && !this.requirement.test(dataset.value)) {
-        _addIssue(this, 'date-time', dataset, config);
+        _addIssue(this, 'week', dataset, config);
       }
       return dataset as Dataset<string, IsoWeekIssue<string>>;
     },

--- a/library/src/actions/isoWeek/isoWeek.ts
+++ b/library/src/actions/isoWeek/isoWeek.ts
@@ -1,0 +1,116 @@
+import { ISO_WEEK_REGEX } from '../../regex.ts';
+import type {
+  BaseIssue,
+  BaseValidation,
+  Dataset,
+  ErrorMessage,
+} from '../../types/index.ts';
+import { _addIssue } from '../../utils/index.ts';
+
+/**
+ * ISO week issue type.
+ */
+export interface IsoWeekIssue<TInput extends string> extends BaseIssue<TInput> {
+  /**
+   * The issue kind.
+   */
+  readonly kind: 'validation';
+  /**
+   * The issue type.
+   */
+  readonly type: 'iso_week';
+  /**
+   * The expected input.
+   */
+  readonly expected: null;
+  /**
+   * The received input.
+   */
+  readonly received: `"${string}"`;
+  /**
+   * The ISO week regex.
+   */
+  readonly requirement: RegExp;
+}
+
+/**
+ * ISO week action type.
+ */
+export interface IsoWeekAction<
+  TInput extends string,
+  TMessage extends ErrorMessage<IsoWeekIssue<TInput>> | undefined,
+> extends BaseValidation<TInput, TInput, IsoWeekIssue<TInput>> {
+  /**
+   * The action type.
+   */
+  readonly type: 'iso_week';
+  /**
+   * The action reference.
+   */
+  readonly reference: typeof isoWeek;
+  /**
+   * The expected property.
+   */
+  readonly expects: null;
+  /**
+   * The ISO week regex.
+   */
+  readonly requirement: RegExp;
+  /**
+   * The error message.
+   */
+  readonly message: TMessage;
+}
+
+/**
+ * Creates an [ISO week](https://en.wikipedia.org/wiki/ISO_8601) validation action.
+ *
+ * Format: yyyy-mm-ddThh:mm
+ *
+ * Hint: The regex used cannot validate the maximum number of days based on
+ * year and month. For example, "2023-06-31T00:00" is valid although June has only
+ * 30 days.
+ *
+ * @returns An ISO week action.
+ */
+export function isoWeek<TInput extends string>(): IsoWeekAction<
+  TInput,
+  undefined
+>;
+
+/**
+ * Creates an [ISO week](https://en.wikipedia.org/wiki/ISO_8601) validation action.
+ *
+ * Format: yyyy-Www
+ *
+ * Hint: The regex used cannot validate the maximum number of weeks in a year.
+ * For example, "2021W53" is valid although 2023 has only 52 weeks.
+ *
+ * @param message The error message.
+ *
+ * @returns An ISO week action.
+ */
+export function isoWeek<
+  TInput extends string,
+  const TMessage extends ErrorMessage<IsoWeekIssue<TInput>> | undefined,
+>(message: TMessage): IsoWeekAction<TInput, TMessage>;
+
+export function isoWeek(
+  message?: ErrorMessage<IsoWeekIssue<string>>
+): IsoWeekAction<string, ErrorMessage<IsoWeekIssue<string>> | undefined> {
+  return {
+    kind: 'validation',
+    type: 'iso_week',
+    reference: isoWeek,
+    async: false,
+    expects: null,
+    requirement: ISO_WEEK_REGEX,
+    message,
+    _run(dataset, config) {
+      if (dataset.typed && !this.requirement.test(dataset.value)) {
+        _addIssue(this, 'date-time', dataset, config);
+      }
+      return dataset as Dataset<string, IsoWeekIssue<string>>;
+    },
+  };
+}


### PR DESCRIPTION
Part of #502

Note that some years, [like 2012, can have 54 weeks](https://www.timeanddate.com/calendar/custom.html?year=2012&country=9&cdt=1&typ=0&display=3&df=1).