### PR TITLE
improve `required` API reference

### DIFF
--- a/website/src/routes/api/(methods)/required/index.mdx
+++ b/website/src/routes/api/(methods)/required/index.mdx
@@ -1,11 +1,10 @@
 ---
 title: required
-description: >-
-  Creates a modified copy of an object schema that marks all entries or only the
-  selected keys as required.
+description: Creates a modified copy of an object schema that marks all or only the selected entries as required.
 source: /methods/required/required.ts
 contributors:
   - fabian-hiller
+  - EltonLobo07
 ---
 
 import { Link } from '@builder.io/qwik-city';
@@ -14,17 +13,22 @@ import { properties } from './properties';
 
 # required
 
-Creates a modified copy of an object schema that marks all entries or only the selected keys as required.
+Creates a modified copy of an object schema that marks all or only the selected entries as required.
 
 ```ts
-const Schema = v.required<TSchema>(schema, message);
-const Schema = v.required<TSchema, TKeys>(schema, keys, message);
+const AllKeysSchema = v.required<TSchema, TMessage>(schema, message);
+const SelectedKeysSchema = v.required<TSchema, TKeys, TMessage>(
+  schema,
+  keys,
+  message
+);
 ```
 
 ## Generics
 
 - `TSchema` <Property {...properties.TSchema} />
 - `TKeys` <Property {...properties.TKeys} />
+- `TMessage` <Property {...properties.TMessage} />
 
 ## Parameters
 
@@ -34,13 +38,14 @@ const Schema = v.required<TSchema, TKeys>(schema, keys, message);
 
 ### Explanation
 
-`required` creates a modified copy of the given object `schema` where all entries or only the selected `keys` are required. It is similar to TypeScript's [`Required`](https://www.typescriptlang.org/docs/handbook/utility-types.html#requiredtype) utility type.
+`required` creates a modified copy of the given object `schema` where all or only the selected `keys` are required. It is similar to TypeScript's [`Required`](https://www.typescriptlang.org/docs/handbook/utility-types.html#requiredtype) utility type.
 
 > Because `required` changes the data type of the input and output, it is not allowed to pass a schema that has been modified by the <Link href='../pipe/'>`pipe`</Link> method, as this may cause runtime errors. Please use the <Link href='../pipe/'>`pipe`</Link> method after you have modified the schema with `required`.
 
 ## Returns
 
-- `Schema` <Property {...properties.Schema} />
+- `AllKeysSchema` <Property {...properties.AllKeysSchema} />
+- `SelectedKeysSchema` <Property {...properties.SelectedKeysSchema} />
 
 ## Examples
 
