### PR TITLE
add `mapAsync` & `MapSchemaAsync` doc

### DIFF
--- a/website/src/routes/api/(async)/mapAsync/index.mdx
+++ b/website/src/routes/api/(async)/mapAsync/index.mdx
@@ -1,10 +1,182 @@
 ---
 title: mapAsync
+description: Creates a map schema.
 source: /schemas/map/mapAsync.ts
 contributors:
+  - EltonLobo07
   - fabian-hiller
 ---
 
+import { ApiList, Property } from '~/components';
+import { properties } from './properties';
+
 # mapAsync
 
-> The content of this page is not yet ready. Until then, please use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/schemas/map/mapAsync.ts) or take a look at [issue #287](https://github.com/fabian-hiller/valibot/issues/287) to help us extend the API reference.
+Creates a map schema.
+
+```ts
+const Schema = v.mapAsync<TKey, TValue, TMessage>(key, value, message);
+```
+
+## Generics
+
+- `TKey` <Property {...properties.TKey} />
+- `TValue` <Property {...properties.TValue} />
+- `TMessage` <Property {...properties.TMessage} />
+
+## Parameters
+
+- `key` <Property {...properties.key} />
+- `value` <Property {...properties.value} />
+- `message` <Property {...properties.message} />
+
+### Explanation
+
+With `mapAsync` you can validate the data type of the input and whether the entries match `key` and `value`. If the input is not a map, you can use `message` to customize the error message.
+
+## Returns
+
+- `Schema` <Property {...properties.Schema} />
+
+## Examples
+
+The following examples show how `mapAsync` can be used.
+
+### Allowed username to total items map schema
+
+Schema to validate a map with usernames that are allowed to shop as keys and the total items purchased as values.
+
+```ts
+import { isUsernameAllowedToShop } from '~/api';
+
+const UsernameTotalItemsMapSchema = v.mapAsync(
+  v.pipeAsync(
+    v.string(),
+    v.checkAsync(
+      isUsernameAllowedToShop,
+      'The username is not allowed to shop.'
+    )
+  ),
+  v.pipe(v.number(), v.minValue(0))
+);
+```
+
+## Related
+
+The following APIs can be combined with `mapAsync`.
+
+### Schemas
+
+<ApiList
+  items={[
+    'any',
+    'array',
+    'bigint',
+    'blob',
+    'boolean',
+    'custom',
+    'date',
+    'enum',
+    'file',
+    'function',
+    'instance',
+    'intersect',
+    'lazy',
+    'literal',
+    'looseObject',
+    'looseTuple',
+    'nan',
+    'never',
+    'nonNullable',
+    'nonNullish',
+    'nonOptional',
+    'null',
+    'nullable',
+    'nullish',
+    'number',
+    'object',
+    'objectWithRest',
+    'optional',
+    'picklist',
+    'promise',
+    'record',
+    'set',
+    'strictObject',
+    'strictTuple',
+    'string',
+    'symbol',
+    'tuple',
+    'tupleWithRest',
+    'undefined',
+    'union',
+    'unknown',
+    'variant',
+    'void',
+  ]}
+/>
+
+### Methods
+
+<ApiList items={['config', 'getDefault', 'getFallback']} />
+
+### Actions
+
+<ApiList
+  items={[
+    'check',
+    'brand',
+    'maxSize',
+    'minSize',
+    'notSize',
+    'rawCheck',
+    'rawTransform',
+    'readonly',
+    'size',
+    'transform',
+  ]}
+/>
+
+### Utils
+
+<ApiList items={['entriesFromList', 'isOfKind', 'isOfType']} />
+
+### Async
+
+<ApiList
+  items={[
+    'arrayAsync',
+    'checkAsync',
+    'customAsync',
+    'fallbackAsync',
+    'getDefaultsAsync',
+    'getFallbacksAsync',
+    'intersectAsync',
+    'lazyAsync',
+    'looseObjectAsync',
+    'looseTupleAsync',
+    'nonNullableAsync',
+    'nonNullishAsync',
+    'nonOptionalAsync',
+    'nullableAsync',
+    'nullishAsync',
+    'objectAsync',
+    'objectWithRestAsync',
+    'optionalAsync',
+    'parseAsync',
+    'parserAsync',
+    'pipeAsync',
+    'rawCheckAsync',
+    'rawTransformAsync',
+    'recordAsync',
+    'safeParseAsync',
+    'safeParserAsync',
+    'setAsync',
+    'strictObjectAsync',
+    'strictTupleAsync',
+    'transformAsync',
+    'tupleAsync',
+    'tupleWithRestAsync',
+    'unionAsync',
+    'variantAsync',
+  ]}
+/>

--- a/website/src/routes/api/(async)/mapAsync/index.mdx
+++ b/website/src/routes/api/(async)/mapAsync/index.mdx
@@ -42,20 +42,17 @@ With `mapAsync` you can validate the data type of the input and whether the entr
 
 The following examples show how `mapAsync` can be used.
 
-### Allowed username to total items map schema
+### Shopping items schema
 
 Schema to validate a map with usernames that are allowed to shop as keys and the total items purchased as values.
 
 ```ts
-import { isUsernameAllowedToShop } from '~/api';
+import { isUserVerified } from '~/api';
 
-const UsernameTotalItemsMapSchema = v.mapAsync(
+const ShoppingItemsSchema = v.mapAsync(
   v.pipeAsync(
     v.string(),
-    v.checkAsync(
-      isUsernameAllowedToShop,
-      'The username is not allowed to shop.'
-    )
+    v.checkAsync(isUserVerified, 'The username is not allowed to shop.')
   ),
   v.pipe(v.number(), v.minValue(0))
 );

--- a/website/src/routes/api/(async)/mapAsync/properties.ts
+++ b/website/src/routes/api/(async)/mapAsync/properties.ts
@@ -1,0 +1,140 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TKey: {
+    modifier: 'extends',
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'BaseSchema',
+          href: '../BaseSchema/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
+        },
+        {
+          type: 'custom',
+          name: 'BaseSchemaAsync',
+          href: '../BaseSchemaAsync/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  TValue: {
+    modifier: 'extends',
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'BaseSchema',
+          href: '../BaseSchema/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
+        },
+        {
+          type: 'custom',
+          name: 'BaseSchemaAsync',
+          href: '../BaseSchemaAsync/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  TMessage: {
+    modifier: 'extends',
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'ErrorMessage',
+          href: '../ErrorMessage/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'MapIssue',
+              href: '../MapIssue/',
+            },
+          ],
+        },
+        'undefined',
+      ],
+    },
+  },
+  key: {
+    type: {
+      type: 'custom',
+      name: 'TKey',
+    },
+  },
+  value: {
+    type: {
+      type: 'custom',
+      name: 'TValue',
+    },
+  },
+  message: {
+    type: {
+      type: 'custom',
+      name: 'TMessage',
+    },
+  },
+  Schema: {
+    type: {
+      type: 'custom',
+      name: 'MapSchemaAsync',
+      href: '../MapSchemaAsync/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TKey',
+        },
+        {
+          type: 'custom',
+          name: 'TValue',
+        },
+        {
+          type: 'custom',
+          name: 'TMessage',
+        },
+      ],
+    },
+  },
+};

--- a/website/src/routes/api/(types)/ArraySchemaAsync/index.mdx
+++ b/website/src/routes/api/(types)/ArraySchemaAsync/index.mdx
@@ -20,7 +20,7 @@ Array schema async type.
 
 ## Definition
 
-- `ArraySchemaAsync` <Property {...properties.BaseSchema} />
+- `ArraySchemaAsync` <Property {...properties.BaseSchemaAsync} />
   - `type` <Property {...properties.type} />
   - `reference` <Property {...properties.reference} />
   - `expects` <Property {...properties.expects} />

--- a/website/src/routes/api/(types)/ArraySchemaAsync/properties.ts
+++ b/website/src/routes/api/(types)/ArraySchemaAsync/properties.ts
@@ -60,7 +60,7 @@ export const properties: Record<string, PropertyProps> = {
       ],
     },
   },
-  BaseSchema: {
+  BaseSchemaAsync: {
     modifier: 'extends',
     type: {
       type: 'custom',

--- a/website/src/routes/api/(types)/MapSchemaAsync/index.mdx
+++ b/website/src/routes/api/(types)/MapSchemaAsync/index.mdx
@@ -1,0 +1,30 @@
+---
+title: MapSchemaAsync
+description: Map schema async type.
+contributors:
+  - EltonLobo07
+  - fabian-hiller
+---
+
+import { Property } from '~/components';
+import { properties } from './properties';
+
+# MapSchemaAsync
+
+Map schema async type.
+
+## Generics
+
+- `TKey` <Property {...properties.TKey} />
+- `TValue` <Property {...properties.TValue} />
+- `TMessage` <Property {...properties.TMessage} />
+
+## Definition
+
+- `MapSchema` <Property {...properties.BaseSchema} />
+  - `type` <Property {...properties.type} />
+  - `reference` <Property {...properties.reference} />
+  - `expects` <Property {...properties.expects} />
+  - `key` <Property {...properties.key} />
+  - `value` <Property {...properties.value} />
+  - `message` <Property {...properties.message} />

--- a/website/src/routes/api/(types)/MapSchemaAsync/index.mdx
+++ b/website/src/routes/api/(types)/MapSchemaAsync/index.mdx
@@ -21,7 +21,7 @@ Map schema async type.
 
 ## Definition
 
-- `MapSchema` <Property {...properties.BaseSchema} />
+- `MapSchemaAsync` <Property {...properties.BaseSchemaAsync} />
   - `type` <Property {...properties.type} />
   - `reference` <Property {...properties.reference} />
   - `expects` <Property {...properties.expects} />

--- a/website/src/routes/api/(types)/MapSchemaAsync/properties.ts
+++ b/website/src/routes/api/(types)/MapSchemaAsync/properties.ts
@@ -1,0 +1,211 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TKey: {
+    modifier: 'extends',
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'BaseSchema',
+          href: '../BaseSchema/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
+        },
+        {
+          type: 'custom',
+          name: 'BaseSchemaAsync',
+          href: '../BaseSchemaAsync/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  TValue: {
+    modifier: 'extends',
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'BaseSchema',
+          href: '../BaseSchema/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
+        },
+        {
+          type: 'custom',
+          name: 'BaseSchemaAsync',
+          href: '../BaseSchemaAsync/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  TMessage: {
+    modifier: 'extends',
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'ErrorMessage',
+          href: '../ErrorMessage/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'MapIssue',
+              href: '../MapIssue/',
+            },
+          ],
+        },
+        'undefined',
+      ],
+    },
+  },
+  BaseSchema: {
+    modifier: 'extends',
+    type: {
+      type: 'custom',
+      name: 'BaseSchemaAsync',
+      href: '../BaseSchemaAsync/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'InferMapInput',
+          href: '../InferMapInput/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'TKey',
+            },
+            {
+              type: 'custom',
+              name: 'TValue',
+            },
+          ],
+        },
+        {
+          type: 'custom',
+          name: 'InferMapOutput',
+          href: '../InferMapOutput/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'TKey',
+            },
+            {
+              type: 'custom',
+              name: 'TValue',
+            },
+          ],
+        },
+        {
+          type: 'union',
+          options: [
+            {
+              type: 'custom',
+              name: 'MapIssue',
+              href: '../MapIssue/',
+            },
+            {
+              type: 'custom',
+              name: 'InferIssue',
+              href: '../InferIssue/',
+              generics: [
+                {
+                  type: 'custom',
+                  name: 'TKey',
+                },
+              ],
+            },
+            {
+              type: 'custom',
+              name: 'InferIssue',
+              href: '../InferIssue/',
+              generics: [
+                {
+                  type: 'custom',
+                  name: 'TValue',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  type: {
+    type: {
+      type: 'string',
+      value: 'map',
+    },
+  },
+  reference: {
+    type: {
+      type: 'custom',
+      modifier: 'typeof',
+      name: 'mapAsync',
+      href: '../mapAsync/',
+    },
+  },
+  expects: {
+    type: {
+      type: 'string',
+      value: 'Map',
+    },
+  },
+  key: {
+    type: {
+      type: 'custom',
+      name: 'TKey',
+    },
+  },
+  value: {
+    type: {
+      type: 'custom',
+      name: 'TValue',
+    },
+  },
+  message: {
+    type: {
+      type: 'custom',
+      name: 'TMessage',
+    },
+  },
+};

--- a/website/src/routes/api/(types)/MapSchemaAsync/properties.ts
+++ b/website/src/routes/api/(types)/MapSchemaAsync/properties.ts
@@ -98,7 +98,7 @@ export const properties: Record<string, PropertyProps> = {
       ],
     },
   },
-  BaseSchema: {
+  BaseSchemaAsync: {
     modifier: 'extends',
     type: {
       type: 'custom',

--- a/website/src/routes/api/menu.md
+++ b/website/src/routes/api/menu.md
@@ -313,6 +313,7 @@
 - [MacAction](/api/MacAction/)
 - [MapPathItem](/api/MapPathItem/)
 - [MapSchema](/api/MapSchema/)
+- [MapSchemaAsync](/api/MapSchemaAsync/)
 - [MaxBytesAction](/api/MaxBytesAction/)
 - [MaxSizeAction](/api/MaxSizeAction/)
 - [MaxValueAction](/api/MaxValueAction/)


### PR DESCRIPTION
This PR adds `mapAsync` & `MapSchemaAsync` to the documentation. Feel free to replace the example if you have a better one.