### PR TITLE
add `requiredAsync` & `SchemaWithRequiredAsync` API refs

### DIFF
--- a/website/src/routes/api/(async)/partialAsync/index.mdx
+++ b/website/src/routes/api/(async)/partialAsync/index.mdx
@@ -68,9 +68,9 @@ const UpdateUserSchema = v.partialAsync(UserSchema);
 
 /*
   { 
-    email?: string,
-    username?: string, 
-    password?: string 
+    email?: string;
+    username?: string; 
+    password?: string;
   }
 */
 ```

--- a/website/src/routes/api/(async)/requiredAsync/index.mdx
+++ b/website/src/routes/api/(async)/requiredAsync/index.mdx
@@ -1,10 +1,194 @@
 ---
 title: requiredAsync
+description: Creates a modified copy of an object schema that marks all or only the selected entries as required.
 source: /methods/required/requiredAsync.ts
 contributors:
   - fabian-hiller
+  - EltonLobo07
 ---
+
+import { Link } from '@builder.io/qwik-city';
+import { ApiList, Property } from '~/components';
+import { properties } from './properties';
 
 # requiredAsync
 
-> The content of this page is not yet ready. Until then, please use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/methods/required/requiredAsync.ts) or take a look at [issue #287](https://github.com/fabian-hiller/valibot/issues/287) to help us extend the API reference.
+Creates a modified copy of an object schema that marks all or only the selected entries as required.
+
+```ts
+const AllKeysSchema = v.requiredAsync<TSchema, TMessage>(schema, message);
+const SelectedKeysSchema = v.requiredAsync<TSchema, TKeys, TMessage>(
+  schema,
+  keys,
+  message
+);
+```
+
+## Generics
+
+- `TSchema` <Property {...properties.TSchema} />
+- `TKeys` <Property {...properties.TKeys} />
+- `TMessage` <Property {...properties.TMessage} />
+
+## Parameters
+
+- `schema` <Property {...properties.schema} />
+- `keys` <Property {...properties.keys} />
+- `message` <Property {...properties.message} />
+
+### Explanation
+
+`requiredAsync` creates a modified copy of the given object `schema` where all or only the selected `keys` are required. It is similar to TypeScript's [`Required`](https://www.typescriptlang.org/docs/handbook/utility-types.html#requiredtype) utility type.
+
+> Because `requiredAsync` changes the data type of the input and output, it is not allowed to pass a schema that has been modified by the <Link href='../pipeAsync/'>`pipeAsync`</Link> method, as this may cause runtime errors. Please use the <Link href='../pipeAsync/'>`pipeAsync`</Link> method after you have modified the schema with `requiredAsync`.
+
+## Returns
+
+- `AllKeysSchema` <Property {...properties.AllKeysSchema} />
+- `SelectedKeysSchema` <Property {...properties.SelectedKeysSchema} />
+
+## Examples
+
+The following examples show how `requiredAsync` can be used.
+
+### Task schema
+
+Schema to validate an object containing task details.
+
+```ts
+const UpdateTaskSchema = v.objectAsync({
+  owner: v.optionalAsync(
+    v.pipeAsync(
+      v.string(),
+      v.email(),
+      v.checkAsync(isOwnerPresent, 'The owner is not in the database.')
+    )
+  ),
+  title: v.optional(v.pipe(v.string(), v.nonEmpty(), v.maxLength(255))),
+  description: v.optional(v.pipe(v.string(), v.nonEmpty())),
+});
+
+const TaskSchema = v.requiredAsync(UpdateTaskSchema);
+
+/*
+  {
+      owner: string,
+      title: string,
+      description: string
+  }
+*/
+```
+
+## Related
+
+The following APIs can be combined with `requiredAsync`.
+
+### Schemas
+
+<ApiList
+  items={[
+    'array',
+    'intersect',
+    'lazy',
+    'looseObject',
+    'looseTuple',
+    'map',
+    'nonNullable',
+    'nonNullish',
+    'nonOptional',
+    'nullable',
+    'nullish',
+    'object',
+    'objectWithRest',
+    'optional',
+    'record',
+    'set',
+    'strictObject',
+    'strictTuple',
+    'tuple',
+    'tupleWithRest',
+    'undefinedable',
+    'union',
+  ]}
+/>
+
+### Methods
+
+<ApiList
+  items={[
+    'config',
+    'fallback',
+    'forward',
+    'getDefault',
+    'getDefaults',
+    'getFallback',
+    'getFallbacks',
+    'keyof',
+    'omit',
+    'partial',
+    'pick',
+    'unwrap',
+  ]}
+/>
+
+### Actions
+
+<ApiList
+  items={[
+    'brand',
+    'check',
+    'description',
+    'partialCheck',
+    'rawCheck',
+    'rawTransform',
+    'readonly',
+    'transform',
+  ]}
+/>
+
+### Utils
+
+<ApiList items={['isOfKind', 'isOfType']} />
+
+### Async
+
+<ApiList
+  items={[
+    'arrayAsync',
+    'checkAsync',
+    'fallbackAsync',
+    'forwardAsync',
+    'getDefaultsAsync',
+    'getFallbacksAsync',
+    'intersectAsync',
+    'lazyAsync',
+    'looseObjectAsync',
+    'looseTupleAsync',
+    'mapAsync',
+    'nonNullableAsync',
+    'nonNullishAsync',
+    'nonOptionalAsync',
+    'nullableAsync',
+    'nullishAsync',
+    'objectAsync',
+    'objectWithRestAsync',
+    'optionalAsync',
+    'parseAsync',
+    'parserAsync',
+    'partialAsync',
+    'partialCheckAsync',
+    'rawCheckAsync',
+    'rawTransformAsync',
+    'recordAsync',
+    'safeParseAsync',
+    'safeParserAsync',
+    'setAsync',
+    'strictObjectAsync',
+    'strictTupleAsync',
+    'transformAsync',
+    'tupleAsync',
+    'tupleWithRestAsync',
+    'undefinedableAsync',
+    'unionAsync',
+  ]}
+/>

--- a/website/src/routes/api/(async)/requiredAsync/index.mdx
+++ b/website/src/routes/api/(async)/requiredAsync/index.mdx
@@ -51,7 +51,7 @@ const SelectedKeysSchema = v.requiredAsync<TSchema, TKeys, TMessage>(
 
 The following examples show how `requiredAsync` can be used.
 
-### Task schema
+### New task schema
 
 Schema to validate an object containing task details.
 
@@ -68,13 +68,13 @@ const UpdateTaskSchema = v.objectAsync({
   description: v.optional(v.pipe(v.string(), v.nonEmpty())),
 });
 
-const TaskSchema = v.requiredAsync(UpdateTaskSchema);
+const NewTaskSchema = v.requiredAsync(UpdateTaskSchema);
 
 /*
   {
-      owner: string,
-      title: string,
-      description: string
+    owner: string;
+    title: string;
+    description: string;
   }
 */
 ```

