### PR TITLE
add `getFallbacksAsync` API reference

### DIFF
--- a/website/src/routes/api/(async)/getFallbacksAsync/index.mdx
+++ b/website/src/routes/api/(async)/getFallbacksAsync/index.mdx
@@ -1,10 +1,167 @@
 ---
 title: getFallbacksAsync
+description: Returns the fallback values of the schema.
 source: /methods/getFallbacks/getFallbacksAsync.ts
 contributors:
+  - EltonLobo07
   - fabian-hiller
 ---
 
+import { Link } from '@builder.io/qwik-city';
+import { ApiList, Property } from '~/components';
+import { properties } from './properties';
+
 # getFallbacksAsync
 
-> The content of this page is not yet ready. Until then, please use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/methods/getFallbacks/getFallbacksAsync.ts) or take a look at [issue #287](https://github.com/fabian-hiller/valibot/issues/287) to help us extend the API reference.
+Returns the fallback values of the schema.
+
+> The difference to <Link href='../getFallback/'>`getFallback`</Link> is that for object and tuple schemas this function recursively returns the fallback values of the subschemas instead of `undefined`.
+
+```ts
+const values = v.getFallbacksAsync<TSchema>(schema);
+```
+
+## Generics
+
+- `TSchema` <Property {...properties.TSchema} />
+
+## Parameters
+
+- `schema` <Property {...properties.schema} />
+
+## Returns
+
+- `values` <Property {...properties.values} />
+
+## Examples
+
+The following examples show how `getFallbacksAsync` can be used.
+
+### New user fallbacks
+
+Get the fallback values of a new user schema.
+
+```ts
+import { getAnyUniqueUsername, isUsernameUnique } from '~/api';
+
+const NewUserSchema = v.objectAsync({
+  username: v.fallbackAsync(
+    v.pipeAsync(v.string(), v.minLength(3), v.checkAsync(isUsernameUnique)),
+    getAnyUniqueUsername
+  ),
+  password: v.pipe(v.string(), v.minLength(8)),
+});
+
+const fallbackValues = await v.getFallbacksAsync(NewUserSchema);
+/*
+  {
+    username: "cookieMonster07",
+    password: undefined
+  }
+*/
+```
+
+## Related
+
+The following APIs can be combined with `getFallbacksAsync`.
+
+### Schemas
+
+<ApiList
+  items={[
+    'any',
+    'array',
+    'bigint',
+    'blob',
+    'boolean',
+    'custom',
+    'date',
+    'enum',
+    'file',
+    'function',
+    'instance',
+    'intersect',
+    'lazy',
+    'literal',
+    'looseObject',
+    'looseTuple',
+    'map',
+    'nan',
+    'never',
+    'nonNullable',
+    'nonNullish',
+    'nonOptional',
+    'null',
+    'nullable',
+    'nullish',
+    'number',
+    'object',
+    'objectWithRest',
+    'optional',
+    'picklist',
+    'promise',
+    'record',
+    'set',
+    'strictObject',
+    'strictTuple',
+    'string',
+    'symbol',
+    'tuple',
+    'tupleWithRest',
+    'undefined',
+    'union',
+    'unknown',
+    'variant',
+    'void',
+  ]}
+/>
+
+### Methods
+
+<ApiList
+  items={[
+    'config',
+    'fallback',
+    'keyof',
+    'omit',
+    'partial',
+    'pick',
+    'pipe',
+    'required',
+    'unwrap',
+  ]}
+/>
+
+### Async
+
+<ApiList
+  items={[
+    'arrayAsync',
+    'customAsync',
+    'intersectAsync',
+    'lazyAsync',
+    'looseObjectAsync',
+    'looseTupleAsync',
+    'mapAsync',
+    'nonNullableAsync',
+    'nonNullishAsync',
+    'nonOptionalAsync',
+    'nullableAsync',
+    'nullishAsync',
+    'objectAsync',
+    'objectWithRestAsync',
+    'optionalAsync',
+    'recordAsync',
+    'setAsync',
+    'strictObjectAsync',
+    'strictTupleAsync',
+    'tupleAsync',
+    'tupleWithRestAsync',
+    'unionAsync',
+    'variantAsync',
+    'fallbackAsync',
+    'partialAsync',
+    'pipeAsync',
+    'requiredAsync',
+  ]}
+/>

--- a/website/src/routes/api/(async)/getFallbacksAsync/index.mdx
+++ b/website/src/routes/api/(async)/getFallbacksAsync/index.mdx
@@ -138,6 +138,7 @@ The following APIs can be combined with `getFallbacksAsync`.
   items={[
     'arrayAsync',
     'customAsync',
+    'fallbackAsync',
     'intersectAsync',
     'lazyAsync',
     'looseObjectAsync',
@@ -151,7 +152,10 @@ The following APIs can be combined with `getFallbacksAsync`.
     'objectAsync',
     'objectWithRestAsync',
     'optionalAsync',
+    'partialAsync',
+    'pipeAsync',
     'recordAsync',
+    'requiredAsync',
     'setAsync',
     'strictObjectAsync',
     'strictTupleAsync',
@@ -159,9 +163,5 @@ The following APIs can be combined with `getFallbacksAsync`.
     'tupleWithRestAsync',
     'unionAsync',
     'variantAsync',
-    'fallbackAsync',
-    'partialAsync',
-    'pipeAsync',
-    'requiredAsync',
   ]}
 />

--- a/website/src/routes/api/(async)/getFallbacksAsync/properties.ts
+++ b/website/src/routes/api/(async)/getFallbacksAsync/properties.ts
@@ -1,0 +1,67 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TSchema: {
+    modifier: 'extends',
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'BaseSchema',
+          href: '../BaseSchema/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
+        },
+        {
+          type: 'custom',
+          name: 'BaseSchemaAsync',
+          href: '../BaseSchemaAsync/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  schema: {
+    type: {
+      type: 'custom',
+      name: 'TSchema',
+    },
+  },
+  values: {
+    type: {
+      type: 'custom',
+      name: 'Promise',
+      generics: [
+        {
+          type: 'custom',
+          name: 'InferFallbacks',
+          href: '../InferFallbacks/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'TSchema',
+            },
+          ],
+        },
+      ],
+    },
+  },
+};


### PR DESCRIPTION
I have used the same example that was added to `fallbackAsync` as I was unable to think of a better example. I'll try to come up with better examples once most of the API references are added. Feel free to update or add examples if you have something better. 