### PR TITLE
Rename `decimal` to `digits`. Add new `decimal` validation action

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to the library will be documented in this file.
 
 ## vX.X.X (Month DD, YYYY)
 
+- Add `decimal` action to validate integer and float strings (pull request #823)
 - Rename `NoPipe` type to `SchemaWithoutPipe`
+- Rename `decimal` action to `digits` (pull request #823)
 - Fix inference of generics in `IssueDotPath` type (issue #814)
 
 ## v0.41.0 (September 01, 2024)

--- a/library/src/actions/decimal/decimal.test.ts
+++ b/library/src/actions/decimal/decimal.test.ts
@@ -102,16 +102,27 @@ describe('decimal', () => {
       expectActionIssue(action, baseIssue, ['1e3', '1e-3', '1e+3']);
     });
 
-    test('for floats ending in .', () => {
+    test('for floats ending with a dot', () => {
       expectActionIssue(action, baseIssue, ['1.', '342.']);
     });
 
-    test('for floats starting with .', () => {
+    test('for floats starting with a dot', () => {
       expectActionIssue(action, baseIssue, ['.6', '.763']);
     });
 
-    test('for floats starting with . and number sign', () => {
+    test('for floats starting with number sign followed by a dot', () => {
       expectActionIssue(action, baseIssue, ['-.2', '-.922', '+.5', '+.452']);
+    });
+
+    test('for floats with multiple dots', () => {
+      expectActionIssue(action, baseIssue, [
+        '1.2.3',
+        '1..23',
+        '12..3',
+        '12.3.4',
+        '1.23.4',
+        '1.2.34',
+      ]);
     });
 
     test('for word chars', () => {

--- a/library/src/actions/digits/digits.test-d.ts
+++ b/library/src/actions/digits/digits.test-d.ts
@@ -1,0 +1,41 @@
+import { describe, expectTypeOf, test } from 'vitest';
+import type { InferInput, InferIssue, InferOutput } from '../../types/index.ts';
+import { digits, type DigitsAction, type DigitsIssue } from './digits.ts';
+
+describe('digits', () => {
+  describe('should return action object', () => {
+    test('with undefined message', () => {
+      type Action = DigitsAction<string, undefined>;
+      expectTypeOf(digits()).toEqualTypeOf<Action>();
+      expectTypeOf(digits(undefined)).toEqualTypeOf<Action>();
+    });
+
+    test('with string message', () => {
+      expectTypeOf(digits('message')).toEqualTypeOf<
+        DigitsAction<string, 'message'>
+      >();
+    });
+
+    test('with function message', () => {
+      expectTypeOf(digits(() => 'message')).toEqualTypeOf<
+        DigitsAction<string, () => string>
+      >();
+    });
+  });
+
+  describe('should infer correct types', () => {
+    type Action = DigitsAction<string, undefined>;
+
+    test('of input', () => {
+      expectTypeOf<InferInput<Action>>().toEqualTypeOf<string>();
+    });
+
+    test('of output', () => {
+      expectTypeOf<InferOutput<Action>>().toEqualTypeOf<string>();
+    });
+
+    test('of issue', () => {
+      expectTypeOf<InferIssue<Action>>().toEqualTypeOf<DigitsIssue<string>>();
+    });
+  });
+});

--- a/library/src/actions/digits/digits.test.ts
+++ b/library/src/actions/digits/digits.test.ts
@@ -1,47 +1,47 @@
 import { describe, expect, test } from 'vitest';
-import { DECIMAL_REGEX } from '../../regex.ts';
+import { DIGITS_REGEX } from '../../regex.ts';
 import { expectActionIssue, expectNoActionIssue } from '../../vitest/index.ts';
-import { decimal, type DecimalAction, type DecimalIssue } from './decimal.ts';
+import { digits, type DigitsAction, type DigitsIssue } from './digits.ts';
 
-describe('decimal', () => {
+describe('digits', () => {
   describe('should return action object', () => {
-    const baseAction: Omit<DecimalAction<string, never>, 'message'> = {
+    const baseAction: Omit<DigitsAction<string, never>, 'message'> = {
       kind: 'validation',
-      type: 'decimal',
-      reference: decimal,
+      type: 'digits',
+      reference: digits,
       expects: null,
-      requirement: DECIMAL_REGEX,
+      requirement: DIGITS_REGEX,
       async: false,
       _run: expect.any(Function),
     };
 
     test('with undefined message', () => {
-      const action: DecimalAction<string, undefined> = {
+      const action: DigitsAction<string, undefined> = {
         ...baseAction,
         message: undefined,
       };
-      expect(decimal()).toStrictEqual(action);
-      expect(decimal(undefined)).toStrictEqual(action);
+      expect(digits()).toStrictEqual(action);
+      expect(digits(undefined)).toStrictEqual(action);
     });
 
     test('with string message', () => {
-      expect(decimal('message')).toStrictEqual({
+      expect(digits('message')).toStrictEqual({
         ...baseAction,
         message: 'message',
-      } satisfies DecimalAction<string, string>);
+      } satisfies DigitsAction<string, string>);
     });
 
     test('with function message', () => {
       const message = () => 'message';
-      expect(decimal(message)).toStrictEqual({
+      expect(digits(message)).toStrictEqual({
         ...baseAction,
         message,
-      } satisfies DecimalAction<string, typeof message>);
+      } satisfies DigitsAction<string, typeof message>);
     });
   });
 
   describe('should return dataset without issues', () => {
-    const action = decimal();
+    const action = digits();
 
     test('for untyped inputs', () => {
       expect(action._run({ typed: false, value: null }, {})).toStrictEqual({
@@ -59,31 +59,19 @@ describe('decimal', () => {
       expectNoActionIssue(action, ['00', '01', '12', '99']);
     });
 
-    test('for float numbers', () => {
-      expectNoActionIssue(action, ['0.1', '123.456']);
-    });
-
-    test('for number signs', () => {
-      expectNoActionIssue(action, ['+1', '-1', '+123', '-123']);
-    });
-
-    test('for float numbers with a number sign', () => {
-      expectNoActionIssue(action, ['-2.0', '-52.61', '+4.0', '-11.31']);
-    });
-
     test('for multiple digits', () => {
       expectNoActionIssue(action, ['0123456789']);
     });
   });
 
   describe('should return dataset with issues', () => {
-    const action = decimal('message');
-    const baseIssue: Omit<DecimalIssue<string>, 'input' | 'received'> = {
+    const action = digits('message');
+    const baseIssue: Omit<DigitsIssue<string>, 'input' | 'received'> = {
       kind: 'validation',
-      type: 'decimal',
+      type: 'digits',
       expected: null,
       message: 'message',
-      requirement: DECIMAL_REGEX,
+      requirement: DIGITS_REGEX,
     };
 
     test('for empty strings', () => {
@@ -98,20 +86,16 @@ describe('decimal', () => {
       expectActionIssue(action, baseIssue, ['1,000', '1_000', '1 000']);
     });
 
+    test('for number signs', () => {
+      expectActionIssue(action, baseIssue, ['+1', '-1', '+123', '-123']);
+    });
+
+    test('for float numbers', () => {
+      expectActionIssue(action, baseIssue, ['0.1', '123.456']);
+    });
+
     test('for exponential numbers', () => {
       expectActionIssue(action, baseIssue, ['1e3', '1e-3', '1e+3']);
-    });
-
-    test('for floats ending in .', () => {
-      expectActionIssue(action, baseIssue, ['1.', '342.']);
-    });
-
-    test('for floats starting with .', () => {
-      expectActionIssue(action, baseIssue, ['.6', '.763']);
-    });
-
-    test('for floats starting with . and number sign', () => {
-      expectActionIssue(action, baseIssue, ['-.2', '-.922', '+.5', '+.452']);
     });
 
     test('for word chars', () => {
@@ -121,7 +105,9 @@ describe('decimal', () => {
     test('for special chars', () => {
       expectActionIssue(action, baseIssue, [
         '-',
+        '-1',
         '+',
+        '+1',
         '#',
         '#1',
         '$',

--- a/library/src/actions/digits/digits.ts
+++ b/library/src/actions/digits/digits.ts
@@ -1,0 +1,105 @@
+import { DIGITS_REGEX } from '../../regex.ts';
+import type {
+  BaseIssue,
+  BaseValidation,
+  Dataset,
+  ErrorMessage,
+} from '../../types/index.ts';
+import { _addIssue } from '../../utils/index.ts';
+
+/**
+ * Digits issue type.
+ */
+export interface DigitsIssue<TInput extends string> extends BaseIssue<TInput> {
+  /**
+   * The issue kind.
+   */
+  readonly kind: 'validation';
+  /**
+   * The issue type.
+   */
+  readonly type: 'digits';
+  /**
+   * The expected property.
+   */
+  readonly expected: null;
+  /**
+   * The received property.
+   */
+  readonly received: `"${string}"`;
+  /**
+   * The digits regex.
+   */
+  readonly requirement: RegExp;
+}
+
+/**
+ * Digits action type.
+ */
+export interface DigitsAction<
+  TInput extends string,
+  TMessage extends ErrorMessage<DigitsIssue<TInput>> | undefined,
+> extends BaseValidation<TInput, TInput, DigitsIssue<TInput>> {
+  /**
+   * The action type.
+   */
+  readonly type: 'digits';
+  /**
+   * The action reference.
+   */
+  readonly reference: typeof digits;
+  /**
+   * The expected property.
+   */
+  readonly expects: null;
+  /**
+   * The digits regex.
+   */
+  readonly requirement: RegExp;
+  /**
+   * The error message.
+   */
+  readonly message: TMessage;
+}
+
+/**
+ * Creates a [digits](https://en.wikipedia.org/wiki/Numerical_digit) validation action.
+ *
+ * @returns An digits action.
+ */
+export function digits<TInput extends string>(): DigitsAction<
+  TInput,
+  undefined
+>;
+
+/**
+ * Creates a [digits](https://en.wikipedia.org/wiki/Numerical_digit) validation action.
+ *
+ * @param message The error message.
+ *
+ * @returns An digits action.
+ */
+export function digits<
+  TInput extends string,
+  const TMessage extends ErrorMessage<DigitsIssue<TInput>> | undefined,
+>(message: TMessage): DigitsAction<TInput, TMessage>;
+
+export function digits(
+  message?: ErrorMessage<DigitsIssue<string>>
+): DigitsAction<string, ErrorMessage<DigitsIssue<string>> | undefined> {
+  return {
+    kind: 'validation',
+    type: 'digits',
+    reference: digits,
+    async: false,
+    expects: null,
+    requirement: DIGITS_REGEX,
+    message,
+    _run(dataset, config) {
+      if (dataset.typed && !this.requirement.test(dataset.value)) {
+        _addIssue(this, 'digits', dataset, config);
+      }
+      return dataset as Dataset<string, DigitsIssue<string>>;
+    },
+  };
+}

--- a/library/src/actions/digits/index.ts
+++ b/library/src/actions/digits/index.ts
@@ -1,0 +1,1 @@
+export * from './digits.ts';

--- a/library/src/actions/index.ts
+++ b/library/src/actions/index.ts
@@ -9,6 +9,7 @@ export * from './creditCard/index.ts';
 export * from './cuid2/index.ts';
 export * from './decimal/index.ts';
 export * from './description/index.ts';
+export * from './digits/index.ts';
 export * from './email/index.ts';
 export * from './emoji/index.ts';
 export * from './empty/index.ts';

--- a/library/src/regex.ts
+++ b/library/src/regex.ts
@@ -17,7 +17,12 @@ export const CUID2_REGEX: RegExp = /^[a-z][\da-z]*$/u;
 /**
  * [Decimal](https://en.wikipedia.org/wiki/Decimal) regex.
  */
-export const DECIMAL_REGEX: RegExp = /^\d+$/u;
+export const DECIMAL_REGEX: RegExp = /^[+-]?(\d+(\.\d+)?)$/u;
+
+/**
+ * [Digits](https://en.wikipedia.org/wiki/Numerical_digit) regex.
+ */
+export const DIGITS_REGEX: RegExp = /^\d+$/u;
 
 /**
  * Email regex.

--- a/library/src/regex.ts
+++ b/library/src/regex.ts
@@ -17,7 +17,7 @@ export const CUID2_REGEX: RegExp = /^[a-z][\da-z]*$/u;
 /**
  * [Decimal](https://en.wikipedia.org/wiki/Decimal) regex.
  */
-export const DECIMAL_REGEX: RegExp = /^[+-]?(\d+(\.\d+)?)$/u;
+export const DECIMAL_REGEX: RegExp = /^[+-]?\d+(?:\.\d+)?$/u;
 
 /**
  * [Digits](https://en.wikipedia.org/wiki/Numerical_digit) regex.

--- a/website/src/routes/api/(actions)/digits/index.mdx
+++ b/website/src/routes/api/(actions)/digits/index.mdx
@@ -1,0 +1,67 @@
+---
+title: digits
+description: Creates a digits validation action.
+source: /actions/digits/digits.ts
+contributors:
+  - fabian-hiller
+  - andrew-d-jackson
+---
+
+import { ApiList, Property } from '~/components';
+import { properties } from './properties';
+
+# digits
+
+Creates a [digits](https://en.wikipedia.org/wiki/Numerical_digit) validation action.
+
+```ts
+const Action = v.digits<TInput, TMessage>(message);
+```
+
+## Generics
+
+- `TInput` <Property {...properties.TInput} />
+- `TMessage` <Property {...properties.TMessage} />
+
+## Parameters
+
+- `message` <Property {...properties.message} />
+
+### Explanation
+
+With `digits` you can validate the formatting of a string. If the input does not soley consist of numerical digits, you can use `message` to customize the error message.
+
+## Returns
+
+- `Action` <Property {...properties.Action} />
+
+## Examples
+
+The following examples show how `digits` can be used.
+
+### Digits schema
+
+Schema to validate a digits.
+
+```ts
+const DigitsSchema = v.pipe(
+  v.string(),
+  v.digits('The string contains something other than digits.')
+);
+```
+
+## Related
+
+The following APIs can be combined with `digits`.
+
+### Schemas
+
+<ApiList items={['any', 'custom', 'string', 'unknown']} />
+
+### Methods
+
+<ApiList items={['pipe']} />
+
+### Utils
+
+<ApiList items={['isOfKind', 'isOfType']} />

--- a/website/src/routes/api/(actions)/digits/properties.ts
+++ b/website/src/routes/api/(actions)/digits/properties.ts
@@ -1,0 +1,58 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TInput: {
+    modifier: 'extends',
+    type: 'string',
+  },
+  TMessage: {
+    modifier: 'extends',
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'ErrorMessage',
+          href: '../ErrorMessage/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'DigitsIssue',
+              href: '../DigitsIssue/',
+              generics: [
+                {
+                  type: 'custom',
+                  name: 'TInput',
+                },
+              ],
+            },
+          ],
+        },
+        'undefined',
+      ],
+    },
+  },
+  message: {
+    type: {
+      type: 'custom',
+      name: 'TMessage',
+    },
+  },
+  Action: {
+    type: {
+      type: 'custom',
+      name: 'DigitsAction',
+      href: '../DigitsAction/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TInput',
+        },
+        {
+          type: 'custom',
+          name: 'TMessage',
+        },
+      ],
+    },
+  },
+};

--- a/website/src/routes/api/(async)/customAsync/index.mdx
+++ b/website/src/routes/api/(async)/customAsync/index.mdx
@@ -116,6 +116,7 @@ The following APIs can be combined with `customAsync`.
     'cuid2',
     'decimal',
     'description',
+    'digits',
     'email',
     'emoji',
     'empty',

--- a/website/src/routes/api/(async)/fallbackAsync/index.mdx
+++ b/website/src/routes/api/(async)/fallbackAsync/index.mdx
@@ -144,6 +144,7 @@ The following APIs can be combined with `fallbackAsync`.
     'cuid2',
     'decimal',
     'description',
+    'digits',
     'email',
     'emoji',
     'empty',

--- a/website/src/routes/api/(async)/intersectAsync/index.mdx
+++ b/website/src/routes/api/(async)/intersectAsync/index.mdx
@@ -147,6 +147,7 @@ The following APIs can be combined with `intersectAsync`.
     'cuid2',
     'decimal',
     'description',
+    'digits',
     'email',
     'emoji',
     'empty',

--- a/website/src/routes/api/(async)/lazyAsync/index.mdx
+++ b/website/src/routes/api/(async)/lazyAsync/index.mdx
@@ -179,6 +179,7 @@ The following APIs can be combined with `lazyAsync`.
     'cuid2',
     'decimal',
     'description',
+    'digits',
     'email',
     'emoji',
     'empty',

--- a/website/src/routes/api/(async)/pipeAsync/index.mdx
+++ b/website/src/routes/api/(async)/pipeAsync/index.mdx
@@ -181,6 +181,7 @@ The following APIs can be combined with `pipeAsync`.
     'cuid2',
     'decimal',
     'description',
+    'digits',
     'email',
     'emoji',
     'empty',

--- a/website/src/routes/api/(async)/unionAsync/index.mdx
+++ b/website/src/routes/api/(async)/unionAsync/index.mdx
@@ -140,6 +140,7 @@ The following APIs can be combined with `unionAsync`.
     'cuid2',
     'decimal',
     'description',
+    'digits',
     'email',
     'emoji',
     'empty',

--- a/website/src/routes/api/(methods)/config/index.mdx
+++ b/website/src/routes/api/(methods)/config/index.mdx
@@ -160,6 +160,7 @@ The following APIs can be combined with `config`.
     'cuid2',
     'decimal',
     'description',
+    'digits',
     'email',
     'emoji',
     'empty',

--- a/website/src/routes/api/(methods)/fallback/index.mdx
+++ b/website/src/routes/api/(methods)/fallback/index.mdx
@@ -158,6 +158,7 @@ The following APIs can be combined with `fallback`.
     'cuid2',
     'decimal',
     'description',
+    'digits',
     'email',
     'emoji',
     'empty',

--- a/website/src/routes/api/(methods)/pipe/index.mdx
+++ b/website/src/routes/api/(methods)/pipe/index.mdx
@@ -161,6 +161,7 @@ The following APIs can be combined with `pipe`.
     'cuid2',
     'decimal',
     'description',
+    'digits',
     'email',
     'emoji',
     'empty',

--- a/website/src/routes/api/(schemas)/any/index.mdx
+++ b/website/src/routes/api/(schemas)/any/index.mdx
@@ -91,6 +91,7 @@ The following APIs can be combined with `any`.
     'cuid2',
     'decimal',
     'description',
+    'digits',
     'email',
     'emoji',
     'empty',

--- a/website/src/routes/api/(schemas)/custom/index.mdx
+++ b/website/src/routes/api/(schemas)/custom/index.mdx
@@ -120,6 +120,7 @@ The following APIs can be combined with `custom`.
     'cuid2',
     'decimal',
     'description',
+    'digits',
     'email',
     'emoji',
     'empty',

--- a/website/src/routes/api/(schemas)/intersect/index.mdx
+++ b/website/src/routes/api/(schemas)/intersect/index.mdx
@@ -143,6 +143,7 @@ The following APIs can be combined with `intersect`.
     'cuid2',
     'decimal',
     'description',
+    'digits',
     'email',
     'emoji',
     'empty',

--- a/website/src/routes/api/(schemas)/lazy/index.mdx
+++ b/website/src/routes/api/(schemas)/lazy/index.mdx
@@ -179,6 +179,7 @@ The following APIs can be combined with `lazy`.
     'cuid2',
     'decimal',
     'description',
+    'digits',
     'email',
     'emoji',
     'empty',

--- a/website/src/routes/api/(schemas)/string/index.mdx
+++ b/website/src/routes/api/(schemas)/string/index.mdx
@@ -143,6 +143,7 @@ The following APIs can be combined with `string`.
     'check',
     'decimal',
     'description',
+    'digits',
     'email',
     'emoji',
     'empty',

--- a/website/src/routes/api/(schemas)/union/index.mdx
+++ b/website/src/routes/api/(schemas)/union/index.mdx
@@ -159,6 +159,7 @@ The following APIs can be combined with `union`.
     'cuid2',
     'decimal',
     'description',
+    'digits',
     'email',
     'emoji',
     'empty',

--- a/website/src/routes/api/(schemas)/unknown/index.mdx
+++ b/website/src/routes/api/(schemas)/unknown/index.mdx
@@ -91,6 +91,7 @@ The following APIs can be combined with `unknwon`.
     'cuid2',
     'decimal',
     'description',
+    'digits',
     'email',
     'emoji',
     'empty',

--- a/website/src/routes/api/(types)/DigitsAction/index.mdx
+++ b/website/src/routes/api/(types)/DigitsAction/index.mdx
@@ -1,0 +1,28 @@
+---
+title: DigitsAction
+description: Digits action type.
+contributors:
+  - fabian-hiller
+  - andrew-d-jackson
+---
+
+import { Property } from '~/components';
+import { properties } from './properties';
+
+# DigitsAction
+
+Digits action type.
+
+## Generics
+
+- `TInput` <Property {...properties.TInput} />
+- `TMessage` <Property {...properties.TMessage} />
+
+## Definition
+
+- `DigitsAction` <Property {...properties.BaseValidation} />
+  - `type` <Property {...properties.type} />
+  - `reference` <Property {...properties.reference} />
+  - `expects` <Property {...properties.expects} />
+  - `requirement` <Property {...properties.requirement} />
+  - `message` <Property {...properties.message} />

--- a/website/src/routes/api/(types)/DigitsAction/properties.ts
+++ b/website/src/routes/api/(types)/DigitsAction/properties.ts
@@ -1,0 +1,93 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TInput: {
+    modifier: 'extends',
+    type: 'string',
+  },
+  TMessage: {
+    modifier: 'extends',
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'ErrorMessage',
+          href: '../ErrorMessage/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'DecimalIssue',
+              href: '../DecimalIssue/',
+              generics: [
+                {
+                  type: 'custom',
+                  name: 'TInput',
+                },
+              ],
+            },
+          ],
+        },
+        'undefined',
+      ],
+    },
+  },
+  BaseValidation: {
+    modifier: 'extends',
+    type: {
+      type: 'custom',
+      name: 'BaseValidation',
+      href: '../BaseValidation/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TInput',
+        },
+        {
+          type: 'custom',
+          name: 'TInput',
+        },
+        {
+          type: 'custom',
+          name: 'DigitsIssue',
+          href: '../DigitsIssue/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'TInput',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  type: {
+    type: {
+      type: 'string',
+      value: 'digits',
+    },
+  },
+  reference: {
+    type: {
+      type: 'custom',
+      modifier: 'typeof',
+      name: 'digits',
+      href: '../digits/',
+    },
+  },
+  expects: {
+    type: 'null',
+  },
+  requirement: {
+    type: {
+      type: 'custom',
+      name: 'RegExp',
+    },
+  },
+  message: {
+    type: {
+      type: 'custom',
+      name: 'TMessage',
+    },
+  },
+};

--- a/website/src/routes/api/(types)/DigitsIssue/index.mdx
+++ b/website/src/routes/api/(types)/DigitsIssue/index.mdx
@@ -1,0 +1,27 @@
+---
+title: DigitsIssue
+description: Digits issue type.
+contributors:
+  - fabian-hiller
+  - andrew-d-jackson
+---
+
+import { Property } from '~/components';
+import { properties } from './properties';
+
+# DigitsIssue
+
+Digits issue type.
+
+## Generics
+
+- `TInput` <Property {...properties.TInput} />
+
+## Definition
+
+- `DigitsIssue` <Property {...properties.BaseIssue} />
+  - `kind` <Property {...properties.kind} />
+  - `type` <Property {...properties.type} />
+  - `expected` <Property {...properties.expected} />
+  - `received` <Property {...properties.received} />
+  - `requirement` <Property {...properties.requirement} />

--- a/website/src/routes/api/(types)/DigitsIssue/properties.ts
+++ b/website/src/routes/api/(types)/DigitsIssue/properties.ts
@@ -1,0 +1,59 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TInput: {
+    modifier: 'extends',
+    type: 'string',
+  },
+  BaseIssue: {
+    modifier: 'extends',
+    type: {
+      type: 'custom',
+      name: 'BaseIssue',
+      href: '../BaseIssue/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TInput',
+        },
+      ],
+    },
+  },
+  kind: {
+    type: {
+      type: 'string',
+      value: 'validation',
+    },
+  },
+  type: {
+    type: {
+      type: 'string',
+      value: 'digits',
+    },
+  },
+  expected: {
+    type: 'null',
+  },
+  received: {
+    type: {
+      type: 'template',
+      parts: [
+        {
+          type: 'string',
+          value: '"',
+        },
+        'string',
+        {
+          type: 'string',
+          value: '"',
+        },
+      ],
+    },
+  },
+  requirement: {
+    type: {
+      type: 'custom',
+      name: 'RegExp',
+    },
+  },
+};

--- a/website/src/routes/api/menu.md
+++ b/website/src/routes/api/menu.md
@@ -282,6 +282,8 @@
 - [DefaultAsync](/api/DefaultAsync/)
 - [DefaultValue](/api/DefaultValue/)
 - [DescriptionAction](/api/DescriptionAction/)
+- [DigitsAction](/api/DigitsAction/)
+- [DigitsIssue](/api/DigitsIssue/)
 - [EmailAction](/api/EmailAction/)
 - [EmailIssue](/api/EmailIssue/)
 - [EmojiAction](/api/EmojiAction/)

--- a/website/src/routes/api/menu.md
+++ b/website/src/routes/api/menu.md
@@ -83,6 +83,7 @@
 - [cuid2](/api/cuid2/)
 - [decimal](/api/decimal/)
 - [description](/api/description/)
+- [digits](/api/digits/)
 - [email](/api/email/)
 - [emoji](/api/emoji/)
 - [empty](/api/empty/)

--- a/website/src/routes/guides/(main-concepts)/pipelines/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/pipelines/index.mdx
@@ -54,6 +54,7 @@ Pipeline validation actions examine the input and, if the input does not meet a 
     'creditCard',
     'cuid2',
     'decimal',
+    'digits',
     'email',
     'emoji',
     'empty',


### PR DESCRIPTION
See issue #822

This PR:
- Renames the existing `decimal` action to `digits`. `digits` only passes strings containing the numbers 0-9.
- Creates a new `decimal` action. `decimal` passes non-integers and allows number signs.
- Updates the docs to reflect the above.