### PR TITLE
Modify variant schema options reference more precise

### DIFF
--- a/library/src/schemas/variant/variant.ts
+++ b/library/src/schemas/variant/variant.ts
@@ -115,7 +115,7 @@ export function variant(
           let outputDataset: Dataset<unknown, BaseIssue<unknown>> | undefined;
 
           // Parse only if it is a variant schema or if discriminator matches
-          for (const schema of options) {
+          for (const schema of this.options) {
             if (
               schema.type === 'variant' ||
               !schema.entries[this.key]._run(
@@ -155,7 +155,7 @@ export function variant(
         // Otherwise, cache expected discriminators if necessary
         if (!expectedDiscriminators) {
           expectedDiscriminators =
-            [..._discriminators(this.key, options)].join(' | ') || 'never';
+            [..._discriminators(this.key, this.options)].join(' | ') || 'never';
         }
 
         // And add discriminator issue

--- a/library/src/schemas/variant/variantAsync.ts
+++ b/library/src/schemas/variant/variantAsync.ts
@@ -115,7 +115,7 @@ export function variantAsync(
           let outputDataset: Dataset<unknown, BaseIssue<unknown>> | undefined;
 
           // Parse only if it is a variant schema or if discriminator matches
-          for (const schema of options) {
+          for (const schema of this.options) {
             if (
               schema.type === 'variant' ||
               !(
@@ -157,7 +157,7 @@ export function variantAsync(
         // Otherwise, cache expected discriminators if necessary
         if (!expectedDiscriminators) {
           expectedDiscriminators =
-            [..._discriminators(this.key, options)].join(' | ') || 'never';
+            [..._discriminators(this.key, this.options)].join(' | ') || 'never';
         }
 
         // And add discriminator issue


### PR DESCRIPTION
## Overview

The `options` specified when generating a variant schema are curried. So I wrote this fix.

## Details

I don't think it's a good way to do it, but in my use case, if I want to make changes to the `options` below, it won't work without this fix. Since it works with other schemas, the `options` are specified differently only for variant schema.

```ts
const schema = variant('type', [
  object({ type: literal('a'), value: string() }),
  object({ type: literal('b'), value: number() }),
])
const convertSchema = {
  ...schema,
  options: type.options.map((option) =>
    pipe(
      unknown(),
      transform((output) => output.value == null ? { ...output, value: "" } : output),
      option,
    ),
}
safeParse(convertSchema, { type: 'a', value: null }) // <-- parse error
```
