### PR TITLE
fix `fallbackAsync` for async arg & add relevant tests

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the library will be documented in this file.
 - Add `base64` action to validate Base64 strings (pull request #644)
 - Refactor `HEXADECIMAL_REGEX` (pull request #666)
 - Change `EMOJI_REGEX` to be more accurate and strict (pull request #666)
+- Fix bug in `fallbackAsync` method for async schemas (pull request #732)
 
 ## v0.36.0 (July 05, 2024)
 

--- a/library/src/methods/fallback/fallbackAsync.test.ts
+++ b/library/src/methods/fallback/fallbackAsync.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
-import { transform } from '../../actions/index.ts';
-import { number } from '../../schemas/index.ts';
-import { pipe } from '../pipe/index.ts';
+import { checkAsync, transform } from '../../actions/index.ts';
+import { number, string } from '../../schemas/index.ts';
+import { pipe, pipeAsync } from '../pipe/index.ts';
 import {
   fallbackAsync,
   type SchemaWithFallbackAsync,
@@ -44,29 +44,63 @@ describe('fallbackAsync', () => {
     });
   });
 
-  const schema = fallbackAsync(
-    pipe(number(), transform(String)),
-    async () => '123'
-  );
+  describe('when sync schema passed as the argument', () => {
+    const schema = fallbackAsync(
+      pipe(number(), transform(String)),
+      async () => '123'
+    );
 
-  describe('should return default dataset', () => {
-    test('for valid input', async () => {
-      expect(await schema._run({ typed: false, value: 789 }, {})).toStrictEqual(
-        {
+    describe('should return default dataset', () => {
+      test('for valid input', async () => {
+        expect(
+          await schema._run({ typed: false, value: 789 }, {})
+        ).toStrictEqual({
           typed: true,
           value: '789',
-        }
-      );
+        });
+      });
+    });
+
+    describe('should return dataset with fallback', () => {
+      test('for invalid input', async () => {
+        expect(
+          await schema._run({ typed: false, value: 'foo' }, {})
+        ).toStrictEqual({
+          typed: true,
+          value: '123',
+        });
+      });
     });
   });
 
-  describe('should return dataset with fallback', () => {
-    test('for invalid input', async () => {
-      expect(
-        await schema._run({ typed: false, value: 'foo' }, {})
-      ).toStrictEqual({
-        typed: true,
-        value: '123',
+  describe('when async schema passed as the argument', () => {
+    const schema = fallbackAsync(
+      pipeAsync(
+        string(),
+        checkAsync(async (value) => value === 'abcde')
+      ),
+      async () => '12345'
+    );
+
+    describe('should return default dataset', () => {
+      test('for valid input', async () => {
+        expect(
+          await schema._run({ typed: false, value: 'abcde' }, {})
+        ).toStrictEqual({
+          typed: true,
+          value: 'abcde',
+        });
+      });
+    });
+
+    describe('should return dataset with fallback', () => {
+      test('for invalid input', async () => {
+        expect(
+          await schema._run({ typed: false, value: 'abc' }, {})
+        ).toStrictEqual({
+          typed: true,
+          value: '12345',
+        });
       });
     });
   });

--- a/library/src/methods/fallback/fallbackAsync.test.ts
+++ b/library/src/methods/fallback/fallbackAsync.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
-import { checkAsync, transform } from '../../actions/index.ts';
-import { number, string } from '../../schemas/index.ts';
-import { pipe, pipeAsync } from '../pipe/index.ts';
+import { transformAsync } from '../../actions/index.ts';
+import { number } from '../../schemas/index.ts';
+import { pipeAsync } from '../pipe/index.ts';
 import {
   fallbackAsync,
   type SchemaWithFallbackAsync,
@@ -9,7 +9,10 @@ import {
 
 describe('fallbackAsync', () => {
   describe('should return schema object', () => {
-    const schema = pipe(number(), transform(String));
+    const schema = pipeAsync(
+      number(),
+      transformAsync(async (input) => String(input))
+    );
     type Schema = typeof schema;
     const baseSchema: Omit<
       SchemaWithFallbackAsync<Schema, never>,
@@ -44,63 +47,32 @@ describe('fallbackAsync', () => {
     });
   });
 
-  describe('when sync schema passed as the argument', () => {
-    const schema = fallbackAsync(
-      pipe(number(), transform(String)),
-      async () => '123'
-    );
+  const schema = fallbackAsync(
+    pipeAsync(
+      number(),
+      transformAsync(async (input) => String(input))
+    ),
+    async () => '123'
+  );
 
-    describe('should return default dataset', () => {
-      test('for valid input', async () => {
-        expect(
-          await schema._run({ typed: false, value: 789 }, {})
-        ).toStrictEqual({
+  describe('should return default dataset', () => {
+    test('for valid input', async () => {
+      expect(await schema._run({ typed: false, value: 789 }, {})).toStrictEqual(
+        {
           typed: true,
           value: '789',
-        });
-      });
-    });
-
-    describe('should return dataset with fallback', () => {
-      test('for invalid input', async () => {
-        expect(
-          await schema._run({ typed: false, value: 'foo' }, {})
-        ).toStrictEqual({
-          typed: true,
-          value: '123',
-        });
-      });
+        }
+      );
     });
   });
 
-  describe('when async schema passed as the argument', () => {
-    const schema = fallbackAsync(
-      pipeAsync(
-        string(),
-        checkAsync(async (value) => value === 'abcde')
-      ),
-      async () => '12345'
-    );
-
-    describe('should return default dataset', () => {
-      test('for valid input', async () => {
-        expect(
-          await schema._run({ typed: false, value: 'abcde' }, {})
-        ).toStrictEqual({
-          typed: true,
-          value: 'abcde',
-        });
-      });
-    });
-
-    describe('should return dataset with fallback', () => {
-      test('for invalid input', async () => {
-        expect(
-          await schema._run({ typed: false, value: 'abc' }, {})
-        ).toStrictEqual({
-          typed: true,
-          value: '12345',
-        });
+  describe('should return dataset with fallback', () => {
+    test('for invalid input', async () => {
+      expect(
+        await schema._run({ typed: false, value: 'foo' }, {})
+      ).toStrictEqual({
+        typed: true,
+        value: '123',
       });
     });
   });

--- a/library/src/methods/fallback/fallbackAsync.ts
+++ b/library/src/methods/fallback/fallbackAsync.ts
@@ -79,7 +79,7 @@ export function fallbackAsync<
     fallback,
     async: true,
     async _run(dataset, config) {
-      schema._run(dataset, config);
+      await schema._run(dataset, config);
       return dataset.issues
         ? // @ts-expect-error
           { typed: true, value: await getFallback(this, dataset, config) }


### PR DESCRIPTION
This PR fixes the issue related to `fallbackAsync` given any async schema.

Issue:

When the validation of an async schema fails, `fallbackAsync` still returns the default value instead of the supplied fallback value. The code block given below exposes this bug.
```
import * as v from 'valibot';

const Schema = v.fallbackAsync(
  v.pipeAsync(
    v.string(),
    v.checkAsync(async (value) => false)
  ),
  "fallback"
);

// logs: default
console.log(await v.safeParseAsync(Schema, "default"));
```
Fix:

Inside the `_run` method of the object returned by `fallbackAsync`, wait for the schema to run completely before checking if the dataset has any issues. This is needed as `fallbackAsync` can be given an async schema that might execute some async code.

Additional information:

Simply waiting for the async code to complete fixes the issue, but I was worried about the rejected promise case. I checked some of the other methods and found out that there is no logic to catch rejected promises. I assume this is intentional, and the thought process behind this approach would be to let the user handle rejected promises. Let me know if my assumption is incorrect.