### PR TITLE
add `objectAsync` doc & improve `ObjectSchemaAsync` API ref

### DIFF
--- a/website/src/routes/api/(async)/objectAsync/index.mdx
+++ b/website/src/routes/api/(async)/objectAsync/index.mdx
@@ -1,10 +1,187 @@
 ---
 title: objectAsync
+description: Creates an object schema.
 source: /schemas/object/objectAsync.ts
 contributors:
+  - EltonLobo07
   - fabian-hiller
 ---
 
+import { Link } from '@builder.io/qwik-city';
+import { ApiList, Property } from '~/components';
+import { properties } from './properties';
+
 # objectAsync
 
-> The content of this page is not yet ready. Until then, please use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/schemas/object/objectAsync.ts) or take a look at [issue #287](https://github.com/fabian-hiller/valibot/issues/287) to help us extend the API reference.
+Creates an object schema.
+
+```ts
+const Schema = v.objectAsync<TEntries, TMessage>(entries, message);
+```
+
+## Generics
+
+- `TEntries` <Property {...properties.TEntries} />
+- `TMessage` <Property {...properties.TMessage} />
+
+## Parameters
+
+- `entries` <Property {...properties.entries} />
+- `message` <Property {...properties.message} />
+
+### Explanation
+
+With `objectAsync` you can validate the data type of the input and whether the content matches `entries`. If the input is not an object, you can use `message` to customize the error message.
+
+> This schema removes unknown entries. The output will only include the entries you specify. To include unknown entries, use <Link href="../looseObjectAsync/">`looseObjectAsync`</Link>. To return an issue for unknown entries, use <Link href="../strictObjectAsync/">`strictObjectAsync`</Link>. To include and validate unknown entries, use <Link href="../objectWithRestAsync/">`objectWithRestAsync`</Link>.
+
+## Returns
+
+- `Schema` <Property {...properties.Schema} />
+
+## Examples
+
+The following examples show how `objectAsync` can be used. Please see the <Link href="/guides/objects/">object guide</Link> for more examples and explanations.
+
+### New user schema
+
+Schema to validate an object containing new user details.
+
+```ts
+import { isEmailPresent } from '~/api';
+
+const NewUserSchema = v.objectAsync({
+  firstName: v.pipe(v.string(), v.minLength(2), v.maxLength(45)),
+  lastName: v.pipe(v.string(), v.minLength(2), v.maxLength(45)),
+  email: v.pipeAsync(
+    v.string(),
+    v.email(),
+    v.checkAsync(isEmailPresent, 'The email is already in use by another user.')
+  ),
+  password: v.pipe(v.string(), v.minLength(8)),
+  avatar: v.optional(v.pipe(v.string(), v.url())),
+});
+```
+
+## Related
+
+The following APIs can be combined with `objectAsync`.
+
+### Schemas
+
+<ApiList
+  items={[
+    'any',
+    'array',
+    'bigint',
+    'blob',
+    'boolean',
+    'custom',
+    'date',
+    'enum',
+    'file',
+    'function',
+    'instance',
+    'intersect',
+    'lazy',
+    'literal',
+    'looseObject',
+    'looseTuple',
+    'map',
+    'nan',
+    'never',
+    'nonNullable',
+    'nonNullish',
+    'nonOptional',
+    'null',
+    'nullable',
+    'nullish',
+    'number',
+    'objectWithRest',
+    'optional',
+    'picklist',
+    'promise',
+    'record',
+    'set',
+    'strictObject',
+    'strictTuple',
+    'string',
+    'symbol',
+    'tuple',
+    'tupleWithRest',
+    'undefined',
+    'union',
+    'unknown',
+    'variant',
+    'void',
+  ]}
+/>
+
+### Methods
+
+<ApiList
+  items={['config', 'getDefault', 'getFallback', 'keyof', 'omit', 'pick']}
+/>
+
+### Actions
+
+<ApiList
+  items={[
+    'brand',
+    'check',
+    'partialCheck',
+    'rawCheck',
+    'rawTransform',
+    'readonly',
+    'transform',
+  ]}
+/>
+
+### Utils
+
+<ApiList items={['entriesFromList', 'isOfKind', 'isOfType']} />
+
+### Async
+
+<ApiList
+  items={[
+    'arrayAsync',
+    'checkAsync',
+    'customAsync',
+    'fallbackAsync',
+    'forwardAsync',
+    'getDefaultsAsync',
+    'getFallbacksAsync',
+    'intersectAsync',
+    'lazyAsync',
+    'looseObjectAsync',
+    'looseTupleAsync',
+    'mapAsync',
+    'nonNullableAsync',
+    'nonNullishAsync',
+    'nonOptionalAsync',
+    'nullableAsync',
+    'nullishAsync',
+    'objectWithRestAsync',
+    'optionalAsync',
+    'parseAsync',
+    'parserAsync',
+    'partialAsync',
+    'partialCheckAsync',
+    'pipeAsync',
+    'rawCheckAsync',
+    'rawTransformAsync',
+    'recordAsync',
+    'requiredAsync',
+    'safeParseAsync',
+    'safeParserAsync',
+    'setAsync',
+    'strictObjectAsync',
+    'strictTupleAsync',
+    'transformAsync',
+    'tupleAsync',
+    'tupleWithRestAsync',
+    'unionAsync',
+    'variantAsync',
+  ]}
+/>

--- a/website/src/routes/api/(async)/objectAsync/properties.ts
+++ b/website/src/routes/api/(async)/objectAsync/properties.ts
@@ -1,0 +1,62 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TEntries: {
+    modifier: 'extends',
+    type: {
+      type: 'custom',
+      name: 'ObjectEntriesAsync',
+      href: '../ObjectEntriesAsync/',
+    },
+  },
+  TMessage: {
+    modifier: 'extends',
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'ErrorMessage',
+          href: '../ErrorMessage/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'ObjectIssue',
+              href: '../ObjectIssue/',
+            },
+          ],
+        },
+        'undefined',
+      ],
+    },
+  },
+  entries: {
+    type: {
+      type: 'custom',
+      name: 'TEntries',
+    },
+  },
+  message: {
+    type: {
+      type: 'custom',
+      name: 'TMessage',
+    },
+  },
+  Schema: {
+    type: {
+      type: 'custom',
+      name: 'ObjectSchemaAsync',
+      href: '../ObjectSchemaAsync/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TEntries',
+        },
+        {
+          type: 'custom',
+          name: 'TMessage',
+        },
+      ],
+    },
+  },
+};

