### PR TITLE
improve type inference when using findItem with type predicates

### DIFF
--- a/library/src/actions/findItem/findItem.test-d.ts
+++ b/library/src/actions/findItem/findItem.test-d.ts
@@ -1,5 +1,6 @@
 import { describe, expectTypeOf, test } from 'vitest';
 import type { InferInput, InferIssue, InferOutput } from '../../types/index.ts';
+import type { FindItemActionPredicate } from './findItem.ts';
 import { findItem, type FindItemAction } from './findItem.ts';
 
 describe('findItem', () => {
@@ -21,6 +22,23 @@ describe('findItem', () => {
       expectTypeOf<InferOutput<Action>>().toEqualTypeOf<
         string | number | undefined
       >();
+    });
+
+    test('of issue', () => {
+      expectTypeOf<InferIssue<Action>>().toEqualTypeOf<never>();
+    });
+  });
+
+  describe('should infer types when using a type predicate', () => {
+    type Input = (string | number)[];
+    type Action = FindItemActionPredicate<Input, number>;
+
+    test('of input', () => {
+      expectTypeOf<InferInput<Action>>().toEqualTypeOf<Input>();
+    });
+
+    test('of output', () => {
+      expectTypeOf<InferOutput<Action>>().toEqualTypeOf<number | undefined>();
     });
 
     test('of issue', () => {

--- a/library/src/actions/findItem/findItem.ts
+++ b/library/src/actions/findItem/findItem.ts
@@ -1,5 +1,24 @@
 import type { BaseTransformation, SuccessDataset } from '../../types/index.ts';
-import type { ArrayInput, ArrayRequirement } from '../types.ts';
+import type {ArrayInput, ArrayRequirement, ArrayRequirementPredicate} from '../types.ts';
+
+/**
+ * Find item action type when used with type predicate
+ */
+export interface FindItemActionPredicate<TInput extends ArrayInput, TOutput extends TInput[number]>
+    extends BaseTransformation<TInput, TOutput | undefined, never> {
+  /**
+   * The action type.
+   */
+  readonly type: 'find_item';
+  /**
+   * The action reference.
+   */
+  readonly reference: typeof findItem;
+  /**
+   * The find item operation.
+   */
+  readonly operation: ArrayRequirementPredicate<TInput, TOutput>;
+}
 
 /**
  * Find item action type.
@@ -27,6 +46,10 @@ export interface FindItemAction<TInput extends ArrayInput>
  *
  * @returns A find item action.
  */
+export function findItem<TInput extends ArrayInput, TOuput extends TInput[number]>(
+    operation: ArrayRequirementPredicate<TInput, TOuput>
+): FindItemActionPredicate<TInput, TOuput>;
+
 export function findItem<TInput extends ArrayInput>(
   operation: ArrayRequirement<TInput>
 ): FindItemAction<TInput>;

--- a/library/src/actions/types.ts
+++ b/library/src/actions/types.ts
@@ -36,6 +36,15 @@ export type LengthInput = string | ArrayLike<unknown>;
 export type SizeInput = Blob | Map<unknown, unknown> | Set<unknown>;
 
 /**
+ * Array requirement predicate.
+ */
+export type ArrayRequirementPredicate<TInput extends ArrayInput, TOuput extends TInput[number]> = (
+    item: TInput[number],
+    index: number,
+    array: TInput
+) => item is TOuput;
+
+/**
  * Value input type.
  */
 export type ValueInput = string | number | bigint | boolean | Date;


### PR DESCRIPTION
#867 

Not a big fan of duplicating FindItemAction to allow for a type with a predicate, but I didn't want to break retrocompatibility, nor create complex types that would degrade readability or maintenability.