### PR TITLE
improve `objectAsync` and `intersect` API refs

### DIFF
--- a/website/src/routes/api/(async)/objectAsync/index.mdx
+++ b/website/src/routes/api/(async)/objectAsync/index.mdx
@@ -99,6 +99,7 @@ The following APIs can be combined with `objectAsync`.
     'nullable',
     'nullish',
     'number',
+    'object',
     'objectWithRest',
     'optional',
     'picklist',

--- a/website/src/routes/api/(schemas)/intersect/index.mdx
+++ b/website/src/routes/api/(schemas)/intersect/index.mdx
@@ -4,6 +4,7 @@ description: Creates an intersect schema.
 source: /schemas/intersect/intersect.ts
 contributors:
   - fabian-hiller
+  - EltonLobo07
 ---
 
 import { Link } from '@builder.io/qwik-city';
@@ -101,7 +102,6 @@ The following APIs can be combined with `intersect`.
     'tupleWithRest',
     'undefined',
     'union',
-    'intersect',
     'unknown',
     'variant',
     'void',


### PR DESCRIPTION
Improvements:
- Remove `intersect` from the related schemas section of the `intersect` schema.
- Add `object` to the related schemas section of the `objectAsync` schema as they are related.