### PR TITLE
add `parseAsync` API reference

### DIFF
--- a/website/src/routes/api/(async)/parseAsync/index.mdx
+++ b/website/src/routes/api/(async)/parseAsync/index.mdx
@@ -16,7 +16,7 @@ import { properties } from './properties';
 Parses an unknown input based on a schema.
 
 ```ts
-const output = v.parseAsync<TSchema>(schema, input, config?);
+const output = v.parseAsync<TSchema>(schema, input, config);
 ```
 
 ## Generics
@@ -33,7 +33,7 @@ const output = v.parseAsync<TSchema>(schema, input, config?);
 
 `parseAsync` will throw a <Link href="../ValiError/">`ValiError`</Link> if the `input` does not match the `schema`. Therefore you should use a try/catch block to catch errors. If the input matches the schema, it is valid and the `output` of the schema will be returned typed.
 
-> If an asynchronous operation associated with the passed schema fails, the promise returned by `parseAsync` will be rejected and the error might not be of type <Link href="../ValiError/">`ValiError`</Link>.
+> If an asynchronous operation associated with the passed schema throws an error, the promise returned by `parseAsync` is rejected and the error thrown may not be a <Link href="../ValiError/">`ValiError`</Link>.
 
 ## Returns
 

--- a/website/src/routes/api/(async)/parseAsync/index.mdx
+++ b/website/src/routes/api/(async)/parseAsync/index.mdx
@@ -1,10 +1,171 @@
 ---
 title: parseAsync
+description: Parses an unknown input based on a schema.
 source: /methods/parse/parseAsync.ts
 contributors:
   - fabian-hiller
+  - EltonLobo07
 ---
+
+import { Link } from '@builder.io/qwik-city';
+import { ApiList, Property } from '~/components';
+import { properties } from './properties';
 
 # parseAsync
 
-> The content of this page is not yet ready. Until then, please use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/methods/parse/parseAsync.ts) or take a look at [issue #287](https://github.com/fabian-hiller/valibot/issues/287) to help us extend the API reference.
+Parses an unknown input based on a schema.
+
+```ts
+const output = v.parseAsync<TSchema>(schema, input, config?);
+```
+
+## Generics
+
+- `TSchema` <Property {...properties.TSchema} />
+
+## Parameters
+
+- `schema` <Property {...properties.schema} />
+- `input` <Property {...properties.input} />
+- `config` <Property {...properties.config} />
+
+### Explanation
+
+`parseAsync` will throw a <Link href="../ValiError/">`ValiError`</Link> if the `input` does not match the `schema`. Therefore you should use a try/catch block to catch errors. If the input matches the schema, it is valid and the `output` of the schema will be returned typed.
+
+> If an asynchronous operation associated with the passed schema fails, the promise returned by `parseAsync` will be rejected and the error might not be of type <Link href="../ValiError/">`ValiError`</Link>.
+
+## Returns
+
+- `output` <Property {...properties.output} />
+
+## Examples
+
+The following examples show how `parseAsync` can be used.
+
+```ts
+import { isEmailPresent } from '~/api';
+
+try {
+  const StoredEmailSchema = v.pipeAsync(
+    v.string(),
+    v.email(),
+    v.checkAsync(isEmailPresent, 'The email is not in the database.')
+  );
+  const storedEmail = await v.parseAsync(StoredEmailSchema, 'jane@example.com');
+
+  // Handle errors if one occurs
+} catch (error) {
+  console.error(error);
+}
+```
+
+## Related
+
+The following APIs can be combined with `parseAsync`.
+
+### Schemas
+
+<ApiList
+  items={[
+    'any',
+    'array',
+    'bigint',
+    'blob',
+    'boolean',
+    'custom',
+    'date',
+    'enum',
+    'file',
+    'function',
+    'instance',
+    'intersect',
+    'lazy',
+    'literal',
+    'looseObject',
+    'looseTuple',
+    'map',
+    'nan',
+    'never',
+    'nonNullable',
+    'nonNullish',
+    'nonOptional',
+    'null',
+    'nullable',
+    'nullish',
+    'number',
+    'object',
+    'objectWithRest',
+    'optional',
+    'picklist',
+    'promise',
+    'record',
+    'set',
+    'strictObject',
+    'strictTuple',
+    'string',
+    'symbol',
+    'tuple',
+    'tupleWithRest',
+    'undefined',
+    'union',
+    'unknown',
+    'variant',
+    'void',
+  ]}
+/>
+
+### Methods
+
+<ApiList
+  items={[
+    'config',
+    'fallback',
+    'flatten',
+    'keyof',
+    'omit',
+    'partial',
+    'pick',
+    'pipe',
+    'required',
+    'unwrap',
+  ]}
+/>
+
+### Utils
+
+<ApiList items={['getDotPath', 'isValiError', 'ValiError']} />
+
+### Async
+
+<ApiList
+  items={[
+    'arrayAsync',
+    'customAsync',
+    'fallbackAsync',
+    'intersectAsync',
+    'lazyAsync',
+    'looseObjectAsync',
+    'looseTupleAsync',
+    'mapAsync',
+    'nonNullableAsync',
+    'nonNullishAsync',
+    'nonOptionalAsync',
+    'nullableAsync',
+    'nullishAsync',
+    'objectAsync',
+    'objectWithRestAsync',
+    'optionalAsync',
+    'partialAsync',
+    'pipeAsync',
+    'recordAsync',
+    'requiredAsync',
+    'setAsync',
+    'strictObjectAsync',
+    'strictTupleAsync',
+    'tupleAsync',
+    'tupleWithRestAsync',
+    'unionAsync',
+    'variantAsync',
+  ]}
+/>

--- a/website/src/routes/api/(async)/parseAsync/properties.ts
+++ b/website/src/routes/api/(async)/parseAsync/properties.ts
@@ -1,0 +1,96 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TSchema: {
+    modifier: 'extends',
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'BaseSchema',
+          href: '../BaseSchema/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
+        },
+        {
+          type: 'custom',
+          name: 'BaseSchemaAsync',
+          href: '../BaseSchemaAsync/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  schema: {
+    type: {
+      type: 'custom',
+      name: 'TSchema',
+    },
+  },
+  input: {
+    type: 'unknown',
+  },
+  config: {
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'Config',
+          href: '../Config/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'InferIssue',
+              href: '../InferIssue/',
+              generics: [
+                {
+                  type: 'custom',
+                  name: 'TSchema',
+                },
+              ],
+            },
+          ],
+        },
+        'undefined',
+      ],
+    },
+  },
+  output: {
+    type: {
+      type: 'custom',
+      name: 'Promise',
+      generics: [
+        {
+          type: 'custom',
+          name: 'InferOutput',
+          href: '../InferOutput/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'TSchema',
+            },
+          ],
+        },
+      ],
+    },
+  },
+};


### PR DESCRIPTION
There is one change that might be unusual, and that is the note at the end of the 'Explanation' section. I thought it was needed as Valibot doesn't catch the errors thrown by some asynchronous operations.