### PR TITLE
add `rawCheckAsync` & `RawCheckActionAsync` API refs

### DIFF
--- a/website/src/routes/api/(actions)/rawCheck/AddIssue/index.mdx
+++ b/website/src/routes/api/(actions)/rawCheck/AddIssue/index.mdx
@@ -1,0 +1,21 @@
+---
+title: AddIssue
+description: Add issue type.
+contributors:
+  - EltonLobo07
+---
+
+import { Property } from '~/components';
+import { properties } from './properties';
+
+# AddIssue
+
+Add issue type.
+
+## Generics
+
+- `TInput` <Property {...properties.TInput} />
+
+## Definition
+
+- `AddIssue` <Property {...properties.AddIssue} />

--- a/website/src/routes/api/(actions)/rawCheck/AddIssue/properties.ts
+++ b/website/src/routes/api/(actions)/rawCheck/AddIssue/properties.ts
@@ -5,16 +5,17 @@ export const properties: Record<string, PropertyProps> = {
     modifier: 'extends',
     type: 'any',
   },
-  action: {
+  AddIssue: {
     type: {
       type: 'function',
       params: [
         {
-          name: 'context',
+          name: 'info',
+          optional: true,
           type: {
             type: 'custom',
-            name: 'Context',
-            href: './Context/',
+            name: 'IssueInfo',
+            href: '../IssueInfo/',
             generics: [
               {
                 type: 'custom',
@@ -25,19 +26,6 @@ export const properties: Record<string, PropertyProps> = {
         },
       ],
       return: 'void',
-    },
-  },
-  Action: {
-    type: {
-      type: 'custom',
-      name: 'RawCheckAction',
-      href: '../RawCheckAction/',
-      generics: [
-        {
-          type: 'custom',
-          name: 'TInput',
-        },
-      ],
     },
   },
 };

--- a/website/src/routes/api/(actions)/rawCheck/Context/index.mdx
+++ b/website/src/routes/api/(actions)/rawCheck/Context/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Context
+description: Context type.
+contributors:
+  - EltonLobo07
+---
+
+import { Property } from '~/components';
+import { properties } from './properties';
+
+# Context
+
+Context type.
+
+## Generics
+
+- `TInput` <Property {...properties.TInput} />
+
+## Definition
+
+- `Context`
+  - `dataset` <Property {...properties.dataset} />
+  - `config` <Property {...properties.config} />
+  - `addIssue` <Property {...properties.addIssue} />

--- a/website/src/routes/api/(actions)/rawCheck/Context/properties.ts
+++ b/website/src/routes/api/(actions)/rawCheck/Context/properties.ts
@@ -1,0 +1,60 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TInput: {
+    modifier: 'extends',
+    type: 'any',
+  },
+  dataset: {
+    type: {
+      type: 'custom',
+      name: 'Dataset',
+      href: '../../Dataset/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TInput',
+        },
+        {
+          type: 'custom',
+          name: 'BaseIssue',
+          href: '../../BaseIssue/',
+          generics: ['unknown'],
+        },
+      ],
+    },
+  },
+  config: {
+    type: {
+      type: 'custom',
+      name: 'Config',
+      href: '../../Config/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'RawCheckIssue',
+          href: '../../RawCheckIssue/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'TInput',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  addIssue: {
+    type: {
+      type: 'custom',
+      name: 'AddIssue',
+      href: '../AddIssue/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TInput',
+        },
+      ],
+    },
+  },
+};

