### PR TITLE
add `pipeAsync` & `SchemaWithPipeAsync` API refs

### DIFF
--- a/website/src/routes/api/(async)/pipeAsync/index.mdx
+++ b/website/src/routes/api/(async)/pipeAsync/index.mdx
@@ -1,11 +1,303 @@
 ---
 title: pipeAsync
+description: Adds a pipeline to a schema, that can validate and transform its input.
 source: /methods/pipe/pipeAsync.ts
 contributors:
   - EltonLobo07
   - fabian-hiller
 ---
 
+import { Link } from '@builder.io/qwik-city';
+import { ApiList, Property } from '~/components';
+import { properties } from './properties';
+
 # pipeAsync
 
-> The content of this page is not yet ready. Until then, please use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/methods/pipe/pipeAsync.ts) or take a look at [issue #287](https://github.com/fabian-hiller/valibot/issues/287) to help us extend the API reference.
+Adds a pipeline to a schema, that can validate and transform its input.
+
+```ts
+const Schema = v.pipeAsync<TSchema, TItems>(schema, ...items);
+```
+
+## Generics
+
+- `TSchema` <Property {...properties.TSchema} />
+- `TItems` <Property {...properties.TItems} />
+
+## Parameters
+
+- `schema` <Property {...properties.schema} />
+- `items` <Property {...properties.items} />
+
+### Explanation
+
+`pipeAsync` creates a modified copy of the given `schema`, containing a pipeline for detailed validations and transformations. It passes the input data asynchronously through the `items` in the order they are provided and each item can examine and modify it.
+
+> Since `pipeAsync` returns a schema that can be used as the first argument of another pipeline, it is possible to nest multiple `pipeAsync` calls to extend the validation and transformation further.
+
+`pipeAsync` aborts early and marks the output as untyped if issues were collected before attempting to execute a schema or transformation action as the next item in the pipeline, to prevent unexpected behavior.
+
+## Returns
+
+- `Schema` <Property {...properties.Schema} />
+
+## Examples
+
+The following examples show how `pipeAsync` can be used. Please see the <Link href="/guides/pipelines/">pipeline guide</Link> for more examples and explanations.
+
+### Stored email schema
+
+Schema to validate a stored email address.
+
+```ts
+import { isEmailPresent } from '~/api';
+
+const StoredEmailSchema = v.pipeAsync(
+  v.string(),
+  v.nonEmpty('Please enter your email.'),
+  v.email('The email is badly formatted.'),
+  v.maxLength(30, 'Your email is too long.'),
+  v.checkAsync(isEmailPresent, 'The email is not in the database.')
+);
+```
+
+### New user schema
+
+Schema to validate and transform new user details to a string.
+
+```ts
+import { isUsernameUnique } from '~/api';
+
+const NewUserSchema = v.pipeAsync(
+  v.objectAsync({
+    firstName: v.pipe(v.string(), v.minLength(2), v.maxLength(45)),
+    lastName: v.pipe(v.string(), v.minLength(2), v.maxLength(45)),
+    username: v.pipeAsync(
+      v.string(),
+      v.nonEmpty(),
+      v.checkAsync(isUsernameUnique, 'The username is not unique.')
+    ),
+  }),
+  v.transform(
+    ({ firstName, lastName, username }) =>
+      `${username} (${firstName} ${lastName})`
+  )
+);
+```
+
+## Related
+
+The following APIs can be combined with `pipeAsync`.
+
+### Schemas
+
+<ApiList
+  items={[
+    'any',
+    'array',
+    'bigint',
+    'blob',
+    'boolean',
+    'custom',
+    'date',
+    'enum',
+    'file',
+    'function',
+    'instance',
+    'intersect',
+    'lazy',
+    'literal',
+    'looseObject',
+    'looseTuple',
+    'map',
+    'nan',
+    'never',
+    'nonNullable',
+    'nonNullish',
+    'nonOptional',
+    'null',
+    'nullable',
+    'nullish',
+    'number',
+    'object',
+    'objectWithRest',
+    'optional',
+    'picklist',
+    'promise',
+    'record',
+    'set',
+    'strictObject',
+    'strictTuple',
+    'string',
+    'symbol',
+    'tuple',
+    'tupleWithRest',
+    'undefined',
+    'undefinedable',
+    'union',
+    'unknown',
+    'variant',
+    'void',
+  ]}
+/>
+
+### Methods
+
+<ApiList
+  items={[
+    'config',
+    'fallback',
+    'forward',
+    'getDefault',
+    'getDefaults',
+    'getFallback',
+    'getFallbacks',
+    'is',
+    'keyof',
+    'omit',
+    'parse',
+    'parser',
+    'partial',
+    'pick',
+    'required',
+    'safeParse',
+    'safeParser',
+    'unwrap',
+  ]}
+/>
+
+### Actions
+
+<ApiList
+  items={[
+    'base64',
+    'bic',
+    'brand',
+    'bytes',
+    'check',
+    'checkItems',
+    'creditCard',
+    'cuid2',
+    'decimal',
+    'description',
+    'email',
+    'emoji',
+    'empty',
+    'endsWith',
+    'everyItem',
+    'excludes',
+    'filterItems',
+    'findItem',
+    'finite',
+    'hash',
+    'hexadecimal',
+    'hexColor',
+    'imei',
+    'includes',
+    'integer',
+    'ip',
+    'ipv4',
+    'ipv6',
+    'isoDate',
+    'isoDateTime',
+    'isoTime',
+    'isoTimeSecond',
+    'isoTimestamp',
+    'isoWeek',
+    'length',
+    'mac',
+    'mac48',
+    'mac64',
+    'mapItems',
+    'maxBytes',
+    'maxLength',
+    'maxSize',
+    'maxValue',
+    'mimeType',
+    'minBytes',
+    'minLength',
+    'minSize',
+    'minValue',
+    'multipleOf',
+    'nanoid',
+    'nonEmpty',
+    'notBytes',
+    'notLength',
+    'notSize',
+    'notValue',
+    'octal',
+    'partialCheck',
+    'rawCheck',
+    'rawTransform',
+    'readonly',
+    'reduceItems',
+    'regex',
+    'safeInteger',
+    'size',
+    'someItem',
+    'sortItem',
+    'startsWith',
+    'toLowerCase',
+    'toMaxValue',
+    'toMinValue',
+    'toUpperCase',
+    'transform',
+    'trim',
+    'trimEnd',
+    'trimStart',
+    'ulid',
+    'url',
+    'uuid',
+    'value',
+  ]}
+/>
+
+### Utils
+
+<ApiList items={['isOfKind', 'isOfType']} />
+
+### Async
+
+<ApiList
+  items={[
+    'arrayAsync',
+    'checkAsync',
+    'customAsync',
+    'fallbackAsync',
+    'forwardAsync',
+    'getDefaultsAsync',
+    'getFallbacksAsync',
+    'intersectAsync',
+    'lazyAsync',
+    'looseObjectAsync',
+    'looseTupleAsync',
+    'mapAsync',
+    'nonNullableAsync',
+    'nonNullishAsync',
+    'nonOptionalAsync',
+    'nullableAsync',
+    'nullishAsync',
+    'objectAsync',
+    'objectWithRestAsync',
+    'optionalAsync',
+    'parseAsync',
+    'parserAsync',
+    'partialAsync',
+    'partialCheckAsync',
+    'rawCheckAsync',
+    'rawTransformAsync',
+    'recordAsync',
+    'requiredAsync',
+    'safeParseAsync',
+    'safeParserAsync',
+    'setAsync',
+    'strictObjectAsync',
+    'strictTupleAsync',
+    'transformAsync',
+    'tupleAsync',
+    'tupleWithRestAsync',
+    'undefinedableAsync',
+    'unionAsync',
+    'variantAsync',
+  ]}
+/>

--- a/website/src/routes/api/(async)/pipeAsync/properties.ts
+++ b/website/src/routes/api/(async)/pipeAsync/properties.ts
@@ -1,0 +1,118 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TSchema: {
+    modifier: 'extends',
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'BaseSchema',
+          href: '../BaseSchema/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
+        },
+        {
+          type: 'custom',
+          name: 'BaseSchemaAsync',
+          href: '../BaseSchemaAsync/',
+          generics: [
+            'unknown',
+            'unknown',
+            {
+              type: 'custom',
+              name: 'BaseIssue',
+              href: '../BaseIssue/',
+              generics: ['unknown'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  TItems: {
+    modifier: 'extends',
+    type: {
+      type: 'array',
+      item: {
+        type: 'union',
+        options: [
+          {
+            type: 'custom',
+            name: 'PipeItem',
+            href: '../PipeItem/',
+            generics: [
+              'unknown',
+              'unknown',
+              {
+                type: 'custom',
+                name: 'BaseIssue',
+                href: '../BaseIssue/',
+                generics: ['unknown'],
+              },
+            ],
+          },
+          {
+            type: 'custom',
+            name: 'PipeItemAsync',
+            href: '../PipeItemAsync/',
+            generics: [
+              'unknown',
+              'unknown',
+              {
+                type: 'custom',
+                name: 'BaseIssue',
+                href: '../BaseIssue/',
+                generics: ['unknown'],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
+  schema: {
+    type: {
+      type: 'custom',
+      name: 'TSchema',
+    },
+  },
+  items: {
+    type: {
+      type: 'custom',
+      name: 'TItems',
+    },
+  },
+  Schema: {
+    type: {
+      type: 'custom',
+      name: 'SchemaWithPipeAsync',
+      href: '../SchemaWithPipeAsync/',
+      generics: [
+        {
+          type: 'tuple',
+          items: [
+            {
+              type: 'custom',
+              name: 'TSchema',
+            },
+            {
+              type: 'custom',
+              spread: true,
+              name: 'TItems',
+            },
+          ],
+        },
+      ],
+    },
+  },
+};

--- a/website/src/routes/api/(types)/SchemaWithPipeAsync/index.mdx
+++ b/website/src/routes/api/(types)/SchemaWithPipeAsync/index.mdx
@@ -1,0 +1,25 @@
+---
+title: SchemaWithPipeAsync
+description: Schema with pipe async type.
+contributors:
+  - EltonLobo07
+---
+
+import { Property } from '~/components';
+import { properties } from './properties';
+
+# SchemaWithPipeAsync
+
+Schema with pipe async type.
+
+## Generics
+
+- `TPipe` <Property {...properties.TPipe} />
+
+## Definition
+
+- `SchemaWithPipeAsync` <Property {...properties.SchemaWithPipe} />
+  - `pipe` <Property {...properties.pipe} />
+  - `async` <Property {...properties.async} />
+  - `_run` {/* prettier-ignore */}<Property {...properties._run} />
+  - `_types` {/* prettier-ignore */}<Property {...properties._types} />

--- a/website/src/routes/api/(types)/SchemaWithPipeAsync/properties.ts
+++ b/website/src/routes/api/(types)/SchemaWithPipeAsync/properties.ts
@@ -1,0 +1,292 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TPipe: {
+    modifier: 'extends',
+    type: {
+      type: 'tuple',
+      items: [
+        {
+          type: 'union',
+          options: [
+            {
+              type: 'custom',
+              name: 'BaseSchema',
+              href: '../BaseSchema/',
+              generics: [
+                'unknown',
+                'unknown',
+                {
+                  type: 'custom',
+                  name: 'BaseIssue',
+                  href: '../BaseIssue/',
+                  generics: ['unknown'],
+                },
+              ],
+            },
+            {
+              type: 'custom',
+              name: 'BaseSchemaAsync',
+              href: '../BaseSchemaAsync/',
+              generics: [
+                'unknown',
+                'unknown',
+                {
+                  type: 'custom',
+                  name: 'BaseIssue',
+                  href: '../BaseIssue/',
+                  generics: ['unknown'],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'array',
+          spread: true,
+          item: {
+            type: 'union',
+            options: [
+              {
+                type: 'custom',
+                name: 'PipeItem',
+                href: '../PipeItem/',
+                generics: [
+                  'any',
+                  'unknown',
+                  {
+                    type: 'custom',
+                    name: 'BaseIssue',
+                    href: '../BaseIssue/',
+                    generics: ['unknown'],
+                  },
+                ],
+              },
+              {
+                type: 'custom',
+                name: 'PipeItemAsync',
+                href: '../PipeItemAsync/',
+                generics: [
+                  'any',
+                  'unknown',
+                  {
+                    type: 'custom',
+                    name: 'BaseIssue',
+                    href: '../BaseIssue/',
+                    generics: ['unknown'],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+  SchemaWithPipe: {
+    modifier: 'extends',
+    type: {
+      type: 'custom',
+      name: 'Omit',
+      generics: [
+        {
+          type: 'custom',
+          name: 'FirstTupleItem',
+          href: '../FirstTupleItem/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'TPipe',
+            },
+          ],
+        },
+        {
+          type: 'union',
+          options: [
+            {
+              type: 'string',
+              value: 'async',
+            },
+            {
+              type: 'string',
+              value: '_run',
+            },
+            {
+              type: 'string',
+              value: '_types',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  pipe: {
+    type: {
+      type: 'custom',
+      name: 'TPipe',
+    },
+  },
+  async: {
+    type: {
+      type: 'boolean',
+      value: true,
+    },
+  },
+  _run: {
+    type: {
+      type: 'function',
+      params: [
+        {
+          name: 'dataset',
+          type: {
+            type: 'custom',
+            name: 'Dataset',
+            href: '../Dataset/',
+            generics: ['unknown', 'never'],
+          },
+        },
+        {
+          name: 'config',
+          type: {
+            type: 'custom',
+            name: 'Config',
+            href: '../Config/',
+            generics: [
+              {
+                type: 'custom',
+                name: 'InferIssue',
+                href: '../InferIssue/',
+                generics: [
+                  {
+                    type: 'custom',
+                    name: 'FirstTupleItem',
+                    href: '../FirstTupleItem/',
+                    generics: [
+                      {
+                        type: 'custom',
+                        name: 'TPipe',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+      return: {
+        type: 'custom',
+        name: 'Promise',
+        generics: [
+          {
+            type: 'custom',
+            name: 'Dataset',
+            href: '../Dataset/',
+            generics: [
+              {
+                type: 'custom',
+                name: 'InferOutput',
+                href: '../InferOutput/',
+                generics: [
+                  {
+                    type: 'custom',
+                    name: 'LastTupleItem',
+                    href: '../LastTupleItem/',
+                    generics: [
+                      {
+                        type: 'custom',
+                        name: 'TPipe',
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: 'custom',
+                name: 'InferIssue',
+                href: '../InferIssue/',
+                generics: [
+                  {
+                    type: 'custom',
+                    name: 'TPipe',
+                    indexes: ['number'],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
+  _types: {
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'object',
+          entries: [
+            {
+              key: 'input',
+              value: {
+                type: 'custom',
+                name: 'InferInput',
+                href: '../InferInput/',
+                generics: [
+                  {
+                    type: 'custom',
+                    name: 'FirstTupleItem',
+                    href: '../FirstTupleItem/',
+                    generics: [
+                      {
+                        type: 'custom',
+                        name: 'TPipe',
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+            {
+              key: 'output',
+              value: {
+                type: 'custom',
+                name: 'InferOutput',
+                href: '../InferOutput/',
+                generics: [
+                  {
+                    type: 'custom',
+                    name: 'LastTupleItem',
+                    href: '../LastTupleItem/',
+                    generics: [
+                      {
+                        type: 'custom',
+                        name: 'TPipe',
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+            {
+              key: 'issue',
+              value: {
+                type: 'custom',
+                name: 'InferIssue',
+                href: '../InferIssue/',
+                generics: [
+                  {
+                    type: 'custom',
+                    name: 'TPipe',
+                    indexes: ['number'],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        'undefined',
+      ],
+    },
+  },
+};

--- a/website/src/routes/api/menu.md
+++ b/website/src/routes/api/menu.md
@@ -523,6 +523,7 @@
 - [SafeParseResult](/api/SafeParseResult/)
 - [SchemaWithFallback](/api/SchemaWithFallback/)
 - [SchemaWithFallbackAsync](/api/SchemaWithFallbackAsync/)
+- [SchemaWithPipeAsync](/api/SchemaWithPipeAsync/)
 - [SetPathItem](/api/SetPathItem/)
 - [SetIssue](/api/SetIssue/)
 - [SetSchema](/api/SetSchema/)


### PR DESCRIPTION
Feel free to remove or improve the second example. The idea was to create an example that shows how to transform data through `pipeAsync` and nest `pipeAsync` schemas.