### PR TITLE
Modify tupleAsync schema items reference more precise

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the library will be documented in this file.
 ## vX.X.X (Month DD, YYYY)
 
 - Change `FlatErrors` type for better developer experience (discussion #640)
+- Fix `this` reference in `looseTuple`, `looseTupleAsync`, `strictTuple`, `strictTupleAsync`, `tuple`, `tupleAsync`, `tupleWithRest` and `tupleWithRestAsync` schema (pull request #649)
 
 ## v0.31.1 (June 08, 2024)
 

--- a/library/src/schemas/looseTuple/looseTuple.ts
+++ b/library/src/schemas/looseTuple/looseTuple.ts
@@ -92,7 +92,7 @@ export function looseTuple(
         dataset.value = [];
 
         // Parse schema of each tuple item
-        for (let key = 0; key < items.length; key++) {
+        for (let key = 0; key < this.items.length; key++) {
           const value = input[key];
           const itemDataset = this.items[key]._run(
             { typed: false, value },
@@ -145,7 +145,7 @@ export function looseTuple(
 
         // Add rest to dataset if necessary
         if (!dataset.issues || !config.abortEarly) {
-          for (let key = items.length; key < input.length; key++) {
+          for (let key = this.items.length; key < input.length; key++) {
             // @ts-expect-error
             dataset.value.push(input[key]);
           }

--- a/library/src/schemas/looseTuple/looseTupleAsync.ts
+++ b/library/src/schemas/looseTuple/looseTupleAsync.ts
@@ -96,7 +96,7 @@ export function looseTupleAsync(
 
         // Parse schema of each tuple item
         const itemDatasets = await Promise.all(
-          items.map(async (item, key) => {
+          this.items.map(async (item, key) => {
             const value = input[key];
             return [
               key,
@@ -154,7 +154,7 @@ export function looseTupleAsync(
 
         // Add rest to dataset if necessary
         if (!dataset.issues || !config.abortEarly) {
-          for (let key = items.length; key < input.length; key++) {
+          for (let key = this.items.length; key < input.length; key++) {
             // @ts-expect-error
             dataset.value.push(input[key]);
           }

--- a/library/src/schemas/strictTuple/strictTuple.ts
+++ b/library/src/schemas/strictTuple/strictTuple.ts
@@ -92,7 +92,7 @@ export function strictTuple(
         dataset.value = [];
 
         // Parse schema of each tuple item
-        for (let key = 0; key < items.length; key++) {
+        for (let key = 0; key < this.items.length; key++) {
           const value = input[key];
           const itemDataset = this.items[key]._run(
             { typed: false, value },
@@ -146,7 +146,7 @@ export function strictTuple(
         // Check input for unknown items if necessary
         if (
           !(dataset.issues && config.abortEarly) &&
-          items.length < input.length
+          this.items.length < input.length
         ) {
           const value = input[items.length];
           _addIssue(this, 'type', dataset, config, {
@@ -157,7 +157,7 @@ export function strictTuple(
                 type: 'tuple',
                 origin: 'value',
                 input,
-                key: items.length,
+                key: this.items.length,
                 value,
               },
             ],

--- a/library/src/schemas/strictTuple/strictTupleAsync.ts
+++ b/library/src/schemas/strictTuple/strictTupleAsync.ts
@@ -96,7 +96,7 @@ export function strictTupleAsync(
 
         // Parse schema of each tuple item
         const itemDatasets = await Promise.all(
-          items.map(async (item, key) => {
+          this.items.map(async (item, key) => {
             const value = input[key];
             return [
               key,
@@ -155,7 +155,7 @@ export function strictTupleAsync(
         // Check input for unknown items if necessary
         if (
           !(dataset.issues && config.abortEarly) &&
-          items.length < input.length
+          this.items.length < input.length
         ) {
           const value = input[items.length];
           _addIssue(this, 'type', dataset, config, {
@@ -166,7 +166,7 @@ export function strictTupleAsync(
                 type: 'tuple',
                 origin: 'value',
                 input,
-                key: items.length,
+                key: this.items.length,
                 value,
               },
             ],

--- a/library/src/schemas/tuple/tuple.ts
+++ b/library/src/schemas/tuple/tuple.ts
@@ -102,7 +102,7 @@ export function tuple(
         dataset.value = [];
 
         // Parse schema of each tuple item
-        for (let key = 0; key < items.length; key++) {
+        for (let key = 0; key < this.items.length; key++) {
           const value = input[key];
           const itemDataset = this.items[key]._run(
             { typed: false, value },

--- a/library/src/schemas/tuple/tupleAsync.ts
+++ b/library/src/schemas/tuple/tupleAsync.ts
@@ -103,7 +103,7 @@ export function tupleAsync(
 
         // Parse schema of each tuple item
         const itemDatasets = await Promise.all(
-          items.map(async (item, key) => {
+          this.items.map(async (item, key) => {
             const value = input[key];
             return [
               key,

--- a/library/src/schemas/tupleWithRest/tupleWithRest.ts
+++ b/library/src/schemas/tupleWithRest/tupleWithRest.ts
@@ -114,7 +114,7 @@ export function tupleWithRest(
         dataset.value = [];
 
         // Parse schema of each tuple item
-        for (let key = 0; key < items.length; key++) {
+        for (let key = 0; key < this.items.length; key++) {
           const value = input[key];
           const itemDataset = this.items[key]._run(
             { typed: false, value },
@@ -167,7 +167,7 @@ export function tupleWithRest(
 
         // Parse rest with schema if necessary
         if (!dataset.issues || !config.abortEarly) {
-          for (let key = items.length; key < input.length; key++) {
+          for (let key = this.items.length; key < input.length; key++) {
             const value = input[key];
             const itemDataset = this.rest._run({ typed: false, value }, config);
 

--- a/library/src/schemas/tupleWithRest/tupleWithRestAsync.ts
+++ b/library/src/schemas/tupleWithRest/tupleWithRestAsync.ts
@@ -130,7 +130,7 @@ export function tupleWithRestAsync(
         const [normalDatasets, restDatasets] = await Promise.all([
           // Parse schema of each normal item
           Promise.all(
-            items.map(async (item, key) => {
+            this.items.map(async (item, key) => {
               const value = input[key];
               return [
                 key,
@@ -142,11 +142,11 @@ export function tupleWithRestAsync(
 
           // Parse other items with rest schema
           Promise.all(
-            input.slice(items.length).map(async (value, key) => {
+            input.slice(this.items.length).map(async (value, key) => {
               return [
-                key + items.length,
+                key + this.items.length,
                 value,
-                await rest._run({ typed: false, value }, config),
+                await this.rest._run({ typed: false, value }, config),
               ] as const;
             })
           ),


### PR DESCRIPTION
## Overview

The `items` specified when generating a tupleAsync schema are curried. So I wrote this fix.

## Details

This change is for the same reason as the previous change to the variant schema. #600 

I have created [code](https://valibot.dev/playground/?code=JYWwDg9gTgLgBAKjgQwM5wG5wGZQiOAcg2QBtgAjCGQgbgCh6BjCAO1XgGUmALAUxDI4AXkwA6GAFcwpPgEFUAT1ZMAFAG0MY1pJAU+UVQEoANOI5RgrAObGAukYbM2HOC1YYDMbv0Ei4AN70cHBiYT4CyCbBcMAwAqgAXHARgmJxCWKCYKqqGSBGIgB8gTEhWmDAYPJKKqplIeKSrADWrBAA7qzG0Y2NWjBQyOzY0CC5EJIwYFOFwiVBfX3uqBCyYqQQtoTt8HwAHnxMU3yERg19UHxSUKxwk9NTIqI6pKRwAPxwAAxwyQ8zGAXOAAX1MwPyvUa5xCYPoIMYKzWfA2W1UhA4yFgcDAWNQp3OK3gV1QklI8FEyA6yDi5mQ2D4AAU8TVlGp3J5YKkonB1K9SGZCPEOIQHAwketNts+KwACY4llnREuZGo2wkskwRxAA) that reproduces this issue.
```ts
import * as v from 'valibot';

const Schema = v.tupleAsync([v.number(), v.string()]);

const convertSchema = {
  ...Schema,
  items: Schema.items.map((item) => {
    v.pipeAsync(
      v.unknown(),
      v.transform((output) => {
        console.log('not execute')
        return output == null ? 0 : output
      }),
      item,
    )
  })
}

console.log('start parse')
const result = await v.safeParseAsync(convertSchema, [null, 'test']);
console.log('end parse')

console.log(result); // <-- parse error
```