### PR TITLE
add `awaitAsync` API reference

### DIFF
--- a/website/src/routes/api/(async)/awaitAsync/index.mdx
+++ b/website/src/routes/api/(async)/awaitAsync/index.mdx
@@ -101,10 +101,6 @@ The following APIs can be combined with `awaitAsync`.
   ]}
 />
 
-### Methods
-
-<ApiList items={['config', 'getDefault', 'getFallback']} />
-
 ### Utils
 
 <ApiList items={['isOfKind', 'isOfType']} />
@@ -115,9 +111,6 @@ The following APIs can be combined with `awaitAsync`.
   items={[
     'arrayAsync',
     'customAsync',
-    'fallbackAsync',
-    'getDefaultsAsync',
-    'getFallbacksAsync',
     'intersectAsync',
     'lazyAsync',
     'looseObjectAsync',
@@ -131,13 +124,8 @@ The following APIs can be combined with `awaitAsync`.
     'objectAsync',
     'objectWithRestAsync',
     'optionalAsync',
-    'parseAsync',
-    'parserAsync',
-    'pipeAsync',
     'pipeAsync',
     'recordAsync',
-    'safeParseAsync',
-    'safeParserAsync',
     'setAsync',
     'strictObjectAsync',
     'strictTupleAsync',

--- a/website/src/routes/api/(async)/awaitAsync/index.mdx
+++ b/website/src/routes/api/(async)/awaitAsync/index.mdx
@@ -1,10 +1,149 @@
 ---
 title: awaitAsync
-source: /schemas/await/awaitAsync.ts
+description: Creates an await transformation action.
+source: /actions/await/awaitAsync.ts
 contributors:
+  - EltonLobo07
   - fabian-hiller
 ---
 
+import { ApiList, Property } from '~/components';
+import { properties } from './properties';
+
 # awaitAsync
 
-> The content of this page is not yet ready. Until then, please use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/schemas/await/awaitAsync.ts) or take a look at [issue #287](https://github.com/fabian-hiller/valibot/issues/287) to help us extend the API reference.
+Creates an await transformation action.
+
+```ts
+const Action = v.awaitAsync<TInput>();
+```
+
+## Generics
+
+- `TInput` <Property {...properties.TInput} />
+
+### Explanation
+
+With `awaitAsync` you can transform a promise into its resolved value.
+
+## Returns
+
+- `Action` <Property {...properties.Action} />
+
+## Examples
+
+The following examples show how `awaitAsync` can be used.
+
+### Unique emails schema
+
+Schema to check a set of emails wrapped in a promise object.
+
+```ts
+const UniqueEmailsSchema = v.pipeAsync(
+  v.promise(),
+  v.awaitAsync(),
+  v.set(v.pipe(v.string(), v.email()))
+);
+```
+
+## Related
+
+The following APIs can be combined with `awaitAsync`.
+
+### Schemas
+
+<ApiList
+  items={[
+    'any',
+    'array',
+    'bigint',
+    'blob',
+    'boolean',
+    'custom',
+    'date',
+    'enum',
+    'file',
+    'function',
+    'instance',
+    'intersect',
+    'lazy',
+    'literal',
+    'looseObject',
+    'looseTuple',
+    'map',
+    'nan',
+    'never',
+    'nonNullable',
+    'nonNullish',
+    'nonOptional',
+    'null',
+    'nullable',
+    'nullish',
+    'number',
+    'object',
+    'objectWithRest',
+    'optional',
+    'picklist',
+    'promise',
+    'record',
+    'set',
+    'strictObject',
+    'strictTuple',
+    'string',
+    'symbol',
+    'tuple',
+    'tupleWithRest',
+    'undefined',
+    'union',
+    'unknown',
+    'variant',
+    'void',
+  ]}
+/>
+
+### Methods
+
+<ApiList items={['config', 'getDefault', 'getFallback']} />
+
+### Utils
+
+<ApiList items={['isOfKind', 'isOfType']} />
+
+### Async
+
+<ApiList
+  items={[
+    'arrayAsync',
+    'customAsync',
+    'fallbackAsync',
+    'getDefaultsAsync',
+    'getFallbacksAsync',
+    'intersectAsync',
+    'lazyAsync',
+    'looseObjectAsync',
+    'looseTupleAsync',
+    'mapAsync',
+    'nonNullableAsync',
+    'nonNullishAsync',
+    'nonOptionalAsync',
+    'nullableAsync',
+    'nullishAsync',
+    'objectAsync',
+    'objectWithRestAsync',
+    'optionalAsync',
+    'parseAsync',
+    'parserAsync',
+    'pipeAsync',
+    'pipeAsync',
+    'recordAsync',
+    'safeParseAsync',
+    'safeParserAsync',
+    'setAsync',
+    'strictObjectAsync',
+    'strictTupleAsync',
+    'tupleAsync',
+    'tupleWithRestAsync',
+    'unionAsync',
+    'variantAsync',
+  ]}
+/>

--- a/website/src/routes/api/(async)/awaitAsync/properties.ts
+++ b/website/src/routes/api/(async)/awaitAsync/properties.ts
@@ -1,0 +1,25 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TInput: {
+    modifier: 'extends',
+    type: {
+      type: 'custom',
+      name: 'Promise',
+      generics: ['unknown'],
+    },
+  },
+  Action: {
+    type: {
+      type: 'custom',
+      name: 'AwaitActionAsync',
+      href: '../AwaitActionAsync/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TInput',
+        },
+      ],
+    },
+  },
+};


### PR DESCRIPTION
Since `awaitAsync` did not have an equivalent sync action (which is obvious but mentioned for context), I had to fill in the "related" schemas, methods, and utils. So I might have made a mistake, especially relating some methods to `awaitAsync`. I'll share my thoughts:

- For schemas, it is straightforward, as I can use any schema after awaiting the `promise` schema. That means, every schema can be listed.
- For methods, I copied the list from the `promise` schema and separated the sync and async methods properly. I think if a user needs to check the resolved value of a promise, the user will have to use the `promise` schema along with the `awaitAsync` action always. Then can proceed using any combination of schemas, methods and actions. 

Let me know if the reasoning is flawed.