### PR TITLE
Use type exports where appropriate

### DIFF
--- a/library/src/actions/partialCheck/index.ts
+++ b/library/src/actions/partialCheck/index.ts
@@ -1,3 +1,3 @@
 export * from './partialCheck.ts';
 export * from './partialCheckAsync.ts';
-export { PartialCheckIssue } from './types.ts';
+export type { PartialCheckIssue } from './types.ts';

--- a/library/src/actions/rawCheck/index.ts
+++ b/library/src/actions/rawCheck/index.ts
@@ -1,3 +1,3 @@
 export * from './rawCheck.ts';
 export * from './rawCheckAsync.ts';
-export { RawCheckIssue } from './types.ts';
+export type { RawCheckIssue } from './types.ts';

--- a/library/src/actions/rawTransform/index.ts
+++ b/library/src/actions/rawTransform/index.ts
@@ -1,3 +1,3 @@
 export * from './rawTransform.ts';
 export * from './rawTransformAsync.ts';
-export { RawTransformIssue } from './types.ts';
+export type { RawTransformIssue } from './types.ts';


### PR DESCRIPTION
Some type exports are erased by TypeScript and break when using Deno as the runtime:

```
error: Uncaught SyntaxError: The requested module './types.ts' does not provide an export named 'PartialCheckIssue'
export { PartialCheckIssue } from './types.ts';
         ^
    at <anonymous> (https://jsr.io/@valibot/valibot/0.33.1/src/actions/partialCheck/index.ts:3:10)
```

This PR fixes those exports