### PR TITLE
docs: add next-safe-action library to ecosystem page

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -16,6 +16,7 @@ contributors:
   - IlyaSemenov
   - jmcdo29
   - ZerNico
+  - TheEdoRan
 ---
 
 # Ecosystem
@@ -34,6 +35,7 @@ Use the button at the bottom left of this page to add your project to this ecosy
 
 - [Drizzle ORM](https://orm.drizzle.team/): TypeScript ORM that feels like writing SQL
 - [Hono](https://hono.dev/): Ultrafast web framework for the Edges
+- [next-safe-action](https://next-safe-action.dev) Type safe and validated Server Actions for Next.js
 - [tRPC](https://trpc.io/): Move Fast and Break Nothing. End-to-end typesafe APIs made easy
 
 ### Form libraries


### PR DESCRIPTION
Code in this PR adds next-safe-action library to the ecosystem page, as suggested by Fabian in [this tweet](https://x.com/FabianHiller/status/1814702642141995460).