### PR TITLE
Fix lazy generics in docs

### DIFF
--- a/website/src/routes/api/(schemas)/lazy/index.mdx
+++ b/website/src/routes/api/(schemas)/lazy/index.mdx
@@ -51,7 +51,7 @@ type BinaryTree = {
   right: BinaryTree | null;
 };
 
-const BinaryTreeSchema: v.GenericSchema<BinaryTree> = v.object({
+const BinaryTreeSchema: v.GenericSchema<unknown, BinaryTree> = v.object({
   element: v.string(),
   left: v.nullable(v.lazy(() => BinaryTreeSchema)),
   right: v.nullable(v.lazy(() => BinaryTreeSchema)),

--- a/website/src/routes/guides/(schemas)/other/index.mdx
+++ b/website/src/routes/guides/(schemas)/other/index.mdx
@@ -65,7 +65,7 @@ type BinaryTree = {
   right: BinaryTree | null;
 };
 
-const BinaryTreeSchema: v.GenericSchema<BinaryTree> = v.object({
+const BinaryTreeSchema: v.GenericSchema<unknown, BinaryTree> = v.object({
   element: v.string(),
   left: v.nullable(v.lazy(() => BinaryTreeSchema)),
   right: v.nullable(v.lazy(() => BinaryTreeSchema)),


### PR DESCRIPTION
Hey, I noticed that in docs BinaryTreeSchema is parametrized with only input T

that causes type erasure for some types, notable for branded strings, such as:

```ts

const NonEmptyStringSchema = pipe(
  string(),
  minLength(1),
  brand('NonEmptyString')
);

type NonEmptyString = InferOutput<typeof NonEmptyStringSchema>;

const FileSystemCommonSchema = object({
  name: NonEmptyStringSchema,
});

type FileSystem = (
  | {
  readonly type: 'directory';
  readonly children: readonly FileSystem[];
}
  | {
  readonly type: 'file';
}
  ) & {
  readonly name: NonEmptyString;
};

const FileSystemDirectorySchema: GenericSchema<FileSystem & { type: 'directory' }> = intersect([
  FileSystemCommonSchema,
  object({
    type: literal('directory'),
    children: array(lazy(() => FileSystemSchema)),
  }),
]);

const FileSystemFileSchema = intersect([
  FileSystemCommonSchema,
  object({
    type: literal('file'),
  }),
]);

const FileSystemSchema = union([
  FileSystemDirectorySchema,
  FileSystemFileSchema,
]);
```

would cause type error because (I assume) FileSystem's `name` NonEmptyString being downcasted to `string` as an input and then assigned to the output as a default <---- this is only an assumption, I just went with my intuition and put `GenericSchema<unknown, FileSystem & { type: 'directory' }>` there and it works