--- a/website/src/routes/api/(actions)/rawCheck/IssueInfo/index.mdx
+++ b/website/src/routes/api/(actions)/rawCheck/IssueInfo/index.mdx
@@ -1,0 +1,27 @@
+---
+title: IssueInfo
+description: Issue info type.
+contributors:
+  - EltonLobo07
+---
+
+import { Property } from '~/components';
+import { properties } from './properties';
+
+# IssueInfo
+
+Issue info type.
+
+## Generics
+
+- `TInput` <Property {...properties.TInput} />
+
+## Definition
+
+- `IssueInfo`
+  - `label` <Property {...properties.label} />
+  - `input` <Property {...properties.input} />
+  - `expected` <Property {...properties.expected} />
+  - `received` <Property {...properties.received} />
+  - `message` <Property {...properties.message} />
+  - `path` <Property {...properties.path} />

--- a/website/src/routes/api/(actions)/rawCheck/IssueInfo/properties.ts
+++ b/website/src/routes/api/(actions)/rawCheck/IssueInfo/properties.ts
@@ -1,0 +1,91 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TInput: {
+    modifier: 'extends',
+    type: 'any',
+  },
+  kind: {
+    type: {
+      type: 'string',
+      value: 'metadata',
+    },
+  },
+  label: {
+    type: {
+      type: 'union',
+      options: ['string', 'undefined'],
+    },
+  },
+  input: {
+    type: {
+      type: 'union',
+      options: ['unknown', 'undefined'],
+    },
+  },
+  expected: {
+    type: {
+      type: 'union',
+      options: ['string', 'undefined'],
+    },
+  },
+  received: {
+    type: {
+      type: 'union',
+      options: ['string', 'undefined'],
+    },
+  },
+  message: {
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'custom',
+          name: 'ErrorMessage',
+          href: '../../ErrorMessage/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'RawCheckIssue',
+              href: '../../RawCheckIssue/',
+              generics: [
+                {
+                  type: 'custom',
+                  name: 'TInput',
+                },
+              ],
+            },
+          ],
+        },
+        'undefined',
+      ],
+    },
+  },
+  path: {
+    type: {
+      type: 'union',
+      options: [
+        {
+          type: 'tuple',
+          items: [
+            {
+              type: 'custom',
+              name: 'IssuePathItem',
+              href: '../../IssuePathItem/',
+            },
+            {
+              type: 'array',
+              item: {
+                type: 'custom',
+                name: 'IssuePathItem',
+                href: '../../IssuePathItem/',
+              },
+              spread: true,
+            },
+          ],
+        },
+        'undefined',
+      ],
+    },
+  },
+};

--- a/website/src/routes/api/(async)/rawCheckAsync/index.mdx
+++ b/website/src/routes/api/(async)/rawCheckAsync/index.mdx
@@ -1,11 +1,181 @@
 ---
 title: rawCheckAsync
+description: Creates a raw check validation action.
 source: /actions/rawCheck/rawCheckAsync.ts
 contributors:
   - EltonLobo07
   - fabian-hiller
 ---
 
+import { ApiList, Property } from '~/components';
+import { properties } from './properties';
+
 # rawCheckAsync
 
