### PR TITLE
add 'extends' to `CustomAsyncSchema` def of the API ref

### DIFF
--- a/website/src/routes/api/(types)/CustomSchema/index.mdx
+++ b/website/src/routes/api/(types)/CustomSchema/index.mdx
@@ -1,8 +1,9 @@
 ---
 title: CustomSchema
-description: Special schema type.
+description: Custom schema type.
 contributors:
   - fabian-hiller
+  - EltonLobo07
 ---
 
 import { Property } from '~/components';
@@ -10,7 +11,7 @@ import { properties } from './properties';
 
 # CustomSchema
 
-Special schema type.
+Custom schema type.
 
 ## Generics
 

--- a/website/src/routes/api/(types)/CustomSchemaAsync/index.mdx
+++ b/website/src/routes/api/(types)/CustomSchemaAsync/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: CustomSchemaAsync
-description: Special schema async type.
+description: Custom schema async type.
 contributors:
   - fabian-hiller
   - EltonLobo07
@@ -11,7 +11,7 @@ import { properties } from './properties';
 
 # CustomSchemaAsync
 
-Special schema async type.
+Custom schema async type.
 
 ## Generics
 

--- a/website/src/routes/api/(types)/CustomSchemaAsync/index.mdx
+++ b/website/src/routes/api/(types)/CustomSchemaAsync/index.mdx
@@ -3,6 +3,7 @@ title: CustomSchemaAsync
 description: Special schema async type.
 contributors:
   - fabian-hiller
+  - EltonLobo07
 ---
 
 import { Property } from '~/components';

--- a/website/src/routes/api/(types)/CustomSchemaAsync/properties.ts
+++ b/website/src/routes/api/(types)/CustomSchemaAsync/properties.ts
@@ -28,6 +28,7 @@ export const properties: Record<string, PropertyProps> = {
   },
   BaseSchemaAsync: {
     type: {
+      modifier: 'extends',
       type: 'custom',
       name: 'BaseSchemaAsync',
       href: '../BaseSchemaAsync/',


### PR DESCRIPTION
Also, is the "Special schema async type." description intentional? I think it should be "Custom schema async type."