### PR TITLE
Update JSON schema tools on ecosystem page

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -59,8 +59,8 @@ Use the button at the bottom left of this page to add your project to this ecosy
 
 ### Valibot to X
 
-- [@gcornut/valibot-json-schema](https://github.com/gcornut/valibot-json-schema): CLI & JS utility to convert Valibot to JSON schema
 - [@valibot/to-json-schema](https://github.com/fabian-hiller/valibot/tree/main/packages/to-json-schema): The official JSON schema converter for Valibot
+- [@gcornut/cli-valibot-to-json-schema](https://github.com/gcornut/cli-valibot-to-json-schema): CLI wrapper for @valibot/to-json-schema
 - [TypeSchema](https://typeschema.com/): Universal adapter for schema validation
 
 ### X to Valibot


### PR DESCRIPTION
I'm deprecating the @gcornut/valibot-json-schema project as we now have an official JSON schema converter.

I moved the CLI interface to another package because I still needed this use case :) 