### PR TITLE
improve set input and output types API refs

### DIFF
--- a/website/src/routes/api/(types)/InferSetInput/index.mdx
+++ b/website/src/routes/api/(types)/InferSetInput/index.mdx
@@ -3,6 +3,7 @@ title: InferSetInput
 description: Infer set input type.
 contributors:
   - fabian-hiller
+  - EltonLobo07
 ---
 
 import { Property } from '~/components';

--- a/website/src/routes/api/(types)/InferSetInput/properties.ts
+++ b/website/src/routes/api/(types)/InferSetInput/properties.ts
@@ -4,17 +4,37 @@ export const properties: Record<string, PropertyProps> = {
   TValue: {
     modifier: 'extends',
     type: {
-      type: 'custom',
-      name: 'BaseSchema',
-      href: '../BaseSchema/',
-      generics: [
-        'unknown',
-        'unknown',
+      type: 'union',
+      options: [
         {
           type: 'custom',
-          name: 'BaseIssue',
-          href: '../BaseIssue/',
-          generics: ['unknown'],
+          name: 'BaseSchema',
+          href: '../BaseSchema/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
+        },
+        {
+          type: 'custom',
+          name: 'BaseSchemaAsync',
+          href: '../BaseSchemaAsync/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
         },
       ],
     },

--- a/website/src/routes/api/(types)/InferSetOutput/index.mdx
+++ b/website/src/routes/api/(types)/InferSetOutput/index.mdx
@@ -3,6 +3,7 @@ title: InferSetOutput
 description: Infer set output type.
 contributors:
   - fabian-hiller
+  - EltonLobo07
 ---
 
 import { Property } from '~/components';

--- a/website/src/routes/api/(types)/InferSetOutput/properties.ts
+++ b/website/src/routes/api/(types)/InferSetOutput/properties.ts
@@ -4,17 +4,37 @@ export const properties: Record<string, PropertyProps> = {
   TValue: {
     modifier: 'extends',
     type: {
-      type: 'custom',
-      name: 'BaseSchema',
-      href: '../BaseSchema/',
-      generics: [
-        'unknown',
-        'unknown',
+      type: 'union',
+      options: [
         {
           type: 'custom',
-          name: 'BaseIssue',
-          href: '../BaseIssue/',
-          generics: ['unknown'],
+          name: 'BaseSchema',
+          href: '../BaseSchema/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
+        },
+        {
+          type: 'custom',
+          name: 'BaseSchemaAsync',
+          href: '../BaseSchemaAsync/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
         },
       ],
     },


### PR DESCRIPTION
The `InferSetInput` and `InferSetOutput` types can also accept async set schemas. This PR adds this information to the API reference pages.