### PR TITLE
Improve performance of maxBytes()

### DIFF
--- a/library/src/actions/maxBytes/maxBytes.ts
+++ b/library/src/actions/maxBytes/maxBytes.ts
@@ -105,6 +105,8 @@ export function maxBytes(
   number,
   ErrorMessage<MaxBytesIssue<string, number>> | undefined
 > {
+  let cachedTextEncoder: TextEncoder;
+  let cachedUint8Array: Uint8Array;
   return {
     kind: 'validation',
     type: 'max_bytes',
@@ -115,8 +117,10 @@ export function maxBytes(
     message,
     _run(dataset, config) {
       if (dataset.typed) {
-        const length = new TextEncoder().encode(dataset.value).length;
-        if (length > this.requirement) {
+        cachedTextEncoder ??= new TextEncoder()
+        cachedUint8Array ??= new Uint8Array(requirement + 1)
+        const written = cachedTextEncoder.encodeInto(dataset.value, cachedUint8Array).written;
+        if (written > this.requirement) {
           _addIssue(this, 'bytes', dataset, config, {
             received: `${length}`,
           });

--- a/library/src/actions/maxBytes/maxBytes.ts
+++ b/library/src/actions/maxBytes/maxBytes.ts
@@ -118,7 +118,7 @@ export function maxBytes(
     _run(dataset, config) {
       if (dataset.typed) {
         cachedTextEncoder ??= new TextEncoder()
-        cachedUint8Array ??= new Uint8Array(requirement + 1)
+        cachedUint8Array ??= new Uint8Array(requirement + 4)
         const written = cachedTextEncoder.encodeInto(dataset.value, cachedUint8Array).written;
         if (written > this.requirement) {
           _addIssue(this, 'bytes', dataset, config, {


### PR DESCRIPTION
I'd like to use `maxBytes()` to help prevent certain types of abuse sending large amounts of data to clients in order to overload them. This makes it fairly important that `maxBytes()` is as fast as possible and is not itself a bottleneck if someone attempts to send hundreds of megabytes of data

### Before:

Since the current implementation will always read all of the bytes of the string, there is no significant difference between size limits enforced

| input/limit | any size    |
| ----------- | -----------:|
| 1B          | 1’894’455.1 |
| 5MB         | 1’507.1     |
| 50MB        | 150.1       |
| 500MB       | 13.4        |
| max         | 12.5        |

> All values are operations per second, tested on an 2021 Apple M1 Pro MacBook Pro.

### After: (ops/sec)

Caching Uint8Array speeds up 1B inputs by about 30x, and because this new implementation stops reading/writing `N+4` after the maxBytes `requirement`, the performance is more dependent on the `requirement` than the input itself

> Note: It needs to read past the `requirement` to test if the string is too long, the `+4` bytes is because the next character in the string could be anywhere from 1-4 bytes, and `encodeInto()` will drop it if there's not enough room in the array.

| input/limit | <=5MB        | <=50MB       | <=500MB      |
| ----------- | ------------:| ------------:| ------------:|
| 1B          | 30’240’582.3 | 31’011’981.5 | 30’389’671.3 |
| 5MB         | 6’611.1      | 7’095.6      | 7’071.8      |
| 50MB        | 6’736.9      | 551.4        | 498.7        |
| 500MB       | 6’685.8      | 547.4        | 51.6         |
| max         | 6’318.7      | 538.0        | 51.5         |

> All values are operations per second, tested on an 2021 Apple M1 Pro MacBook Pro.