-> The content of this page is not yet ready. Until then, please use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/actions/rawCheck/rawCheckAsync.ts) or take a look at [issue #287](https://github.com/fabian-hiller/valibot/issues/287) to help us extend the API reference.
+Creates a raw check validation action.
+
+```ts
+const Action = v.rawCheckAsync<TInput>(action);
+```
+
+## Generics
+
+- `TInput` <Property {...properties.TInput} />
+
+## Parameters
+
+- `action` <Property {...properties.action} />
+
+### Explanation
+
+With `rawCheckAsync` you can freely validate the input with a custom `action` and add issues if necessary.
+
+## Returns
+
+- `Action` <Property {...properties.Action} />
+
+## Examples
+
+The following examples show how `rawCheckAsync` can be used.
+
+### Add users schema
+
+Object schema that ensures only the users that are not already in the group are added.
+
+> This `rawCheckAsync` validation action adds an issue for any invalid username and forwards it via `path` to the appropriate nested field.
+
+```ts
+import { isNewGroupUser } from '~/api';
+
+const AddUsersSchema = v.pipeAsync(
+  v.object({
+    groupId: v.pipe(v.string(), v.uuid()),
+    usernames: v.array(v.pipe(v.string(), v.nonEmpty())),
+  }),
+  v.rawCheckAsync(async ({ dataset, addIssue }) => {
+    if (!dataset.typed) {
+      return;
+    }
+    const { groupId, usernames } = dataset.value;
+    for (let index = 0; index < usernames.length; index++) {
+      const username = usernames[index];
+      if (await isNewGroupUser(username, groupId)) {
+        continue;
+      }
+      addIssue({
+        received: username,
+        message: 'The user is already in the group.',
+        path: [
+          {
+            type: 'object',
+            origin: 'value',
+            input: dataset.value,
+            key: 'usernames',
+            value: usernames,
+          },
+          {
+            type: 'array',
+            origin: 'value',
+            input: usernames,
+            key: index,
+            value: username,
+          },
+        ],
+      });
+    }
+  })
+);
+```
+
+## Related
+
+The following APIs can be combined with `rawCheckAsync`.
+
+### Schemas
+
+<ApiList
+  items={[
+    'any',
+    'array',
+    'bigint',
+    'blob',
+    'boolean',
+    'custom',
+    'date',
+    'enum',
+    'file',
+    'function',
+    'instance',
+    'intersect',
+    'lazy',
+    'literal',
+    'looseObject',
+    'looseTuple',
+    'map',
+    'nan',
+    'never',
+    'nonNullable',
+    'nonNullish',
+    'nonOptional',
+    'null',
+    'nullable',
+    'nullish',
+    'number',
+    'object',
+    'objectWithRest',
+    'optional',
+    'picklist',
+    'promise',
+    'record',
+    'set',
+    'strictObject',
+    'strictTuple',
+    'string',
+    'symbol',
+    'tuple',
+    'tupleWithRest',
+    'undefined',
+    'undefinedable',
+    'union',
+    'unknown',
+    'variant',
+    'void',
+  ]}
+/>
+
+### Utils
+
+<ApiList items={['isOfKind', 'isOfType']} />
+
+### Async
+
+<ApiList
+  items={[
+    'arrayAsync',
+    'customAsync',
+    'forwardAsync',
+    'intersectAsync',
+    'lazyAsync',
+    'looseObjectAsync',
+    'looseTupleAsync',
+    'mapAsync',
+    'nonNullableAsync',
+    'nonNullishAsync',
+    'nonOptionalAsync',
+    'nullableAsync',
+    'nullishAsync',
+    'objectAsync',
+    'objectWithRestAsync',
+    'optionalAsync',
+    'pipeAsync',
+    'recordAsync',
+    'setAsync',
+    'strictObjectAsync',
+    'strictTupleAsync',
+    'tupleAsync',
+    'tupleWithRestAsync',
+    'undefinedableAsync',
+    'unionAsync',
+    'variantAsync',
+  ]}
+/>

--- a/website/src/routes/api/(async)/rawCheckAsync/index.mdx
+++ b/website/src/routes/api/(async)/rawCheckAsync/index.mdx
@@ -40,12 +40,12 @@ The following examples show how `rawCheckAsync` can be used.
 
 ### Add users schema
 
-Object schema that ensures only the users that are not already in the group are added.
+Object schema that ensures that only users not already in the group are included.
 
 > This `rawCheckAsync` validation action adds an issue for any invalid username and forwards it via `path` to the appropriate nested field.
 
 ```ts
-import { isNewGroupUser } from '~/api';
+import { isAlreadyInGroup } from '~/api';
 
 const AddUsersSchema = v.pipeAsync(
   v.object({
@@ -53,35 +53,33 @@ const AddUsersSchema = v.pipeAsync(
     usernames: v.array(v.pipe(v.string(), v.nonEmpty())),
   }),
   v.rawCheckAsync(async ({ dataset, addIssue }) => {
-    if (!dataset.typed) {
-      return;
-    }
-    const { groupId, usernames } = dataset.value;
-    for (let index = 0; index < usernames.length; index++) {
-      const username = usernames[index];
-      if (await isNewGroupUser(username, groupId)) {
-        continue;
-      }
-      addIssue({
-        received: username,
-        message: 'The user is already in the group.',
-        path: [
-          {
-            type: 'object',
-            origin: 'value',
-            input: dataset.value,
-            key: 'usernames',
-            value: usernames,
-          },
-          {
-            type: 'array',
-            origin: 'value',
-            input: usernames,
-            key: index,
-            value: username,
-          },
-        ],
-      });
+    if (dataset.typed) {
+      await Promise.all(
+        dataset.value.usernames.map(async (username, index) => {
+          if (await isAlreadyInGroup(username, dataset.value.groupId)) {
+            addIssue({
+              received: username,
+              message: 'The user is already in the group.',
+              path: [
+                {
+                  type: 'object',
+                  origin: 'value',
+                  input: dataset.value,
+                  key: 'usernames',
+                  value: dataset.value.usernames,
+                },
+                {
+                  type: 'array',
+                  origin: 'value',
+                  input: dataset.value.usernames,
+                  key: index,
+                  value: username,
+                },
+              ],
+            });
+          }
+        })
+      );
     }
   })
 );

--- a/website/src/routes/api/(async)/rawCheckAsync/properties.ts
+++ b/website/src/routes/api/(async)/rawCheckAsync/properties.ts
@@ -1,0 +1,166 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TInput: {
+    modifier: 'extends',
+    type: 'any',
+  },
+  action: {
+    type: {
+      type: 'function',
+      params: [
+        {
+          name: 'context',
+          type: {
+            type: 'object',
+            entries: [
+              {
+                key: 'dataset',
+                value: {
+                  type: 'custom',
+                  name: 'Dataset',
+                  href: '../Dataset/',
+                  generics: [
+                    {
+                      type: 'custom',
+                      name: 'TInput',
+                    },
+                    {
+                      type: 'custom',
+                      name: 'BaseIssue',
+                      href: '../BaseIssue/',
+                      generics: ['unknown'],
+                    },
+                  ],
+                },
+              },
+              {
+                key: 'config',
+                value: {
+                  type: 'custom',
+                  name: 'Config',
+                  href: '../Config/',
+                  generics: [
+                    {
+                      type: 'custom',
+                      name: 'RawCheckIssue',
+                      href: '../RawCheckIssue/',
+                      generics: [
+                        {
+                          type: 'custom',
+                          name: 'TInput',
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+              {
+                key: 'addIssue',
+                value: {
+                  type: 'function',
+                  params: [
+                    {
+                      name: 'info',
+                      optional: true,
+                      type: {
+                        type: 'object',
+                        entries: [
+                          {
+                            key: 'label',
+                            optional: true,
+                            value: 'string',
+                          },
+                          {
+                            key: 'input',
+                            optional: true,
+                            value: 'unknown',
+                          },
+                          {
+                            key: 'expected',
+                            optional: true,
+                            value: 'string',
+                          },
+                          {
+                            key: 'received',
+                            optional: true,
+                            value: 'string',
+                          },
+                          {
+                            key: 'message',
+                            optional: true,
+                            value: {
+                              type: 'custom',
+                              name: 'ErrorMessage',
+                              href: '../ErrorMessage/',
+                              generics: [
+                                {
+                                  type: 'custom',
+                                  name: 'RawCheckIssue',
+                                  href: '../RawCheckIssue/',
+                                  generics: [
+                                    {
+                                      type: 'custom',
+                                      name: 'TInput',
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          },
+                          {
+                            key: 'path',
+                            optional: true,
+                            value: {
+                              type: 'tuple',
+                              items: [
+                                {
+                                  type: 'custom',
+                                  name: 'IssuePathItem',
+                                  href: '../IssuePathItem/',
+                                },
+                                {
+                                  type: 'array',
+                                  spread: true,
+                                  item: {
+                                    type: 'custom',
+                                    name: 'IssuePathItem',
+                                    href: '../IssuePathItem/',
+                                  },
+                                },
+                              ],
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                  return: 'void',
+                },
+              },
+            ],
+          },
+        },
+      ],
+      return: {
+        type: 'custom',
+        name: 'MaybePromise',
+        href: '../MaybePromise/',
+        generics: ['void'],
+      },
+    },
+  },
+  Action: {
+    type: {
+      type: 'custom',
+      name: 'RawCheckActionAsync',
+      href: '../RawCheckActionAsync/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TInput',
+        },
+      ],
+    },
+  },
+};

--- a/website/src/routes/api/(async)/rawCheckAsync/properties.ts
+++ b/website/src/routes/api/(async)/rawCheckAsync/properties.ts
@@ -12,131 +12,13 @@ export const properties: Record<string, PropertyProps> = {
         {
           name: 'context',
           type: {
-            type: 'object',
-            entries: [
+            type: 'custom',
+            name: 'Context',
+            href: '../rawCheck/Context/',
+            generics: [
               {
-                key: 'dataset',
-                value: {
-                  type: 'custom',
-                  name: 'Dataset',
-                  href: '../Dataset/',
-                  generics: [
-                    {
-                      type: 'custom',
-                      name: 'TInput',
-                    },
-                    {
-                      type: 'custom',
-                      name: 'BaseIssue',
-                      href: '../BaseIssue/',
-                      generics: ['unknown'],
-                    },
-                  ],
-                },
-              },
-              {
-                key: 'config',
-                value: {
-                  type: 'custom',
-                  name: 'Config',
-                  href: '../Config/',
-                  generics: [
-                    {
-                      type: 'custom',
-                      name: 'RawCheckIssue',
-                      href: '../RawCheckIssue/',
-                      generics: [
-                        {
-                          type: 'custom',
-                          name: 'TInput',
-                        },
-                      ],
-                    },
-                  ],
-                },
-              },
-              {
-                key: 'addIssue',
-                value: {
-                  type: 'function',
-                  params: [
-                    {
-                      name: 'info',
-                      optional: true,
-                      type: {
-                        type: 'object',
-                        entries: [
-                          {
-                            key: 'label',
-                            optional: true,
-                            value: 'string',
-                          },
-                          {
-                            key: 'input',
-                            optional: true,
-                            value: 'unknown',
-                          },
-                          {
-                            key: 'expected',
-                            optional: true,
-                            value: 'string',
-                          },
-                          {
-                            key: 'received',
-                            optional: true,
-                            value: 'string',
-                          },
-                          {
-                            key: 'message',
-                            optional: true,
-                            value: {
-                              type: 'custom',
-                              name: 'ErrorMessage',
-                              href: '../ErrorMessage/',
-                              generics: [
-                                {
-                                  type: 'custom',
-                                  name: 'RawCheckIssue',
-                                  href: '../RawCheckIssue/',
-                                  generics: [
-                                    {
-                                      type: 'custom',
-                                      name: 'TInput',
-                                    },
-                                  ],
-                                },
-                              ],
-                            },
-                          },
-                          {
-                            key: 'path',
-                            optional: true,
-                            value: {
-                              type: 'tuple',
-                              items: [
-                                {
-                                  type: 'custom',
-                                  name: 'IssuePathItem',
-                                  href: '../IssuePathItem/',
-                                },
-                                {
-                                  type: 'array',
-                                  spread: true,
-                                  item: {
-                                    type: 'custom',
-                                    name: 'IssuePathItem',
-                                    href: '../IssuePathItem/',
-                                  },
-                                },
-                              ],
-                            },
-                          },
-                        ],
-                      },
-                    },
-                  ],
-                  return: 'void',
-                },
+                type: 'custom',
+                name: 'TInput',
               },
             ],
           },

--- a/website/src/routes/api/(types)/RawCheckActionAsync/index.mdx
+++ b/website/src/routes/api/(types)/RawCheckActionAsync/index.mdx
@@ -1,0 +1,24 @@
+---
+title: RawCheckActionAsync
+description: Raw check action async type.
+contributors:
+  - EltonLobo07
+---
+
+import { Property } from '~/components';
+import { properties } from './properties';
+
+# RawCheckActionAsync
+
+Raw check action async type.
+
+## Generics
+
+- `TInput` <Property {...properties.TInput} />
+
+## Definition
+
+- `RawCheckActionAsync` <Property {...properties.BaseValidationAsync} />
+  - `type` <Property {...properties.type} />
+  - `reference` <Property {...properties.reference} />
+  - `expects` <Property {...properties.expects} />

--- a/website/src/routes/api/(types)/RawCheckActionAsync/properties.ts
+++ b/website/src/routes/api/(types)/RawCheckActionAsync/properties.ts
@@ -1,0 +1,54 @@
+import type { PropertyProps } from '~/components';
+
+export const properties: Record<string, PropertyProps> = {
+  TInput: {
+    modifier: 'extends',
+    type: 'any',
+  },
+  BaseValidationAsync: {
+    modifier: 'extends',
+    type: {
+      type: 'custom',
+      name: 'BaseValidationAsync',
+      href: '../BaseValidationAsync/',
+      generics: [
+        {
+          type: 'custom',
+          name: 'TInput',
+        },
+        {
+          type: 'custom',
+          name: 'TInput',
+        },
+        {
+          type: 'custom',
+          name: 'RawCheckIssue',
+          href: '../RawCheckIssue/',
+          generics: [
+            {
+              type: 'custom',
+              name: 'TInput',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  type: {
+    type: {
+      type: 'string',
+      value: 'raw_check',
+    },
+  },
+  reference: {
+    type: {
+      type: 'custom',
+      modifier: 'typeof',
+      name: 'rawCheckAsync',
+      href: '../rawCheckAsync/',
+    },
+  },
+  expects: {
+    type: 'null',
+  },
+};

--- a/website/src/routes/api/menu.md
+++ b/website/src/routes/api/menu.md
@@ -509,6 +509,7 @@
 - [PromiseIssue](/api/PromiseIssue/)
 - [PromiseSchema](/api/PromiseSchema/)
 - [RawCheckAction](/api/RawCheckAction/)
+- [RawCheckActionAsync](/api/RawCheckActionAsync/)
 - [RawCheckIssue](/api/RawCheckIssue/)
 - [RawTransformAction](/api/RawTransformAction/)
 - [RawTransformIssue](/api/RawTransformIssue/)


### PR DESCRIPTION
This PR adds `rawCheckAsync` and `rawCheckActionAsync` API references. While adding content, something was unclear to me. The question I asked myself was: Should I create a 'type' page (for example, [IntersectOptions](https://valibot.dev/api/IntersectOptions/)) for the `Context` type used by the only parameter of the function passed to this action, or should I inline the type? The `rawCheck` API reference inlined the type definition, and so I did the same. I assume the reason for inlining the type definition for the `rawCheck` API reference was to avoid polluting the 'types' section on the website with local types that are associated with maybe just one action so that we reduce the chances of naming collisions? For example, there is a `Context` type in the `_addIssue.ts` file. If someday we were to create a 'type' page for it along with the `Context` type associated with the `rawCheck` action, it wouldn't be directly possible due to conflicting names. But inlining type definitions might also not be a good idea. If the `Context` type associated to the `rawCheck` and `rawCheckAsync` actions changed, we will have to update the content in both places. Can you clarify when I should create a dedicated 'type' page for a type definition?