@@ -135,8 +140,8 @@ The following APIs can be combined with `required`.
 
 <ApiList
   items={[
-    'check',
     'brand',
+    'check',
     'description',
     'partialCheck',
     'rawCheck',

--- a/website/src/routes/api/(methods)/required/properties.ts
+++ b/website/src/routes/api/(methods)/required/properties.ts
@@ -27,10 +27,12 @@ export const properties: Record<string, PropertyProps> = {
                     {
                       type: 'custom',
                       name: 'ErrorMessage',
+                      href: '../ErrorMessage/',
                       generics: [
                         {
                           type: 'custom',
-                          name: 'ObjectIssue',
+                          name: 'LooseObjectIssue',
+                          href: '../LooseObjectIssue/',
                         },
                       ],
                     },
@@ -55,10 +57,12 @@ export const properties: Record<string, PropertyProps> = {
                     {
                       type: 'custom',
                       name: 'ErrorMessage',
+                      href: '../ErrorMessage/',
                       generics: [
                         {
                           type: 'custom',
                           name: 'ObjectIssue',
+                          href: '../ObjectIssue/',
                         },
                       ],
                     },
@@ -98,6 +102,7 @@ export const properties: Record<string, PropertyProps> = {
                     {
                       type: 'custom',
                       name: 'ErrorMessage',
+                      href: '../ErrorMessage/',
                       generics: [
                         {
                           type: 'custom',
@@ -127,10 +132,12 @@ export const properties: Record<string, PropertyProps> = {
                     {
                       type: 'custom',
                       name: 'ErrorMessage',
+                      href: '../ErrorMessage/',
                       generics: [
                         {
                           type: 'custom',
-                          name: 'ObjectIssue',
+                          name: 'StrictObjectIssue',
+                          href: '../StrictObjectIssue/',
                         },
                       ],
                     },
@@ -147,16 +154,31 @@ export const properties: Record<string, PropertyProps> = {
   TKeys: {
     modifier: 'extends',
     type: {
+      type: 'custom',
+      name: 'ObjectKeys',
+      href: '../ObjectKeys/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TSchema',
+        },
+      ],
+    },
+  },
+  TMessage: {
+    modifier: 'extends',
+    type: {
       type: 'union',
       options: [
         {
           type: 'custom',
-          name: 'ObjectKeys',
-          href: '../ObjectKeys/',
+          name: 'ErrorMessage',
+          href: '../ErrorMessage/',
           generics: [
             {
               type: 'custom',
-              name: 'TSchema',
+              name: 'NonOptionalIssue',
+              href: '../NonOptionalIssue/',
             },
           ],
         },
@@ -178,26 +200,33 @@ export const properties: Record<string, PropertyProps> = {
   },
   message: {
     type: {
-      type: 'union',
-      options: [
-        {
-          type: 'custom',
-          name: 'ErrorMessage',
-          generics: [
-            {
-              type: 'custom',
-              name: 'NonOptionalIssue',
-            },
-          ],
-        },
-        'undefined',
-      ],
+      type: 'custom',
+      name: 'TMessage',
     },
   },
-  Schema: {
+  AllKeysSchema: {
     type: {
       type: 'custom',
       name: 'SchemaWithRequired',
+      href: '../SchemaWithRequired/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TSchema',
+        },
+        'undefined',
+        {
+          type: 'custom',
+          name: 'TMessage',
+        },
+      ],
+    },
+  },
+  SelectedKeysSchema: {
+    type: {
+      type: 'custom',
+      name: 'SchemaWithRequired',
+      href: '../SchemaWithRequired/',
       generics: [
         {
           type: 'custom',
@@ -205,7 +234,11 @@ export const properties: Record<string, PropertyProps> = {
         },
         {
           type: 'custom',
-          name: 'TKeys',
+          name: 'Tkeys',
+        },
+        {
+          type: 'custom',
+          name: 'TMessage',
         },
       ],
     },

--- a/website/src/routes/api/(types)/SchemaWithRequired/index.mdx
+++ b/website/src/routes/api/(types)/SchemaWithRequired/index.mdx
@@ -1,0 +1,12 @@
+---
+title: SchemaWithRequired
+description: Schema with required type.
+contributors:
+  - EltonLobo07
+---
+
+# SchemaWithRequired
+
+Schema with required type.
+
+> This type is too complex to display. Please refer to the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/methods/required/required.ts).

--- a/website/src/routes/api/menu.md
+++ b/website/src/routes/api/menu.md
@@ -527,6 +527,7 @@
 - [SchemaWithPartialAsync](/api/SchemaWithPartialAsync/)
 - [SchemaWithPipe](/api/SchemaWithPipe/)
 - [SchemaWithPipeAsync](/api/SchemaWithPipeAsync/)
+- [SchemaWithRequired](/api/SchemaWithRequired/)
 - [SchemaWithRequiredAsync](/api/SchemaWithRequiredAsync/)
 - [SetPathItem](/api/SetPathItem/)
 - [SetIssue](/api/SetIssue/)


### PR DESCRIPTION
Improvements:
- Rephrase the description
- Rename the output schema names
- Add a type parameter for the message parameter
- Improve the "Returns" section
- Add `SchemaWithRequired` API reference
- Sort "Related Actions" list