### PR TITLE
fix(to-json-schema): Error in JSR

### DIFF
--- a/packages/to-json-schema/src/index.ts
+++ b/packages/to-json-schema/src/index.ts
@@ -1,2 +1,2 @@
 export * from './toJsonSchema.ts';
-export { ConversionConfig } from './type.ts';
+export type { ConversionConfig } from './type.ts';


### PR DESCRIPTION
When I imported from `@valibot/to-json-schema` using JSR and Deno, I received an error.

![スクリーンショット 2024-09-28 185110](https://github.com/user-attachments/assets/9e08e888-a62c-42ee-9af2-067d58a16d18)
Code:
```ts
import { toJsonSchema } from '@valibot/to-json-schema'
import { schema } from '../schema/schema.ts'

export const makeSchema = async () => {
  const jsonSchema = toJsonSchema(schema)
  
  await Deno.writeTextFile('schema.json', JSON.stringify(jsonSchema, null, 2))
}

if (import.meta.main) {
  await makeSchema()
}
```
The PR will fixes it.

