### PR TITLE
docs: add valibot-env to guides/ecosystem

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -70,3 +70,4 @@ Use the button at the bottom left of this page to add your project to this ecosy
 - [fastify-type-provider-valibot](https://github.com/qlaffont/fastify-type-provider-valibot): Fastify Type Provider with Valibot
 - [valibotx](https://github.com/IlyaSemenov/valibotx): A collection of extensions and shortcuts to core valibot functions
 - [valimock](https://github.com/saeris/valimock): Generate mock data using your Valibot schemas using [Faker](https://github.com/faker-js/faker)
+- [valibot-env](https://y-hiraoka.github.io/valibot-env): Environment variables validator with Valibot


### PR DESCRIPTION
This pull request adds a link to the valibot-env package in the documentation. I developed valibot-env to help with environment variables validation using Valibot, and I think this link will make it easier for users to find and use the package.

Thanks for your nice package!
