### PR TITLE
fix: parenthesis typo on pipe example

### DIFF
--- a/website/src/routes/guides/(migration)/migrate-to-v0.31.0/index.mdx
+++ b/website/src/routes/guides/(migration)/migrate-to-v0.31.0/index.mdx
@@ -39,7 +39,7 @@ As mentioned above, one of the biggest differences is the new <Link href="/api/p
 const Schema = v.string([v.email()]);
 
 // To this
-const Schema = v.pipe(v.string(), v.email()));
+const Schema = v.pipe(v.string(), v.email());
 ```
 
 We will be publishing a blog post soon explaining all the benefits of this change. In the meantime, you can read the description of discussion [#463](https://github.com/fabian-hiller/valibot/discussions/463) and PR [#502](https://github.com/fabian-hiller/valibot/pull/502), which introduced this change.


### PR DESCRIPTION
Fix parenthesis typo on pipe example at documentation page