--- a/website/src/routes/api/(types)/ObjectSchemaAsync/index.mdx
+++ b/website/src/routes/api/(types)/ObjectSchemaAsync/index.mdx
@@ -3,6 +3,7 @@ title: ObjectSchemaAsync
 description: Object schema async type.
 contributors:
   - fabian-hiller
+  - EltonLobo07
 ---
 
 import { Property } from '~/components';

--- a/website/src/routes/api/(types)/ObjectSchemaAsync/properties.ts
+++ b/website/src/routes/api/(types)/ObjectSchemaAsync/properties.ts
@@ -32,6 +32,7 @@ export const properties: Record<string, PropertyProps> = {
   },
   BaseSchemaAsync: {
     type: {
+      modifier: 'extends',
       type: 'custom',
       name: 'BaseSchemaAsync',
       href: '../BaseSchemaAsync/',


### PR DESCRIPTION
This PR adds `objectAsync` and improves `ObjectSchemaAsync` API refs.

Question: The "Examples" section's description links to the [object guide](https://valibot.dev/guides/objects/) which contains sync examples and explanations. Do you think it is a good idea to add an [async guide](https://valibot.dev/guides/async-validation/) link too, so that the user is aware of the details related to asynchronous validation while reading the [object guide](https://valibot.dev/guides/objects/) page? Or can we assume that the user knows about async validation making the async guide link unnecessary? 