### PR TITLE
Fix public API errors

### DIFF
--- a/library/src/schemas/lazy/lazy.test-d.ts
+++ b/library/src/schemas/lazy/lazy.test-d.ts
@@ -1,5 +1,12 @@
 import { describe, expectTypeOf, test } from 'vitest';
-import type { InferInput, InferIssue, InferOutput } from '../../types/index.ts';
+import type {
+  GenericSchema,
+  InferInput,
+  InferIssue,
+  InferOutput,
+} from '../../types/index.ts';
+import { object } from '../object/object.ts';
+import { optional } from '../optional/optional.ts';
 import {
   string,
   type StringIssue,
@@ -28,5 +35,25 @@ describe('lazy', () => {
     test('of issue', () => {
       expectTypeOf<InferIssue<Schema>>().toEqualTypeOf<StringIssue>();
     });
+  });
+
+  test('should handle recursion', () => {
+    interface BinaryTree {
+      element: string;
+      left?: BinaryTree;
+      right?: BinaryTree;
+    }
+
+    const BinaryTreeSchema: GenericSchema<BinaryTree> = object({
+      element: string(),
+      left: optional(lazy(() => BinaryTreeSchema)),
+      right: optional(lazy(() => BinaryTreeSchema)),
+    });
+
+    expectTypeOf<
+      NonNullable<
+        NonNullable<InferInput<typeof BinaryTreeSchema>['left']>['right']
+      >
+    >().toEqualTypeOf<BinaryTree>();
   });
 });

--- a/library/src/schemas/object/object.test-d.ts
+++ b/library/src/schemas/object/object.test-d.ts
@@ -2,6 +2,11 @@ import { describe, expectTypeOf, test } from 'vitest';
 import type { ReadonlyAction } from '../../actions/index.ts';
 import type { SchemaWithPipe } from '../../methods/index.ts';
 import type { InferInput, InferIssue, InferOutput } from '../../types/index.ts';
+import type { LazySchema } from '../lazy/index.ts';
+import type {
+  NonNullableIssue,
+  NonNullableSchema,
+} from '../nonNullable/index.ts';
 import type { NullishSchema } from '../nullish/index.ts';
 import type { NumberIssue, NumberSchema } from '../number/index.ts';
 import type { OptionalSchema } from '../optional/index.ts';
@@ -10,6 +15,7 @@ import {
   type StringIssue,
   type StringSchema,
 } from '../string/index.ts';
+import type { UndefinedIssue, UndefinedSchema } from '../undefined/index.ts';
 import { object, type ObjectSchema } from './object.ts';
 import type { ObjectIssue } from './types.ts';
 
@@ -45,6 +51,8 @@ describe('object', () => {
         key3: NullishSchema<StringSchema<undefined>, never>;
         key4: ObjectSchema<{ key: NumberSchema<undefined> }, never>;
         key5: SchemaWithPipe<[StringSchema<undefined>, ReadonlyAction<string>]>;
+        key6: LazySchema<UndefinedSchema<undefined>>;
+        key7: NonNullableSchema<UndefinedSchema<undefined>, undefined>;
       },
       undefined
     >;
@@ -56,6 +64,8 @@ describe('object', () => {
         key3?: string | null | undefined;
         key4: { key: number };
         key5: string;
+        key6: undefined;
+        key7: undefined;
       }>();
     });
 
@@ -66,12 +76,18 @@ describe('object', () => {
         key3?: string | null | undefined;
         key4: { key: number };
         readonly key5: string;
+        key6: undefined;
+        key7: undefined;
       }>();
     });
 
     test('of issue', () => {
       expectTypeOf<InferIssue<Schema>>().toEqualTypeOf<
-        ObjectIssue | StringIssue | NumberIssue
+        | ObjectIssue
+        | StringIssue
+        | NumberIssue
+        | UndefinedIssue
+        | NonNullableIssue
       >();
     });
   });

--- a/library/src/schemas/object/object.test-d.ts
+++ b/library/src/schemas/object/object.test-d.ts
@@ -53,6 +53,12 @@ describe('object', () => {
         key5: SchemaWithPipe<[StringSchema<undefined>, ReadonlyAction<string>]>;
         key6: LazySchema<UndefinedSchema<undefined>>;
         key7: NonNullableSchema<UndefinedSchema<undefined>, undefined>;
+        key8: LazySchema<
+          NonNullableSchema<
+            NullishSchema<StringSchema<undefined>, 'foo'>,
+            undefined
+          >
+        >;
       },
       undefined
     >;
@@ -66,6 +72,7 @@ describe('object', () => {
         key5: string;
         key6: undefined;
         key7: undefined;
+        key8?: string | undefined;
       }>();
     });
 
@@ -78,6 +85,7 @@ describe('object', () => {
         readonly key5: string;
         key6: undefined;
         key7: undefined;
+        key8: string;
       }>();
     });
 

