### PR TITLE
fix(grit): prevent nested pipes from being incorrectly rewritten

### DIFF
--- a/.grit/patterns/migrate_to_v0_31_0.md
+++ b/.grit/patterns/migrate_to_v0_31_0.md
@@ -7,12 +7,14 @@ language js
 
 pattern rewritten_names() {
   or {
+    // This could end up as a three way rename, hence why we only do it in first phase
     `custom` => `check`,
+    `special` => `custom`,
+    // These are safe to apply in the second pass
     `BaseSchema` => `GenericSchema`,
     `Input` => `InferInput`,
     `Output` => `InferOutput`,
     `SchemaConfig` => `Config`,
-    `special` => `custom`,
     `toCustom` => `transform`,
     `toTrimmed` => `trim`,
     `toTrimmedEnd` => `trimEnd`,
@@ -130,22 +132,37 @@ pattern rewrite_nested_pipes($v, $args) {
   }
 }
 
-any {
-  rewrite_names($v),
-  rewrite_pipes($v),
-  rewrite_brand_and_transform($v),
-  rewrite_coerce($v),
-  rewrite_flatten($v),
-  rewrite_nested_pipes($v),
-} where {
-  $v <: or {
-    // Direct imports
-    undefined,
-    // Default wildcard specification
-    `v`,
-    // Other wildcard imports
-    identifier() where $program <: contains `import * as $v from 'valibot'`
+pattern is_valibot() {
+  `$v` where {
+    $v <: or {
+      // Direct imports
+      undefined,
+      // Default wildcard specification
+      `v`,
+      // Other wildcard imports
+      identifier() where $program <: contains `import * as $v from 'valibot'`
+    }
   }
+}
+
+pattern one_pass() {
+  any {
+    rewrite_pipes($v),
+    rewrite_brand_and_transform($v),
+    rewrite_coerce($v),
+    rewrite_flatten($v),
+    rewrite_nested_pipes($v),
+  } where {
+    $v <: is_valibot()
+  }
+}
+
+sequential {
+  bubble file($body) where $body <: contains or {
+    one_pass(),
+    rewrite_names($v) where $v <: is_valibot()
+  },
+  bubble file($body) where $body <: maybe contains one_pass()
 }
 ```
 
@@ -324,7 +341,7 @@ const Schema1 = v.pipe(v.string(), v.url(), v.brand('foo'));
 const Schema2 = v.pipe(v.string(), v.transform((input) => input.length));
 const Schema3 = v.pipe(v.string(), v.brand('Name'), v.transform((input) => input.length));
 const Schema4 = v.pipe(v.string(), v.brand('Name1'), v.brand('Name2'));
-const Schema5 = v.pipe(v.pipe(v.unknown(), v.transform((input) => new Date(input))), v.transform((input) => input.toJSON()));
+const Schema5 = v.pipe(v.unknown(), v.transform((input) => new Date(input)), v.transform((input) => input.toJSON()));
 ```
 
 ## Should transform unnecessary pipes
@@ -340,7 +357,7 @@ After:
 
 ```js
 const Schema1 = v.pipe(v.string(), v.email(), v.maxLength(10));
-const Schema2 = v.pipe(v.pipe(v.unknown(), v.transform((input) => new Date(input))), v.transform((input) => input.toJSON()));
+const Schema2 = v.pipe(v.unknown(), v.transform((input) => new Date(input)), v.transform((input) => input.toJSON()));
 ```
 
 ## Should not rename unrelated methods
@@ -377,7 +394,7 @@ const Schema1 = v.pipe(v.string(), v.email(), v.maxLength(10));
 const Schema3 = v.pipe(v.array(v.pipe(v.string(), v.decimal())), v.transform((input) => input.length));
 ```
 
-<!-- ## Should inject unknown for pipes without a schema
+## Should inject unknown for pipes without a schema
 
 ```js
 const Schema2 = v.transform(v.coerce(v.date(), (input) => new Date(input)), (input) => input.toJSON());
@@ -385,4 +402,4 @@ const Schema2 = v.transform(v.coerce(v.date(), (input) => new Date(input)), (inp
 
 ```js
 const Schema2 = v.pipe(v.unknown(), v.transform((input) => new Date(input)), v.transform((input) => input.toJSON()));
-``` -->
+```


### PR DESCRIPTION
We use `sequential` to rerun the migration twice to catch cases where transform/pipe interact weirdly. Test cases cover everything discussed so far.