### PR TITLE
add `parserAsync` API reference

### DIFF
--- a/website/src/routes/api/(async)/parserAsync/index.mdx
+++ b/website/src/routes/api/(async)/parserAsync/index.mdx
@@ -1,11 +1,165 @@
 ---
 title: parserAsync
+description: Returns a function that parses an unknown input based on a schema.
 source: /methods/parser/parserAsync.ts
 contributors:
   - EltonLobo07
   - fabian-hiller
 ---
 
+import { ApiList, Property } from '~/components';
+import { properties } from './properties';
+
 # parserAsync
 
-> The content of this page is not yet ready. Until then, please use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/methods/parser/parserAsync.ts) or take a look at [issue #287](https://github.com/fabian-hiller/valibot/issues/287) to help us extend the API reference.
+Returns a function that parses an unknown input based on a schema.
+
+```ts
+const parser = v.parserAsync<TSchema, TConfig>(schema, config);
+```
+
+## Generics
+
+- `TSchema` <Property {...properties.TSchema} />
+- `TConfig` <Property {...properties.TConfig} />
+
+## Parameters
+
+- `schema` <Property {...properties.schema} />
+- `config` <Property {...properties.config} />
+
+## Returns
+
+- `parser` <Property {...properties.parser} />
+
+## Examples
+
+The following examples show how `parserAsync` can be used.
+
+```ts
+import { isEmailPresent } from '~/api';
+
+try {
+  const StoredEmailSchema = v.pipeAsync(
+    v.string(),
+    v.email(),
+    v.checkAsync(isEmailPresent, 'The email is not in the database.')
+  );
+  const storedEmailParser = v.parserAsync(StoredEmailSchema);
+  const storedEmail = await storedEmailParser('jane@example.com');
+
+  // Handle errors if one occurs
+} catch (error) {
+  console.error(error);
+}
+```
+
+## Related
+
+The following APIs can be combined with `parserAsync`.
+
+### Schemas
+
+<ApiList
+  items={[
+    'any',
+    'array',
+    'bigint',
+    'blob',
+    'boolean',
+    'custom',
+    'date',
+    'enum',
+    'file',
+    'function',
+    'instance',
+    'intersect',
+    'lazy',
+    'literal',
+    'looseObject',
+    'looseTuple',
+    'map',
+    'nan',
+    'never',
+    'nonNullable',
+    'nonNullish',
+    'nonOptional',
+    'null',
+    'nullable',
+    'nullish',
+    'number',
+    'object',
+    'objectWithRest',
+    'optional',
+    'picklist',
+    'promise',
+    'record',
+    'set',
+    'strictObject',
+    'strictTuple',
+    'string',
+    'symbol',
+    'tuple',
+    'tupleWithRest',
+    'undefined',
+    'union',
+    'unknown',
+    'variant',
+    'void',
+  ]}
+/>
+
+### Methods
+
+<ApiList
+  items={[
+    'config',
+    'fallback',
+    'flatten',
+    'keyof',
+    'omit',
+    'partial',
+    'pick',
+    'pipe',
+    'required',
+    'unwrap',
+  ]}
+/>
+
+### Utils
+
+<ApiList items={['getDotPath', 'isValiError', 'ValiError']} />
+
+### Async
+
+<ApiList
+  items={[
+    'arrayAsync',
+    'customAsync',
+    'fallbackAsync',
+    'intersectAsync',
+    'lazyAsync',
+    'looseObjectAsync',
+    'looseTupleAsync',
+    'mapAsync',
+    'nonNullableAsync',
+    'nonNullishAsync',
+    'nonOptionalAsync',
+    'nullableAsync',
+    'nullishAsync',
+    'objectAsync',
+    'objectWithRestAsync',
+    'optionalAsync',
+    'partialAsync',
+    'pipeAsync',
+    'recordAsync',
+    'requiredAsync',
+    'setAsync',
+    'strictObjectAsync',
+    'strictTupleAsync',
+    'tupleAsync',
+    'tupleWithRestAsync',
+    'unionAsync',
+    'variantAsync',
+  ]}
+/>

--- a/website/src/routes/api/(async)/parserAsync/properties.ts
+++ b/website/src/routes/api/(async)/parserAsync/properties.ts
@@ -1,0 +1,98 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TSchema: {
+    modifier: 'extends',
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'BaseSchema',
+          href: '../BaseSchema/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
+        },
+        {
+          type: 'custom',
+          name: 'BaseSchemaAsync',
+          href: '../BaseSchemaAsync/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  TConfig: {
+    modifier: 'extends',
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'Config',
+          href: '../Config/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'InferIssue',
+              href: '../InferIssue/',
+              generics: [
+                {
+                  type: 'custom',
+                  name: 'TSchema',
+                },
+              ],
+            },
+          ],
+        },
+        'undefined',
+      ],
+    },
+  },
+  schema: {
+    type: {
+      type: 'custom',
+      name: 'TSchema',
+    },
+  },
+  config: {
+    type: {
+      type: 'custom',
+      name: 'TConfig',
+    },
+  },
+  parser: {
+    type: {
+      type: 'custom',
+      name: 'ParserAsync',
+      href: '../ParserAsync/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TSchema',
+        },
+        {
+          type: 'custom',
+          name: 'TConfig',
+        },
+      ],
+    },
+  },
+};


### PR DESCRIPTION
I noticed the 'Explanation' section is missing under 'Parameters'. I assume this is because `parserAsync` returns a function instead of directly using the arguments to generate a final output. But I think an explanation like the one on [this](https://valibot.dev/api/parseAsync/) webpage is needed. Maybe we can add a similar explanation under the 'Returns' section. Good idea? 