--- a/library/src/schemas/object/objectAsync.test-d.ts
+++ b/library/src/schemas/object/objectAsync.test-d.ts
@@ -2,6 +2,9 @@ import { describe, expectTypeOf, test } from 'vitest';
 import type { ReadonlyAction } from '../../actions/index.ts';
 import type { SchemaWithPipe } from '../../methods/index.ts';
 import type { InferInput, InferIssue, InferOutput } from '../../types/index.ts';
+import type { LazySchemaAsync } from '../lazy/index.ts';
+import type { NonNullableSchemaAsync } from '../nonNullable/index.ts';
+import type { NonNullableIssue } from '../nonNullable/index.ts';
 import type { NullishSchema } from '../nullish/index.ts';
 import type { NumberIssue, NumberSchema } from '../number/index.ts';
 import type { OptionalSchema } from '../optional/index.ts';
@@ -10,6 +13,7 @@ import {
   type StringIssue,
   type StringSchema,
 } from '../string/index.ts';
+import type { UndefinedIssue, UndefinedSchema } from '../undefined/index.ts';
 import { objectAsync, type ObjectSchemaAsync } from './objectAsync.ts';
 import type { ObjectIssue } from './types.ts';
 
@@ -45,6 +49,8 @@ describe('objectAsync', () => {
         key3: NullishSchema<StringSchema<undefined>, never>;
         key4: ObjectSchemaAsync<{ key: NumberSchema<undefined> }, never>;
         key5: SchemaWithPipe<[StringSchema<undefined>, ReadonlyAction<string>]>;
+        key6: LazySchemaAsync<UndefinedSchema<undefined>>;
+        key7: NonNullableSchemaAsync<UndefinedSchema<undefined>, undefined>;
       },
       undefined
     >;
@@ -56,6 +62,8 @@ describe('objectAsync', () => {
         key3?: string | null | undefined;
         key4: { key: number };
         key5: string;
+        key6: undefined;
+        key7: undefined;
       }>();
     });
 
@@ -66,12 +74,18 @@ describe('objectAsync', () => {
         key3?: string | null | undefined;
         key4: { key: number };
         readonly key5: string;
+        key6: undefined;
+        key7: undefined;
       }>();
     });
 
     test('of issue', () => {
       expectTypeOf<InferIssue<Schema>>().toEqualTypeOf<
-        ObjectIssue | StringIssue | NumberIssue
+        | ObjectIssue
+        | StringIssue
+        | NumberIssue
+        | UndefinedIssue
+        | NonNullableIssue
       >();
     });
   });

--- a/library/src/schemas/object/objectAsync.test-d.ts
+++ b/library/src/schemas/object/objectAsync.test-d.ts
@@ -51,6 +51,12 @@ describe('objectAsync', () => {
         key5: SchemaWithPipe<[StringSchema<undefined>, ReadonlyAction<string>]>;
         key6: LazySchemaAsync<UndefinedSchema<undefined>>;
         key7: NonNullableSchemaAsync<UndefinedSchema<undefined>, undefined>;
+        key8: LazySchemaAsync<
+          NonNullableSchemaAsync<
+            NullishSchema<StringSchema<undefined>, 'foo'>,
+            undefined
+          >
+        >;
       },
       undefined
     >;
@@ -64,6 +70,7 @@ describe('objectAsync', () => {
         key5: string;
         key6: undefined;
         key7: undefined;
+        key8?: string | undefined;
       }>();
     });
 
@@ -76,6 +83,7 @@ describe('objectAsync', () => {
         readonly key5: string;
         key6: undefined;
         key7: undefined;
+        key8: string;
       }>();
     });
 

--- a/library/src/types/issue.ts
+++ b/library/src/types/issue.ts
@@ -291,8 +291,7 @@ type TupleKeys<TItems extends TupleItems | TupleItemsAsync> = Exclude<
  * Tuple path type.
  */
 type TuplePath<TItems extends TupleItems | TupleItemsAsync> = {
-  // @ts-expect-error
-  [TKey in TupleKeys<TItems>]: DotPath<TKey, TItems[TKey]>;
+  [TKey in keyof TItems]: DotPath<TKey, TItems[TKey]>;
 }[TupleKeys<TItems>];
 
 /**

--- a/library/src/types/other.ts
+++ b/library/src/types/other.ts
@@ -90,11 +90,9 @@ export type DefaultValue<
 export type QuestionMarkSchema =
   | NullishSchema<BaseSchema<unknown, unknown, BaseIssue<unknown>>, unknown>
   | OptionalSchema<BaseSchema<unknown, unknown, BaseIssue<unknown>>, unknown>
-  // @ts-expect-error
-  | LazySchema<QuestionMarkSchema>
+  | LazySchema<BaseSchema<unknown, unknown, BaseIssue<unknown>>>
   | NonNullableSchema<
-      // @ts-expect-error
-      QuestionMarkSchema,
+      BaseSchema<unknown, unknown, BaseIssue<unknown>>,
       ErrorMessage<NonNullableIssue> | undefined
     >;
 
@@ -112,10 +110,12 @@ export type QuestionMarkSchemaAsync =
       | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
       unknown
     >
-  // @ts-expect-error
-  | LazySchemaAsync<QuestionMarkSchema | QuestionMarkSchemaAsync>
+  | LazySchemaAsync<
+      | BaseSchema<unknown, unknown, BaseIssue<unknown>>
+      | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
+    >
   | NonNullableSchemaAsync<
-      // @ts-expect-error
-      QuestionMarkSchema | QuestionMarkSchemaAsync,
+      | BaseSchema<unknown, unknown, BaseIssue<unknown>>
+      | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
       ErrorMessage<NonNullableIssue> | undefined
     >;

--- a/library/src/types/other.ts
+++ b/library/src/types/other.ts
@@ -80,6 +80,10 @@ export type DefaultValue<
       : TDefault
     : never;
 
+type QuestionMarkSchemaBase =
+  | NullishSchema<BaseSchema<unknown, unknown, BaseIssue<unknown>>, unknown>
+  | OptionalSchema<BaseSchema<unknown, unknown, BaseIssue<unknown>>, unknown>;
+
 /**
  * Question mark schema type.
  *
@@ -88,18 +92,14 @@ export type DefaultValue<
  * `nullish`.
  */
 export type QuestionMarkSchema =