--- a/website/src/routes/api/(async)/requiredAsync/properties.ts
+++ b/website/src/routes/api/(async)/requiredAsync/properties.ts
@@ -5,8 +5,8 @@ export const properties: Record<string, PropertyProps> = {
     modifier: 'extends',
     type: {
       type: 'custom',
-      name: 'NoPipe',
-      href: '../NoPipe/',
+      name: 'SchemaWithoutPipe',
+      href: '../SchemaWithoutPipe/',
       generics: [
         {
           type: 'union',

--- a/website/src/routes/api/(async)/requiredAsync/properties.ts
+++ b/website/src/routes/api/(async)/requiredAsync/properties.ts
@@ -1,0 +1,264 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TSchema: {
+    modifier: 'extends',
+    type: {
+      type: 'custom',
+      name: 'NoPipe',
+      href: '../NoPipe/',
+      generics: [
+        {
+          type: 'union',
+          options: [
+            {
+              type: 'custom',
+              name: 'LooseObjectSchemaAsync',
+              href: '../LooseObjectSchemaAsync/',
+              generics: [
+                {
+                  type: 'custom',
+                  name: 'ObjectEntriesAsync',
+                  href: '../ObjectEntriesAsync/',
+                },
+                {
+                  type: 'union',
+                  options: [
+                    {
+                      type: 'custom',
+                      name: 'ErrorMessage',
+                      href: '../ErrorMessage/',
+                      generics: [
+                        {
+                          type: 'custom',
+                          name: 'LooseObjectIssue',
+                          href: '../LooseObjectIssue/',
+                        },
+                      ],
+                    },
+                    'undefined',
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'custom',
+              name: 'ObjectSchemaAsync',
+              href: '../ObjectSchemaAsync/',
+              generics: [
+                {
+                  type: 'custom',
+                  name: 'ObjectEntriesAsync',
+                  href: '../ObjectEntriesAsync/',
+                },
+                {
+                  type: 'union',
+                  options: [
+                    {
+                      type: 'custom',
+                      name: 'ErrorMessage',
+                      href: '../ErrorMessage/',
+                      generics: [
+                        {
+                          type: 'custom',
+                          name: 'ObjectIssue',
+                          href: '../ObjectIssue/',
+                        },
+                      ],
+                    },
+                    'undefined',
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'custom',
+              name: 'ObjectWithRestSchemaAsync',
+              href: '../ObjectWithRestSchemaAsync/',
+              generics: [
+                {
+                  type: 'custom',
+                  name: 'ObjectEntriesAsync',
+                  href: '../ObjectEntriesAsync/',
+                },
+                {
+                  type: 'union',
+                  options: [
+                    {
+                      type: 'custom',
+                      name: 'BaseSchema',
+                      href: '../BaseSchema/',
+                      generics: [
+                        'unknown',
+                        'unknown',
+                        {
+                          type: 'custom',
+                          name: 'BaseIssue',
+                          href: '../BaseIssue/',
+                          generics: ['unknown'],
+                        },
+                      ],
+                    },
+                    {
+                      type: 'custom',
+                      name: 'BaseSchemaAsync',
+                      href: '../BaseSchemaAsync/',
+                      generics: [
+                        'unknown',
+                        'unknown',
+                        {
+                          type: 'custom',
+                          name: 'BaseIssue',
+                          href: '../BaseIssue/',
+                          generics: ['unknown'],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  type: 'union',
+                  options: [
+                    {
+                      type: 'custom',
+                      name: 'ErrorMessage',
+                      href: '../ErrorMessage/',
+                      generics: [
+                        {
+                          type: 'custom',
+                          name: 'ObjectWithRestIssue',
+                          href: '../ObjectWithRestIssue/',
+                        },
+                      ],
+                    },
+                    'undefined',
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'custom',
+              name: 'StrictObjectSchemaAsync',
+              href: '../StrictObjectSchemaAsync/',
+              generics: [
+                {
+                  type: 'custom',
+                  name: 'ObjectEntriesAsync',
+                  href: '../ObjectEntriesAsync/',
+                },
+                {
+                  type: 'union',
+                  options: [
+                    {
+                      type: 'custom',
+                      name: 'ErrorMessage',
+                      href: '../ErrorMessage/',
+                      generics: [
+                        {
+                          type: 'custom',
+                          name: 'StrictObjectIssue',
+                          href: '../StrictObjectIssue/',
+                        },
+                      ],
+                    },
+                    'undefined',
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
+  TKeys: {
+    type: {
+      type: 'custom',
+      name: 'ObjectKeys',
+      href: '../ObjectKeys/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TSchema',
+        },
+      ],
+    },
+  },
+  TMessage: {
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'ErrorMessage',
+          href: '../ErrorMessage/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'NonOptionalIssue',
+              href: '../NonOptionalIssue/',
+            },
+          ],
+        },
+        'undefined',
+      ],
+    },
+  },
+  schema: {
+    type: {
+      type: 'custom',
+      name: 'TSchema',
+    },
+  },
+  keys: {
+    type: {
+      type: 'custom',
+      name: 'TKey',
+    },
+  },
+  message: {
+    type: {
+      type: 'custom',
+      name: 'TMessage',
+    },
+  },
+  AllKeysSchema: {
+    type: {
+      type: 'custom',
+      name: 'SchemaWithRequiredAsync',
+      href: '../SchemaWithRequiredAsync/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TSchema',
+        },
+        'undefined',
+        {
+          type: 'custom',
+          name: 'TMessage',
+        },
+      ],
+    },
+  },
+  SelectedKeysSchema: {
+    type: {
+      type: 'custom',
+      name: 'SchemaWithRequiredAsync',
+      href: '../SchemaWithRequiredAsync/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TSchema',
+        },
+        {
+          type: 'custom',
+          name: 'TKeys',
+        },
+        {
+          type: 'custom',
+          name: 'TMessage',
+        },
+      ],
+    },
+  },
+};

--- a/website/src/routes/api/(types)/SchemaWithRequiredAsync/index.mdx
+++ b/website/src/routes/api/(types)/SchemaWithRequiredAsync/index.mdx
@@ -1,0 +1,12 @@
+---
+title: SchemaWithRequiredAsync
+description: Schema with required async type.
+contributors:
+  - EltonLobo07
+---
+
+# SchemaWithRequiredAsync
+
+Schema with required async type.
+
+> This type is too complex to display. Please refer to the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/methods/required/requiredAsync.ts).

--- a/website/src/routes/api/menu.md
+++ b/website/src/routes/api/menu.md
@@ -527,6 +527,7 @@
 - [SchemaWithPartialAsync](/api/SchemaWithPartialAsync/)
 - [SchemaWithPipe](/api/SchemaWithPipe/)
 - [SchemaWithPipeAsync](/api/SchemaWithPipeAsync/)
+- [SchemaWithRequiredAsync](/api/SchemaWithRequiredAsync/)
 - [SetPathItem](/api/SetPathItem/)
 - [SetIssue](/api/SetIssue/)
 - [SetSchema](/api/SetSchema/)


### PR DESCRIPTION
The `requiredAsync` reference with this PR is a bit different from the `required` reference on the website. After this PR is merged, I'll make sure to update the `required` reference (if there are any changes needed). Here are the differences along with the reasons:

1. The `required` reference does not use a type parameter for the message parameter but the `requiredAsync` reference does. I think we should list `TMessage` so that: 
    a. the reference is as close to the code as possible. 
    b. we display the link between the `message` parameter and the output schema in the reference.

2. The naming of the output schemas. Instead of naming the output `Schema`, it is better to name the schemas `AllKeysSchema` and `SelectedKeysSchema` so that readers can identify the schemas in the 'Returns' section.