### PR TITLE
fix(deno): Add missing file extensions

### DIFF
--- a/library/src/types/config.ts
+++ b/library/src/types/config.ts
@@ -1,5 +1,5 @@
-import type { BaseIssue } from './issue';
-import type { ErrorMessage } from './other';
+import type { BaseIssue } from './issue.ts';
+import type { ErrorMessage } from './other.ts';
 
 /**
  * Config type.

--- a/library/src/utils/entriesFromList/entriesFromList.ts
+++ b/library/src/utils/entriesFromList/entriesFromList.ts
@@ -1,4 +1,8 @@
-import type { BaseIssue, BaseSchema, MaybeReadonly } from '../../types';
+import type {
+  BaseIssue,
+  BaseSchema,
+  MaybeReadonly,
+} from '../../types/index.ts';
 
 /**
  * Creates a object entries definition from a list of keys and a schema.

--- a/library/src/vitest/expectNoActionIssue.ts
+++ b/library/src/vitest/expectNoActionIssue.ts
@@ -1,5 +1,5 @@
 import { expect } from 'vitest';
-import type { BaseIssue, BaseValidation, InferInput } from '../types';
+import type { BaseIssue, BaseValidation, InferInput } from '../types/index.ts';
 
 /**
  * Expect no action issue to be returned.

--- a/library/src/vitest/expectNoActionIssueAsync.ts
+++ b/library/src/vitest/expectNoActionIssueAsync.ts
@@ -1,5 +1,9 @@
 import { expect } from 'vitest';
-import type { BaseIssue, BaseValidationAsync, InferInput } from '../types';
+import type {
+  BaseIssue,
+  BaseValidationAsync,
+  InferInput,
+} from '../types/index.ts';
 
 /**
  * Expect no action issue to be returned.

--- a/library/src/vitest/expectNoSchemaIssue.ts
+++ b/library/src/vitest/expectNoSchemaIssue.ts
@@ -1,5 +1,5 @@
 import { expect } from 'vitest';
-import type { BaseIssue, BaseSchema, InferInput } from '../types';
+import type { BaseIssue, BaseSchema, InferInput } from '../types/index.ts';
 
 /**
  * Expect no schema issue to be returned.

--- a/library/src/vitest/expectNoSchemaIssueAsync.ts
+++ b/library/src/vitest/expectNoSchemaIssueAsync.ts
@@ -1,5 +1,5 @@
 import { expect } from 'vitest';
-import type { BaseIssue, BaseSchemaAsync, InferInput } from '../types';
+import type { BaseIssue, BaseSchemaAsync, InferInput } from '../types/index.ts';
 
 /**
  * Expect no schema issue to be returned.


### PR DESCRIPTION
## Summary

Fixled some files that were imported without extensions.

## Details

When using `https://deno.land/x/valibot` with deno, the type check fails after updating to `v0.31.0`.

So, I fixed some files has `import` without extensions.

I checked this fixes by `deno check src/**/*.ts` on `Library` dir.