-  | NullishSchema<BaseSchema<unknown, unknown, BaseIssue<unknown>>, unknown>
-  | OptionalSchema<BaseSchema<unknown, unknown, BaseIssue<unknown>>, unknown>
-  | LazySchema<BaseSchema<unknown, unknown, BaseIssue<unknown>>>
+  | QuestionMarkSchemaBase
+  | LazySchema<QuestionMarkSchemaBase>
   | NonNullableSchema<
-      BaseSchema<unknown, unknown, BaseIssue<unknown>>,
+      QuestionMarkSchemaBase,
       ErrorMessage<NonNullableIssue> | undefined
     >;
 
-/**
- * Question mark schema async type.
- */
-export type QuestionMarkSchemaAsync =
+type QuestionMarkSchemaAsyncBase =
   | NullishSchemaAsync<
       | BaseSchema<unknown, unknown, BaseIssue<unknown>>
       | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
@@ -109,13 +109,15 @@ export type QuestionMarkSchemaAsync =
       | BaseSchema<unknown, unknown, BaseIssue<unknown>>
       | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
       unknown
-    >
-  | LazySchemaAsync<
-      | BaseSchema<unknown, unknown, BaseIssue<unknown>>
-      | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
-    >
+    >;
+
+/**
+ * Question mark schema async type.
+ */
+export type QuestionMarkSchemaAsync =
+  | QuestionMarkSchemaAsyncBase
+  | LazySchemaAsync<QuestionMarkSchemaBase | QuestionMarkSchemaAsyncBase>
   | NonNullableSchemaAsync<
-      | BaseSchema<unknown, unknown, BaseIssue<unknown>>
-      | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
+      QuestionMarkSchemaBase | QuestionMarkSchemaAsyncBase,
       ErrorMessage<NonNullableIssue> | undefined
     >;

--- a/library/src/utils/getDotPath/getDotPath.test-d.ts
+++ b/library/src/utils/getDotPath/getDotPath.test-d.ts
@@ -1,0 +1,15 @@
+import { assert, describe, expectTypeOf, test } from 'vitest';
+import { safeParse } from '../../methods/index.ts';
+import { number, object, string, tuple } from '../../schemas/index.ts';
+import { getDotPath } from './getDotPath.ts';
+
+describe('getDotPath', () => {
+  test('should infer correct dot path type', () => {
+    const schema = object({ foo: tuple([string(), number()]) });
+    const issue = safeParse(schema, {}).issues?.[0];
+    assert(issue !== undefined);
+    expectTypeOf(getDotPath<typeof schema>(issue)).toEqualTypeOf<
+      'foo' | 'foo.0' | 'foo.1' | null
+    >();
+  });
+});

--- a/website/src/routes/guides/(get-started)/installation/index.mdx
+++ b/website/src/routes/guides/(get-started)/installation/index.mdx
@@ -18,7 +18,7 @@ Except for this guide, the rest of this documentation assumes that you are using
 
 It should make no difference whether you use individual imports or a wildcard import. Tree shaking and code splitting should work in both cases.
 
-If you are using TypeScript, I recommend that you enable strict mode in your `tsconfig.json` so that all types are calculated correctly and skip library checks.
+If you are using TypeScript, I recommend that you enable strict mode in your `tsconfig.json` so that all types are calculated correctly.
 
 > The minimum required TypeScript version is v5.0.2.
 
@@ -26,7 +26,6 @@ If you are using TypeScript, I recommend that you enable strict mode in your `ts
 {
   "compilerOptions": {
     "strict": true,
-    "skipLibCheck": true,
     // ...
   }
 }


### PR DESCRIPTION
Fix https://github.com/fabian-hiller/valibot/issues/776
Fix https://github.com/fabian-hiller/valibot/issues/659

The `getDotPath` test seems alright, but I'm not sure if the `lazy` one actually hits the changes, it's a lot of layers to unravel. Can you investigate, please? Also, what's the reason these types were recursive in the first place? Don't mean to pull a Chesterton’s Fence here.