### PR TITLE
improve `lazy` API reference

### DIFF
--- a/website/src/routes/api/(schemas)/lazy/index.mdx
+++ b/website/src/routes/api/(schemas)/lazy/index.mdx
@@ -5,6 +5,7 @@ source: /schemas/lazy/lazy.ts
 contributors:
   - fabian-hiller
   - morinokami
+  - EltonLobo07
 ---
 
 import { Link } from '@builder.io/qwik-city';
@@ -16,12 +17,12 @@ import { properties } from './properties';
 Creates a lazy schema.
 
 ```ts
-const Schema = v.lazy<TGetter>(getter);
+const Schema = v.lazy<TWrapped>(getter);
 ```
 
 ## Generics
 
-- `TGetter` <Property {...properties.TGetter} />
+- `TWrapped` <Property {...properties.TWrapped} />
 
 ## Parameters
 
@@ -43,7 +44,7 @@ The following examples show how `lazy` can be used.
 
 Recursive schema to validate a binary tree.
 
-> Due to a TypeScript limitation, the input and output types of recursive schemas cannot be inferred automatically. Therefore, you must explicitly specify these types using <Link href="/api/BaseSchema/">`BaseSchema`</Link>.
+> Due to a TypeScript limitation, the input and output types of recursive schemas cannot be inferred automatically. Therefore, you must explicitly specify these types using <Link href="/api/GenericSchema/">`GenericSchema`</Link>.
 
 ```ts
 type BinaryTree = {

--- a/website/src/routes/api/(schemas)/lazy/properties.ts
+++ b/website/src/routes/api/(schemas)/lazy/properties.ts
@@ -1,32 +1,32 @@
 import type { PropertyProps } from '~/components';
 
 export const properties: Record<string, PropertyProps> = {
-  TGetter: {
+  TWrapped: {
     modifier: 'extends',
+    type: {
+      type: 'custom',
+      name: 'BaseSchema',
+      href: '../BaseSchema/',
+      generics: [
+        'unknown',
+        'unknown',
+        {
+          type: 'custom',
+          name: 'BaseIssue',
+          href: '../BaseIssue/',
+          generics: ['unknown'],
+        },
+      ],
+    },
+  },
+  getter: {
     type: {
       type: 'function',
       params: [{ name: 'input', type: 'unknown' }],
       return: {
         type: 'custom',
-        name: 'BaseSchema',
-        href: '../BaseSchema/',
-        generics: [
-          'unknown',
-          'unknown',
-          {
-            type: 'custom',
-            name: 'BaseIssue',
-            href: '../BaseIssue/',
-            generics: ['unknown'],
-          },
-        ],
+        name: 'TWrapped',
       },
-    },
-  },
-  getter: {
-    type: {
-      type: 'custom',
-      name: 'TGetter',
     },
   },
   Schema: {
@@ -37,7 +37,7 @@ export const properties: Record<string, PropertyProps> = {
       generics: [
         {
           type: 'custom',
-          name: 'TGetter',
+          name: 'TWrapped',
         },
       ],
     },


### PR DESCRIPTION
Improvements:
- Change the name and constraint of the type parameter.
- Change the type of the `getter` parameter.
- Update the name of the type argument of `LazySchema`.
- Recommend `GenericSchema` to explicitly specify types.