### PR TITLE
docs(website): migrate main concepts away from first-person

### DIFF
--- a/website/src/routes/guides/(advanced)/async-validation/index.mdx
+++ b/website/src/routes/guides/(advanced)/async-validation/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Async validation
 description: >-
-  By default, I validate each schema synchronously. This is usually the fastest
-  way to validate unknown data, but sometimes you need to validate something
-  asynchronously.
+  By default, Valibot validates each schema synchronously. This is usually the
+  fastest way to validate unknown data, but sometimes you need to validate
+  something asynchronously.
 contributors:
   - fabian-hiller
 ---
@@ -12,11 +12,11 @@ import { Link } from '@builder.io/qwik-city';
 
 # Async validation
 
-By default, I validate each schema synchronously. This is usually the fastest way to validate unknown data, but sometimes you need to validate something asynchronously. For example, you might want to check if a username already exists in your database.
+By default, Valibot validates each schema synchronously. This is usually the fastest way to validate unknown data, but sometimes you need to validate something asynchronously. For example, you might want to check if a username already exists in your database.
 
 ## How it works
 
-To be able to do this, I provide an asynchronous implementation when necessary. The only difference is that the asynchronous implementation is promise-based. Otherwise, the API and functionality is exactly the same.
+To be able to do this, Valibot provides an asynchronous implementation when necessary. The only difference is that the asynchronous implementation is promise-based. Otherwise, the API and functionality is exactly the same.
 
 ### Naming
 

--- a/website/src/routes/guides/(advanced)/internationalization/index.mdx
+++ b/website/src/routes/guides/(advanced)/internationalization/index.mdx
@@ -11,11 +11,11 @@ import { Link } from '@builder.io/qwik-city';
 
 # Internationalization
 
-Providing error messages in the native language of your users can improve the user experience and adoption rate of your software. That is why I offer several flexible ways to easily implement i18n.
+Providing error messages in the native language of your users can improve the user experience and adoption rate of your software. That is why we offer several flexible ways to easily implement i18n.
 
 ## Official translations
 
-The fastest way to get started with i18n is to use my official translations. They are provided in a separate package called [`@valibot/i18n`](https://github.com/fabian-hiller/valibot/tree/main/packages/i18n).
+The fastest way to get started with i18n is to use Valibot's official translations. They are provided in a separate package called [`@valibot/i18n`](https://github.com/fabian-hiller/valibot/tree/main/packages/i18n).
 
 > If you are missing a translation, feel free to open an [issue](https://github.com/fabian-hiller/valibot/issues/new) or pull request on GitHub.
 
@@ -56,7 +56,7 @@ v.parse(Schema, input, { lang: 'de' });
 
 ## Custom translations
 
-You can use the same APIs as [`@valibot/i18n`](https://github.com/fabian-hiller/valibot/tree/main/packages/i18n) to add your own translations to my global storage. Alternatively, you can also pass them directly to a specific schema or validation function as the first optional argument.
+You can use the same APIs as [`@valibot/i18n`](https://github.com/fabian-hiller/valibot/tree/main/packages/i18n) to add your own translations to the global storage. Alternatively, you can also pass them directly to a specific schema or validation function as the first optional argument.
 
 > You can either enter the translations manually or use an i18n library like [Paraglide JS](https://inlang.com/m/gerre34r/library-inlang-paraglideJs).
 

--- a/website/src/routes/guides/(advanced)/json-schema/index.mdx
+++ b/website/src/routes/guides/(advanced)/json-schema/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: JSON Schema
 description: >-
-  This guide will show you how to convert my schemas to JSON Schema format.
+  This guide will show you how to convert Valibot schemas to JSON Schema format.
 contributors:
   - fabian-hiller
 ---
@@ -10,7 +10,7 @@ import { Link } from '@builder.io/qwik-city';
 
 # JSON Schema
 
-In favor of a larger feature set and smaller bundle size, I am not implemented with JSON Schema in mind. However, in some use cases, you may still need a JSON Schema. This guide will show you how to convert my schemas to JSON Schema format.
+In favor of a larger feature set and smaller bundle size, Valibot is not implemented with JSON Schema in mind. However, in some use cases, you may still need a JSON Schema. This guide will show you how to convert Valibot schemas to JSON Schema format.
 
 ## Valibot to JSON Schema
 
@@ -28,7 +28,7 @@ const JsonEmailSchema = toJsonSchema(ValibotEmailSchema); // { type: 'string', f
 
 ## Cons of JSON Schema
 
-My schemas intentionally do not output JSON Schema natively. This is because JSON Schema is limited to JSON-compliant data structures. In addition, more advanced features like transformations are not supported. Since I want to leverage the full power of TypeScript, I output a custom format instead.
+Valibot schemas intentionally do not output JSON Schema natively. This is because JSON Schema is limited to JSON-compliant data structures. In addition, more advanced features like transformations are not supported. Since we want to leverage the full power of TypeScript, we output a custom format instead.
 
 Another drawback of JSON Schema is that JSON Schema itself does not contain any validation logic. Therefore, an additional function is required that can validate the entire JSON Schema specification. This approach is usually not tree-shakable and results in a large bundle size.
 

--- a/website/src/routes/guides/(advanced)/naming-convention/index.mdx
+++ b/website/src/routes/guides/(advanced)/naming-convention/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: Naming convention
 description: >-
-  There are two naming conventions that I recommend you to use when working with
-  me. In this guide I will explain both of them.
+  There are two naming conventions that we recommend you to use when working
+  with Valibot. In this guide we will explain both of them.
 contributors:
   - fabian-hiller
   - shairez
@@ -10,7 +10,7 @@ contributors:
 
 # Naming convention
 
-In many cases a schema is created and exported together with the inferred type. There are two naming conventions for this procedure that I recommend you to use when working with me. In this guide I will explain both of them and share why I think they might make sense.
+In many cases a schema is created and exported together with the inferred type. There are two naming conventions for this procedure that we recommend you to use when working with Valibot. In this guide we will explain both of them and share why we think they might make sense.
 
 > You don't have to follow any of these conventions. They are only recommendations.
 

--- a/website/src/routes/guides/(get-started)/comparison/index.mdx
+++ b/website/src/routes/guides/(get-started)/comparison/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comparison
 description: >-
-  Even though my API resembles other solutions at first glance, the
+  Even though Valibot's API resembles other solutions at first glance, the
   implementation and structure of the source code is very different.
 contributors:
   - fabian-hiller
@@ -11,15 +11,15 @@ contributors:
 
 # Comparison
 
-Even though my API resembles other solutions at first glance, the implementation and structure of the source code is very different. In the following, I would like to highlight the differences that can be beneficial for both you and your users.
+Even though Valibot's API resembles other solutions at first glance, the implementation and structure of the source code is very different. In the following, we would like to highlight the differences that can be beneficial for both you and your users.
 
 ## Modular design
 
-Instead of relying on a few large functions with many methods, my API design and source code is based on many small and independent functions, each with just a single task. This modular design has several advantages.
+Instead of relying on a few large functions with many methods, Valibot's API design and source code is based on many small and independent functions, each with just a single task. This modular design has several advantages.
 
-On one hand, my functionality can be easily extended with external code. On the other, it makes my source code more robust and secure because the functionality of the individual functions as well as special edge cases can be tested much easier through unit tests.
+On one hand, the functionality of Valibot can be easily extended with external code. On the other, it makes the source code more robust and secure because the functionality of the individual functions as well as special edge cases can be tested much easier through unit tests.
 
-However, perhaps the biggest advantage is that a bundler can use the import statements to remove any code that is not needed. Thus, only the code that is actually used ends up in the production build. This allows me to extend my functionality with additional functions without increasing the bundle size for all users.
+However, perhaps the biggest advantage is that a bundler can use the static import statements to remove any code that is not needed. Thus, only the code that is actually used ends up in the production build. This allows us to extend the functionality of the library with additional functions without increasing the bundle size for all users.
 
 This can make a big difference, especially for client-side validation, as it reduces the bundle size and, depending on the framework, speeds up the startup time.
 
@@ -43,7 +43,7 @@ const LoginSchema = v.object({
 
 ### Comparison with Zod
 
-For example, to validate a simple login form, [Zod](https://zod.dev/) requires [12.9 kB](https://bundlejs.com/?q=zod&treeshake=%5B%7B+object%2Cstring+%7D%5D) whereas I require only [1.19 kB](https://bundlejs.com/?q=valibot&treeshake=%5B%7B+email%2CminLength%2Cobject%2Cstring%2Cpipe+%7D%5D). That's a 92 % reduction in bundle size. This is due to the fact that Zod's functions have several methods with additional functionalities, that cannot be easily removed by current bundlers when they are not executed in your source code.
+For example, to validate a simple login form, [Zod](https://zod.dev/) requires [12.9 kB](https://bundlejs.com/?q=zod&treeshake=%5B%7B+object%2Cstring+%7D%5D) whereas Valibot require only [1.19 kB](https://bundlejs.com/?q=valibot&treeshake=%5B%7B+email%2CminLength%2CnonEmpty%2Cobject%2Cstring%2Cpipe+%7D%5D). That's a 92 % reduction in bundle size. This is due to the fact that Zod's functions have several methods with additional functionalities, that cannot be easily removed by current bundlers when they are not executed in your source code.
 
 {/* prettier-ignore */}
 ```ts
@@ -63,6 +63,6 @@ const LoginSchema = object({
 
 With a schema library, a distinction must be made between startup performance and runtime performance. Startup performance describes the time required to load and initialize the library. This benchmark is mainly influenced by the bundle size and the amount of work required to create a schema. Runtime performance describes the time required to validate unknown data using a schema.
 
-Since my implementation is optimized to minimize the bundle size and the effort of initialization, there is hardly a library that performs better in a [TTI](https://web.dev/articles/tti) benchmark than I do. In terms of runtime performance, I am in the midfield. Roughly speaking, I am about twice as fast as [Zod](https://zod.dev/), but much slower than [Typia](https://typia.io/) and [TypeBox](https://github.com/sinclairzx81/typebox), because I don't yet use a compiler that can generate optimal code, and my implementation doesn't allow the use of the [`Function`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/Function) constructor.
+Since Valibot's implementation is optimized to minimize the bundle size and the effort of initialization, there is hardly any library that performs better in a [TTI](https://web.dev/articles/tti) benchmark. In terms of runtime performance, Valibot is in the midfield. Roughly speaking, the library is about twice as fast as [Zod](https://zod.dev/), but much slower than [Typia](https://typia.io/) and [TypeBox](https://github.com/sinclairzx81/typebox), because we don't yet use a compiler that can generate highly optimized runtime code, and my implementation doesn't allow the use of the [`Function`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/Function) constructor.
 
-> Further details on performance can be found in the [bachelor's thesis](/thesis.pdf) I am based on.
+> Further details on performance can be found in the [bachelor's thesis](/thesis.pdf) Valibot is based on.

--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: Ecosystem
 description: >-
-  This page is for you if you are a frameworks or library author and want to
-  integrate me or if you are looking for projects that support Valibot.
+  This page is for you if you are looking for frameworks or libraries that
+  support Valibot.
 contributors:
   - fabian-hiller
   - Saeris
@@ -23,17 +23,15 @@ contributors:
 
 # Ecosystem
 
-This page is for you if you are a frameworks or library author and want to integrate me or if you are looking for projects that support Valibot.
+This page is for you if you are looking for frameworks or libraries that support Valibot.
 
-## Categories
+> Use the button at the bottom left of this page to add your project to this ecosystem page. Please make sure to add your project to an appropriate existing category in alphabetical order or create a new category if necessary.
 
-Use the button at the bottom left of this page to add your project to this ecosystem page. Please make sure to add your project to an appropriate existing category in alphabetical order or create a new category if necessary.
-
-### Frameworks
+## Frameworks
 
 - [NestJS](https://docs.nestjs.com): A progressive Node.js framework for building efficient, reliable and scalable server-side applications
 
-### API libraries
+## API libraries
 
 - [Drizzle ORM](https://orm.drizzle.team/): TypeScript ORM that feels like writing SQL
 - [GQLoom](https://gqloom.dev/): Weave GraphQL schema and resolvers using Valibot
@@ -41,7 +39,7 @@ Use the button at the bottom left of this page to add your project to this ecosy
 - [next-safe-action](https://next-safe-action.dev) Type safe and validated Server Actions for Next.js
 - [tRPC](https://trpc.io/): Move Fast and Break Nothing. End-to-end typesafe APIs made easy
 
-### Form libraries
+## Form libraries
 
 - [@rvf/valibot](https://github.com/airjp73/rvf/tree/main/packages/valibot): Valibot schema parser for [RVF](https://rvf-js.io/)
 - [conform-to-valibot](https://github.com/chimame/conform-to-valibot): Valibot schema parser for [conform](https://conform.guide/)
@@ -54,21 +52,21 @@ Use the button at the bottom left of this page to add your project to this ecosy
 - [VeeValidate](https://vee-validate.logaretm.com/v4/): Painless Vue.js forms
 - [vue-valibot-form](https://github.com/IlyaSemenov/vue-valibot-form): Minimalistic Vue3 composable for handling form submit
 
-### Component libraries
+## Component libraries
 
 - [Nuxt UI](https://ui.nuxt.com/): Fully styled and customizable components for Nuxt
 
-### Valibot to X
+## Valibot to X
 
 - [@valibot/to-json-schema](https://github.com/fabian-hiller/valibot/tree/main/packages/to-json-schema): The official JSON schema converter for Valibot
 - [@gcornut/cli-valibot-to-json-schema](https://github.com/gcornut/cli-valibot-to-json-schema): CLI wrapper for @valibot/to-json-schema
 - [TypeSchema](https://typeschema.com/): Universal adapter for schema validation
 
-### X to Valibot
+## X to Valibot
 
 - [TypeBox-Codegen](https://sinclairzx81.github.io/typebox-workbench/): Code generation for schema libraries
 
-### Utilities
+## Utilities
 
 - [@nest-lab/typeschema](https://github.com/jmcdo29/nest-lab/tree/main/packages/typeschema): A ValidationPipe that handles many schema validators in a class-based fashion for NestJS's input validation
 - [@valibot/i18n](https://github.com/fabian-hiller/valibot/tree/main/packages/i18n): The official i18n translations for Valibot

--- a/website/src/routes/guides/(get-started)/installation/index.mdx
+++ b/website/src/routes/guides/(get-started)/installation/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: Installation
 description: >-
-  I am currently available for Node, Bun and Deno. Below I will show you how to
-  add me to your project.
+  Valibot is currently available for Node, Bun and Deno. Below you will learn
+  how to add the library to your project.
 contributors:
   - fabian-hiller
   - Shyam-Chen
@@ -10,7 +10,7 @@ contributors:
 
 # Installation
 
-I am currently available for Node, Bun and Deno. Below I will show you how to add me to your project.
+Valibot is currently available for Node, Bun and Deno. Below you will learn how to add the library to your project.
 
 ## General
 
@@ -18,7 +18,7 @@ Except for this guide, the rest of this documentation assumes that you are using
 
 It should make no difference whether you use individual imports or a wildcard import. Tree shaking and code splitting should work in both cases.
 
-If you are using TypeScript, I recommend that you enable strict mode in your `tsconfig.json` so that all types are calculated correctly.
+If you are using TypeScript, we recommend that you enable strict mode in your `tsconfig.json` so that all types are calculated correctly.
 
 > The minimum required TypeScript version is v5.0.2.
 
@@ -33,7 +33,7 @@ If you are using TypeScript, I recommend that you enable strict mode in your `ts
 
 ## From npm
 
-For Node and Bun, you can add me to your project with a single command via your favorite package manager.
+For Node and Bun, you can add the library to your project with a single command using your favorite package manager.
 
 ```bash
 npm install valibot     # npm
@@ -42,7 +42,7 @@ pnpm add valibot        # pnpm
 bun add valibot         # bun
 ```
 
-After that you can import me into any JavaScript or TypeScript file.
+Then you can import it into any JavaScript or TypeScript file.
 
 ```ts
 // With individual imports
@@ -54,7 +54,7 @@ import * as v from 'valibot';
 
 ## From JSR
 
-For Node, Deno and Bun, you can add me to your project with a single command via your favorite package manager.
+For Node, Deno and Bun, you can add the library to your project with a single command using your favorite package manager.
 
 ```bash
 deno add jsr:@valibot/valibot      # deno
@@ -64,7 +64,7 @@ pnpm dlx jsr add @valibot/valibot  # pnpm
 bunx jsr add @valibot/valibot      # bun
 ```
 
-After that you can import me into any JavaScript or TypeScript file.
+Then you can import it into any JavaScript or TypeScript file.
 
 ```ts
 // With individual imports
@@ -86,7 +86,7 @@ import * as v from 'jsr:@valibot/valibot';
 
 ## From Deno
 
-With Deno, you can reference me directly through my deno.land/x URL.
+With Deno, you can reference the library directly through our deno.land/x URL.
 
 ```ts
 // With individual imports

--- a/website/src/routes/guides/(get-started)/quick-start/index.mdx
+++ b/website/src/routes/guides/(get-started)/quick-start/index.mdx
@@ -13,7 +13,7 @@ import { ApiList } from '~/components';
 
 # Quick start
 
-A Valibot schema can be compared to a type definition in TypeScript. The big difference is that TypeScript types are "not executed" and are more or less a DX feature. A schema on the other hand—apart from the inferred type definition—can also be executed at runtime to truly guarantee type safety of unknown data.
+A Valibot schema can be compared to a type definition in TypeScript. The big difference is that TypeScript types are "not executed" and are more or less a DX feature. A schema on the other hand, apart from the inferred type definition, can also be executed at runtime to truly guarantee type safety of unknown data.
 
 > Until Valibot reaches v1, feedback on the API, naming, and implementation is very welcome and much appreciated. Please create or reply to an [issue](https://github.com/fabian-hiller/valibot/issues) and help Valibot be the best schema library for JavaScript and TypeScript.
 

--- a/website/src/routes/guides/(get-started)/use-cases/index.mdx
+++ b/website/src/routes/guides/(get-started)/use-cases/index.mdx
@@ -10,24 +10,24 @@ contributors:
 
 # Use cases
 
-Next, I would like to point out some use cases for which I am particularly well suited. I welcome [ideas](https://github.com/fabian-hiller/valibot/issues/new) for other use cases that I may not have thought of yet.
+Next, we would like to point out some use cases for which Valibot is particularly well suited. We welcome [ideas](https://github.com/fabian-hiller/valibot/issues/new) for other use cases that we may not have thought of yet.
 
 ## Server requests
 
 Since most API endpoints can be reached via the Internet, basically anyone can send a request and transmit data. It is therefore important to apply zero trust security and to check request data thoroughly before processing it further.
 
-This works particularly well with a schema, compared to if/else conditions, as even complex structures can be easily mapped. In addition, I automatically type the parsed data according to the schema, which improves type safety and thus makes your code more secure.
+This works particularly well with a schema, compared to if/else conditions, as even complex structures can be easily mapped. In addition, the library automatically type the parsed data according to the schema, which improves type safety and thus makes your code more secure.
 
 ## Form validation
 
-A schema can also be used for form validation. Due to my small bundle size and the possibility to individualize the error messages, I am particularly well suited for this. Also, fullstack frameworks like Next.js, Remix, and Nuxt allow the same schema to be used for validation in the browser as well as on the server, which reduces your code to the minimum.
+A schema can also be used for form validation. Due to Valibot's small bundle size and the possibility to individualize the error messages, the library is particularly well suited for this. Also, fullstack frameworks like Next.js, Remix, and Nuxt allow the same schema to be used for validation in the browser as well as on the server, which reduces your code to the minimum.
 
 [Modular Forms](https://modularforms.dev/react/guides/validate-your-fields#schema-validation), for example, offers validation based on a schema at form and field level. In addition, the form can be made type-safe using the schema, which also enables autocompletion during development. In combination with the right framework, a fully type-safe and progressively enhanced form can be created with few lines of code and a great experience for developers and end-users.
 
 ## Browser state
 
-The browser state, which is stored using cookies, search parameters or the local storage, can be accidentally or intentionally manipulated by the user. To ensure the functionality of an application, it can help to validate this data before processing. My schemas can be used for this, which also improves type safety.
+The browser state, which is stored using cookies, search parameters or the local storage, can be accidentally or intentionally manipulated by the user. To ensure the functionality of an application, it can help to validate this data before processing. Valibot can be used for this, which also improves type safety.
 
 ## Config files
 
-Library authors can also make use of me, for example, to match configuration files with a schema and, in the event of an error, provide clear indications of the cause and how to fix the problem. The same applies to environment variables to quickly detect configuration errors.
+Library authors can also make use of Valibot, for example, to match configuration files with a schema and, in the event of an error, provide clear indications of the cause and how to fix the problem. The same applies to environment variables to quickly detect configuration errors.

--- a/website/src/routes/guides/(main-concepts)/infer-types/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/infer-types/index.mdx
@@ -6,6 +6,7 @@ description: >-
 contributors:
   - fabian-hiller
   - gmaxlev
+  - BastiDood
 ---
 
 import { Link } from '@builder.io/qwik-city';

--- a/website/src/routes/guides/(main-concepts)/infer-types/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/infer-types/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: Infer types
 description: >-
-  Another cool feature that my schemas allow you to do is to infer the input and
-  output type. This makes your work even easier.
+  Another cool feature of schemas is the ability to infer input and
+  output types. This makes your work even easier.
 contributors:
   - fabian-hiller
   - gmaxlev
@@ -13,13 +13,13 @@ import { Link } from '@builder.io/qwik-city';
 
 # Infer types
 
-Another cool feature that my schemas allow you to do is to infer the input and output type. This makes your work even easier, because you don't have to create the type definition additionally.
+Another cool feature of schemas is the ability to infer input and output types. This makes your work even easier because you don't have to write the type definition yourself.
 
 ## Infer input types
 
 The input type of a schema corresponds to the TypeScript type that the incoming data of a schema must match to be valid. To extract this type you use the utility type <Link href="/api/InferInput/">`InferInput`</Link>.
 
-> You are probably interested in input type only in special cases. I recommend you to use the output type in most cases.
+> You are probably interested in the input type only in special cases. In most cases, the output type should be sufficient.
 
 ```ts
 import * as v from 'valibot';

--- a/website/src/routes/guides/(main-concepts)/infer-types/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/infer-types/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: Infer types
 description: >-
-  Another cool feature of schemas is the ability to infer input and
-  output types. This makes your work even easier.
+  Another cool feature of schemas is the ability to infer input and output
+  types. This makes your work even easier.
 contributors:
   - fabian-hiller
   - gmaxlev

--- a/website/src/routes/guides/(main-concepts)/issues/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/issues/index.mdx
@@ -16,7 +16,7 @@ When validating unknown data against a schema, Valibot collects information abou
 
 ## Issue info
 
-A single issue conforms to the schema below.
+A single issue conforms to the TypeScript type definition below.
 
 ```ts
 type BaseIssue = {
@@ -45,7 +45,7 @@ Each issue contains the following required information.
 
 #### Kind
 
-`kind` describes the kind of the problem. If an input does not match the data type—for example a number was passed instead of a string—`kind` has the value `'schema'`. In all other cases, the reason is not the data type but the actual content of the data. For example, if a string is invalid because it does not match a regex, `kind` has the value `'validation'`.
+`kind` describes the kind of the problem. If an input does not match the data type, for example a number was passed instead of a string, `kind` has the value `'schema'`. In all other cases, the reason is not the data type but the actual content of the data. For example, if a string is invalid because it does not match a regex, `kind` has the value `'validation'`.
 
 #### Type
 
@@ -65,7 +65,7 @@ Each issue contains the following required information.
 
 #### Message
 
-`message` contains a human-understandable error message that can be fully customized as described in our <Link href="/guides/schemas/#error-messages">schemas</Link> and <Link href="/guides/internationalization/">internationalization</Link> guide.
+`message` contains a human-understandable error message that can be fully customized as described in our <Link href="/guides/quick-start/#error-messages">quick start</Link> and <Link href="/guides/internationalization/">internationalization</Link> guide.
 
 ### Optional info
 
@@ -92,7 +92,9 @@ type PathItem = {
 For example, you can use the following code to create a dot path.
 
 ```ts
-const dotPath = issue.path.map((item) => item.key).join('.');
+import * as v from 'valibot';
+
+const dotPath = v.getDotPath(issue);
 ```
 
 #### Issues
@@ -101,7 +103,7 @@ const dotPath = issue.path.map((item) => item.key).join('.');
 
 #### Config
 
-`lang` can be used as part of our <Link href="/guides/internationalization/">i18n feature</Link> to define the required language. `abortEarly` and `abortPipeEarly` gives you an info that the validation was aborted prematurely. You can find more info about this in the <Link href="/guides/parse-data/#abort-early">parse data</Link> guide. `skipPipe` indicates that the pipeline validation was skipped. These are all configurations that you can control yourself.
+`lang` can be used as part of our <Link href="/guides/internationalization/">i18n feature</Link> to define the required language. `abortEarly` and `abortPipeEarly` gives you an info that the validation was aborted prematurely. You can find more info about this in the <Link href="/guides/parse-data/#configuration">parse data</Link> guide. These are all configurations that you can control yourself.
 
 ## Formatting
 

--- a/website/src/routes/guides/(main-concepts)/issues/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/issues/index.mdx
@@ -5,6 +5,7 @@ description: >-
   about each issue.
 contributors:
   - fabian-hiller
+  - BastiDood
 ---
 
 import { Link } from '@builder.io/qwik-city';

--- a/website/src/routes/guides/(main-concepts)/issues/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/issues/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Issues
 description: >-
-  When validating unknown data against a schema, I collect detailed information
+  When validating unknown data against a schema, Valibot collects detailed information
   about each issue.
 contributors:
   - fabian-hiller
@@ -12,11 +12,11 @@ import { Link } from '@builder.io/qwik-city';
 
 # Issues
 
-When validating unknown data against a schema, I collect information about each issue and at the end, if there is at least one issue, I return them in an array. Each issue provides detailed information for you or your users to fix the problem.
+When validating unknown data against a schema, Valibot collects information about each issue. If there is at least one issue, these are returned in an array. Each issue provides detailed information for you or your users to fix the problem.
 
 ## Issue info
 
-The issues are an array of objects. In the following I will explain you exactly what information an issue contains and how this information can help you.
+A single issue conforms to the schema below.
 
 ```ts
 type BaseIssue = {
@@ -45,7 +45,7 @@ Each issue contains the following required information.
 
 #### Kind
 
-`kind` describes the kind of the problem. If an input does not match the data type, for example a number was passed instead of a string, `kind` has the value `'schema'`. In all other cases the reason is not the datatype but the actual content of the data. For example, if a string is invalid because it does not match a regex, `kind` has the value `'validation'`.
+`kind` describes the kind of the problem. If an input does not match the data type—for example a number was passed instead of a string—`kind` has the value `'schema'`. In all other cases, the reason is not the data type but the actual content of the data. For example, if a string is invalid because it does not match a regex, `kind` has the value `'validation'`.
 
 #### Type
 
@@ -105,7 +105,7 @@ const dotPath = issue.path.map((item) => item.key).join('.');
 
 ## Formatting
 
-For common use cases like forms, I can help you with small functions to format issues. However, once you understand how they work, you can easily format them yourself and put them in the right form for your use case.
+For common use cases such as form validation, Valibot includes small built-in functions for formatting issues. However, once you understand how they work, you can easily format them yourself and put them in the right form for your use case.
 
 ### Flatten errors
 

--- a/website/src/routes/guides/(main-concepts)/mental-model/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/mental-model/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mental model
 description: >-
-  My mental model is mainly divided between schemas, methods, and actions. It is
+  The mental model is mainly divided between schemas, methods, and actions. It is
   crucial to understand this concept.
 contributors:
   - fabian-hiller
@@ -14,7 +14,7 @@ import MentalModelLight from './mental-model-light.jpg?jsx';
 
 # Mental model
 
-My mental model is mainly divided between **schemas**, **methods**, and **actions**. Since each functionality is imported as its own function, it is crucial to understand this concept as it makes working with my modular API design much easier.
+The mental model is mainly divided between **schemas**, **methods**, and **actions**. Since each functionality is imported as its own function, it is crucial to understand this concept as it makes working with the modular API design much easier.
 
 <MentalModelDark
   alt="Code example with a schema, method and actions"
@@ -25,11 +25,11 @@ My mental model is mainly divided between **schemas**, **methods**, and **action
   class="dark:hidden"
 />
 
-> My <Link href="/api/">API reference</Link> gives you a great overview of all schemas, methods and actions, and at the end of a specific API reference we list all related schemas, methods and actions that can be combined with it.
+> The <Link href="/api/">API reference</Link> gives you a great overview of all schemas, methods, and actions. For each one, the corresponding reference page also lists down other related schemas, methods, and actions for better discoverability.
 
 ## Schemas
 
-Schemas are the starting point for using Valibot. They allow you to validate **a specific data type**, like a string, object or date. Each schema is independent. They can be reused or even nested to reflect more complex data structures.
+Schemas are the starting point for using Valibot. They allow you to validate **a specific data type**, like a string, object, or date. Each schema is independent. They can be reused or even nested to reflect more complex data structures.
 
 ```ts
 import * as v from 'valibot';

--- a/website/src/routes/guides/(main-concepts)/mental-model/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/mental-model/index.mdx
@@ -5,6 +5,7 @@ description: >-
   crucial to understand this concept.
 contributors:
   - fabian-hiller
+  - BastiDood
 ---
 
 import { Link } from '@builder.io/qwik-city';

--- a/website/src/routes/guides/(main-concepts)/mental-model/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/mental-model/index.mdx
@@ -1,8 +1,8 @@
 ---
 title: Mental model
 description: >-
-  The mental model is mainly divided between schemas, methods, and actions. It is
-  crucial to understand this concept.
+  Valibot's mental model is mainly divided between schemas, methods, and
+  actions. It is crucial to understand this concept.
 contributors:
   - fabian-hiller
   - BastiDood
@@ -14,7 +14,7 @@ import MentalModelLight from './mental-model-light.jpg?jsx';
 
 # Mental model
 
-The mental model is mainly divided between **schemas**, **methods**, and **actions**. Since each functionality is imported as its own function, it is crucial to understand this concept as it makes working with the modular API design much easier.
+Valibot's mental model is mainly divided between **schemas**, **methods**, and **actions**. Since each functionality is imported as its own function, it is crucial to understand this concept as it makes working with the modular API design much easier.
 
 <MentalModelDark
   alt="Code example with a schema, method and actions"

--- a/website/src/routes/guides/(main-concepts)/methods/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/methods/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Methods
 description: >-
-  Apart from `parse`, `safeParse` and `is`, I offer some more methods to make
+  Apart from `parse`, `safeParse`, and `is`, Valibot offers some more methods to make
   working with your schemas easier.
 contributors:
   - fabian-hiller
@@ -16,11 +16,11 @@ import { ApiList } from '~/components';
 
 # Methods
 
-Apart from <Link href="/api/parse/">`parse`</Link>, <Link href="/api/safeParse/">`safeParse`</Link> and <Link href="/api/is/">`is`</Link>, I offer some more methods to make working with your schemas easier. In the following I distinguish between schema, object and pipeline methods.
+Apart from <Link href="/api/parse/">`parse`</Link>, <Link href="/api/safeParse/">`safeParse`</Link>, and <Link href="/api/is/">`is`</Link>, Valibot offers some more methods to make working with your schemas easier: schema, object, and pipeline methods.
 
 ## Schema methods
 
-My schema methods either add additional functionality, simplify the handling or help you to use a schema, for example for validation or to extract specific information.
+Schema methods add functionality, simplify ergonomics, and help you use schemas for validation and data extraction.
 
 <ApiList
   label="Schema methods"
@@ -41,7 +41,7 @@ My schema methods either add additional functionality, simplify the handling or 
   ]}
 />
 
-> For more information on <Link href="/api/pipe/">`pipe`</Link>, see the <Link href="/guides/pipelines/">pipelines</Link> guide, for more information on validation methods, see the <Link href="/guides/parse-data/">parse data</Link> guide and for more information on <Link href="/api/flatten/">`flatten`</Link>, see the <Link href="/guides/issues/#formatting">issues</Link> guide.
+> For more information on <Link href="/api/pipe/">`pipe`</Link>, see the <Link href="/guides/pipelines/">pipelines</Link> guide. For more information on validation methods, see the <Link href="/guides/parse-data/">parse data</Link> guide. For more information on <Link href="/api/flatten/">`flatten`</Link>, see the <Link href="/guides/issues/#formatting">issues</Link> guide.
 
 ### Fallback
 
@@ -56,7 +56,7 @@ const stringOutput = v.parse(StringSchema, 123); // 'hello'
 
 ## Object methods
 
-My object methods make it easier for you to work with object schemas. They are strongly oriented towards the functionality of TypeScript.
+Object methods make it easier for you to work with object schemas. They are strongly oriented towards the functionality of TypeScript.
 
 <ApiList
   label="Object methods"
@@ -65,7 +65,7 @@ My object methods make it easier for you to work with object schemas. They are s
 
 ### TypeScript similarities
 
-I offer almost the same options as TypeScript. For example, you can make the values of an object optional with <Link href="/api/partial/">`partial`</Link> or make them required with <Link href="/api/required/">`required`</Link> and with <Link href="/api/pick/">`pick`</Link> or <Link href="/api/omit/">`omit`</Link>, you can include or exclude certain values of an existing schema.
+Like in TypeScript, you can make the values of an object optional with <Link href="/api/partial/">`partial`</Link>; make them required with <Link href="/api/required/">`required`</Link>; and even include/exclude certain values from an existing schema with <Link href="/api/pick/">`pick`</Link> and <Link href="/api/omit/">`omit`</Link>.
 
 ```ts
 import * as v from 'valibot';
@@ -85,7 +85,7 @@ const object2 = v.pick(object1, ['key1']);
 
 ## Pipeline methods
 
-My pipeline methods help you to modify the results of validations and transformations within a pipeline.
+Pipeline methods modify the results of validations and transformations within a pipeline.
 
 <ApiList label="Pipeline methods" items={['forward']} />
 
@@ -93,7 +93,11 @@ My pipeline methods help you to modify the results of validations and transforma
 
 ### Forward
 
-‎<Link href="/api/forward/">`forward`</Link> allows you to associate an issue with a nested schema. For example, if you want to check that both password entries in a registration form match, you can use it to forward the issue to the second password field in case of an error. This allows you to display the error message in the correct place.
+<Link href="/api/forward/">`forward`</Link> allows you to associate an issue
+with a nested schema. For example, if you want to check that both password
+entries in a registration form match, you can use it to forward the issue to the
+second password field in case of an error. This allows you to display the error
+message in the correct place.
 
 ```ts
 import * as v from 'valibot';

--- a/website/src/routes/guides/(main-concepts)/methods/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/methods/index.mdx
@@ -16,7 +16,7 @@ import { ApiList } from '~/components';
 
 # Methods
 
-Apart from <Link href="/api/parse/">`parse`</Link>, <Link href="/api/safeParse/">`safeParse`</Link>, and <Link href="/api/is/">`is`</Link>, Valibot offers some more methods to make working with your schemas easier: schema, object, and pipeline methods.
+Apart from <Link href="/api/parse/">`parse`</Link> and <Link href="/api/safeParse/">`safeParse`</Link>, Valibot offers some more methods to make working with your schemas easier. In the following we distinguish between schema, object and pipeline methods.
 
 ## Schema methods
 
@@ -56,7 +56,7 @@ const stringOutput = v.parse(StringSchema, 123); // 'hello'
 
 ## Object methods
 
-Object methods make it easier for you to work with object schemas. They are strongly oriented towards the functionality of TypeScript.
+Object methods make it easier for you to work with object schemas. They are strongly oriented towards TypeScript's utility types.
 
 <ApiList
   label="Object methods"
@@ -65,7 +65,7 @@ Object methods make it easier for you to work with object schemas. They are stro
 
 ### TypeScript similarities
 
-Like in TypeScript, you can make the values of an object optional with <Link href="/api/partial/">`partial`</Link>; make them required with <Link href="/api/required/">`required`</Link>; and even include/exclude certain values from an existing schema with <Link href="/api/pick/">`pick`</Link> and <Link href="/api/omit/">`omit`</Link>.
+Like in TypeScript, you can make the values of an object optional with <Link href="/api/partial/">`partial`</Link>, make them required with <Link href="/api/required/">`required`</Link>, and even include/exclude certain values from an existing schema with <Link href="/api/pick/">`pick`</Link> and <Link href="/api/omit/">`omit`</Link>.
 
 ```ts
 import * as v from 'valibot';
@@ -93,11 +93,7 @@ Pipeline methods modify the results of validations and transformations within a 
 
 ### Forward
 
-<Link href="/api/forward/">`forward`</Link> allows you to associate an issue
-with a nested schema. For example, if you want to check that both password
-entries in a registration form match, you can use it to forward the issue to the
-second password field in case of an error. This allows you to display the error
-message in the correct place.
+‎<Link href="/api/forward/">`forward`</Link> allows you to associate an issue with a nested schema. For example, if you want to check that both password entries in a registration form match, you can use it to forward the issue to the second password field in case of an error. This allows you to display the error message in the correct place.
 
 ```ts
 import * as v from 'valibot';

--- a/website/src/routes/guides/(main-concepts)/methods/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/methods/index.mdx
@@ -8,6 +8,7 @@ contributors:
   - estubmo
   - FlorianDevPhynix
   - Yovach
+  - BastiDood
 ---
 
 import { Link } from '@builder.io/qwik-city';

--- a/website/src/routes/guides/(main-concepts)/parse-data/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/parse-data/index.mdx
@@ -13,13 +13,13 @@ import { Link } from '@builder.io/qwik-city';
 
 # Parse data
 
-Now that you've learned how to create a schema, let's look at how you can use it to validate unknown data and make it type-safe. I offer 3 different ways for this. Just pick what you think fits your code best.
+Now that you've learned how to create a schema, let's look at how you can use it to validate unknown data and make it type-safe. There are three different ways to do this.
 
 > Each schema has a `~validate` method. However, this is an internal API and should only be used if you know what you are doing.
 
 ## Default way
 
-The <Link href="/api/parse/">`parse`</Link> method will throw a <Link href="/api/ValiError/">`ValiError`</Link> if the input does not match the schema. Therefore you should use a try/catch block to catch errors. If the input matches the schema, it is valid and the output of the schema will be returned typed.
+The <Link href="/api/parse/">`parse`</Link> method will throw a <Link href="/api/ValiError/">`ValiError`</Link> if the input does not match the schema. Therefore, you should use a `try`/`catch` block to catch errors. If the input matches the schema, it is valid and the output of the schema will be returned as the correct TypeScript type.
 
 ```ts
 import * as v from 'valibot';
@@ -38,7 +38,7 @@ try {
 
 If you want issues to be returned instead of thrown, you can use <Link href="/api/safeParse/">`safeParse`</Link>. The returned value then contains the `.success` property, which is `true` if the input is valid or `false` otherwise.
 
-If the input is valid, you can use `.output` to get the output of the schema validation. On the other hand, if the input was invalid, the issues found can be accessed via `.issues`.
+If the input is valid, you can use `.output` to get the output of the schema validation. Otherwise, if the input was invalid, the issues found can be accessed via `.issues`.
 
 ```ts
 import * as v from 'valibot';
@@ -72,11 +72,11 @@ if (v.is(EmailSchema, data)) {
 
 ## Configuration
 
-By default, I collect each issue during validation to give you detailed feedback on why the input does not match the schema. If this is not required in your use case, you can control this behavior with `abortEarly` and `abortPipeEarly` to improve the performance of validation.
+By default, Valibot exhaustively collects every issue during validation to give you detailed feedback on why the input does not match the schema. If this is not required for your use case, you can control this behavior with `abortEarly` and `abortPipeEarly` to improve the performance of validation.
 
 ### Abort validation
 
-If you set `abortEarly` to `true` I immediately abort the validation after finding the first issue. If you just want to know if data matches a schema, but you don't care about the details, this can speed up the performance.
+If you set `abortEarly` to `true`, data validation immediately aborts upon finding the first issue. If you just want to know if some data matches a schema, but you don't care about the details, this can improve performance.
 
 ```ts
 import * as v from 'valibot';
@@ -100,7 +100,7 @@ try {
 
 ### Abort pipeline
 
-If you only set `abortPipeEarly` to `true` I only abort the validation within a pipeline, after finding the first issue. For example, if you want to show only the first error of a field when validating a form, you can use this option to speed up the performance of validation.
+If you only set `abortPipeEarly` to `true`, validation can only abort within a pipeline after finding the first issue. For example, if you want to show only the first error of a field when validating a form, you can use this option to improve validation performance.
 
 ```ts
 import * as v from 'valibot';

--- a/website/src/routes/guides/(main-concepts)/parse-data/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/parse-data/index.mdx
@@ -19,7 +19,7 @@ Now that you've learned how to create a schema, let's look at how you can use it
 
 ## Default way
 
-The <Link href="/api/parse/">`parse`</Link> method will throw a <Link href="/api/ValiError/">`ValiError`</Link> if the input does not match the schema. Therefore, you should use a `try`/`catch` block to catch errors. If the input matches the schema, it is valid and the output of the schema will be returned as the correct TypeScript type.
+The <Link href="/api/parse/">`parse`</Link> method will throw a <Link href="/api/ValiError/">`ValiError`</Link> if the input does not match the schema. Therefore, you should use a try/catch block to catch errors. If the input matches the schema, it is valid and the output of the schema will be returned with the correct TypeScript type.
 
 ```ts
 import * as v from 'valibot';
@@ -100,7 +100,7 @@ try {
 
 ### Abort pipeline
 
-If you only set `abortPipeEarly` to `true`, validation can only abort within a pipeline after finding the first issue. For example, if you want to show only the first error of a field when validating a form, you can use this option to improve validation performance.
+If you only set `abortPipeEarly` to `true`, the validation within a pipeline will only abort after finding the first issue. For example, if you only want to show the first error of a field when validating a form, you can use this option to improve performance.
 
 ```ts
 import * as v from 'valibot';

--- a/website/src/routes/guides/(main-concepts)/parse-data/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/parse-data/index.mdx
@@ -6,6 +6,7 @@ description: >-
 contributors:
   - fabian-hiller
   - cmaciasjimenez
+  - BastiDood
 ---
 
 import { Link } from '@builder.io/qwik-city';

--- a/website/src/routes/guides/(main-concepts)/pipelines/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/pipelines/index.mdx
@@ -42,7 +42,7 @@ const EmailSchema = v.pipe(
 
 Pipeline validation actions examine the input and, if the input does not meet a certain condition, return an issue. If the input is valid, it is returned as the output and, if present, picked up by the next action in the pipeline.
 
-> Whenever possible, pipelines are run completely—even if an issue has occurred—to collect all possible issues. If exiting upon encountering the first issue is desired (perhaps for performance reasons), you may set the `abortPipeEarly` option to `true`. Learn more about this <Link href="/guides/parse-data/#configuration">here</Link>.
+> Whenever possible, pipelines are run completely, even if an issue has occurred, to collect all possible issues. If you want to abort the pipeline early after the first issue, you need to set the `abortPipeEarly` option to `true`. Learn more about this <Link href="/guides/parse-data/#configuration">here</Link>.
 
 <ApiList
   label="Validation actions"

--- a/website/src/routes/guides/(main-concepts)/pipelines/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/pipelines/index.mdx
@@ -9,6 +9,7 @@ contributors:
   - ariskemper
   - morinokami
   - daxeh
+  - BastiDood
 ---
 
 import { Link } from '@builder.io/qwik-city';

--- a/website/src/routes/guides/(main-concepts)/pipelines/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/pipelines/index.mdx
@@ -17,7 +17,7 @@ import { ApiList } from '~/components';
 
 # Pipelines
 
-For detailed validations and transformations, a schema can be wrapped in a pipeline. Especially for schema functions like <Link href="/api/string/">`string`</Link>, <Link href="/api/number/">`number`</Link>, <Link href="/api/date/">`date`</Link>, <Link href="/api/object/">`object`</Link> and <Link href="/api/array/">`array`</Link> this feature is useful to validate further details apart from the raw data type.
+For detailed validations and transformations, a schema can be wrapped in a pipeline. Especially for schema functions like <Link href="/api/string/">`string`</Link>, <Link href="/api/number/">`number`</Link>, <Link href="/api/date/">`date`</Link>, <Link href="/api/object/">`object`</Link>, and <Link href="/api/array/">`array`</Link>, this feature is useful for validating properties beyond the raw data type.
 
 ## How it works
 
@@ -42,7 +42,7 @@ const EmailSchema = v.pipe(
 
 Pipeline validation actions examine the input and, if the input does not meet a certain condition, return an issue. If the input is valid, it is returned as the output and, if present, picked up by the next action in the pipeline.
 
-> If possible, I run a pipeline completely, even if an issue has occurred, to collect all possible issues. If you want me to abort the pipeline early after the first issue, you need to set the `abortPipeEarly` option to `true`. Learn more about this <Link href="/guides/parse-data/#configuration">here</Link>.
+> Whenever possible, pipelines are run completely—even if an issue has occurred—to collect all possible issues. If exiting upon encountering the first issue is desired (perhaps for performance reasons), you may set the `abortPipeEarly` option to `true`. Learn more about this <Link href="/guides/parse-data/#configuration">here</Link>.
 
 <ApiList
   label="Validation actions"
@@ -120,7 +120,7 @@ Pipeline validation actions examine the input and, if the input does not meet a 
   ]}
 />
 
-Some of these actions can be combined with different schemas. For example, <Link href="/api/minValue/">`minValue`</Link> can be used to validate the minimum value of <Link href="/api/string/">`string`</Link>, <Link href="/api/number/">`number`</Link>, <Link href="/api/bigint/">`bigint`</Link> and <Link href="/api/date/">`date`</Link>.
+Some of these actions can be combined with different schemas. For example, <Link href="/api/minValue/">`minValue`</Link> can be used to validate the minimum value of <Link href="/api/string/">`string`</Link>, <Link href="/api/number/">`number`</Link>, <Link href="/api/bigint/">`bigint`</Link>, and <Link href="/api/date/">`date`</Link>.
 
 ```ts
 import * as v from 'valibot';
@@ -133,7 +133,7 @@ const DateSchema = v.pipe(v.date(), v.minValue(new Date()));
 
 ### Custom validation
 
-For custom validations, <Link href="/api/check/">`check`</Link> can be used. If the function passed as the first argument returns `false`, an issue is returned. Otherwise the input is considered valid.
+For custom validations, <Link href="/api/check/">`check`</Link> can be used. If the function passed as the first argument returns `false`, an issue is returned. Otherwise, the input is considered valid.
 
 ```ts
 import * as v from 'valibot';

--- a/website/src/routes/guides/(main-concepts)/quick-start/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/quick-start/index.mdx
@@ -5,6 +5,7 @@ description: >-
   get started creating your first schema.
 contributors:
   - fabian-hiller
+  - BastiDood
 ---
 
 import { Link } from '@builder.io/qwik-city';

--- a/website/src/routes/guides/(main-concepts)/quick-start/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/quick-start/index.mdx
@@ -13,13 +13,13 @@ import { ApiList } from '~/components';
 
 # Quick start
 
-My schema can be compared to a type definition in TypeScript. The big difference is that TypeScript types are "not executed" and are more or less a DX feature. A schema on the other hand, apart from the inferred type definition, can also be executed at runtime to guarantee type safety of unknown data.
+A Valibot schema can be compared to a type definition in TypeScript. The big difference is that TypeScript types are "not executed" and are more or less a DX feature. A schema on the other hand—apart from the inferred type definition—can also be executed at runtime to truly guarantee type safety of unknown data.
 
-> Until I reach v1, I welcome lots of feedback on the API, naming and implementation. Please create or reply to an [issue](https://github.com/fabian-hiller/valibot/issues) and help me become the best schema library for JavaScript and TypeScript.
+> Until Valibot reaches v1, feedback on the API, naming, and implementation is very welcome and much appreciated. Please create or reply to an [issue](https://github.com/fabian-hiller/valibot/issues) and help Valibot be the best schema library for JavaScript and TypeScript.
 
 ## Basic concept
 
-Similar to how types can be defined in TypeScript, my source code allows you to define a schema with various small functions. This applies to primitive values like strings as well as to more complex data sets like objects.
+Similar to how types can be defined in TypeScript, Valibot allows you to define a schema with various small functions. This applies to primitive values like strings as well as more complex data sets like objects.
 
 ```ts
 import * as v from 'valibot';
@@ -39,7 +39,7 @@ const LoginSchema = v.object({
 
 ## Pipelines
 
-In addition, I can help you to perform more detailed validations and transformations with the <Link href="/api/pipe/">`pipe`</Link> method. Thus, for example, it can be ensured that a string is an email and ends with a certain domain.
+In addition, pipelines enable you to perform more detailed validations and transformations with the <Link href="/api/pipe/">`pipe`</Link> method. Thus, for example, it can be ensured that a string is an email that ends with a certain domain.
 
 ```ts
 import * as v from 'valibot';
@@ -51,7 +51,7 @@ A pipeline must always start with a schema, followed by up to 19 validation or t
 
 ## Error messages
 
-If I detect an issue during validation, I create a specific issue object with various details and an error message. This error message can be overridden via the first optional argument of a schema or validation action.
+If an issue is detected during validation, the library emits a specific issue object that includes various details and an error message. This error message can be overridden via the first optional argument of a schema or validation action.
 
 ```ts
 import * as v from 'valibot';

--- a/website/src/routes/guides/(main-concepts)/schemas/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/schemas/index.mdx
@@ -17,7 +17,7 @@ import { ApiList } from '~/components';
 
 # Schemas
 
-Schemas allow you to validate a specific data type. They are similar to type definitions in TypeScript. Aside from primitive values (such as strings) and complex values (such as objects), Valibot also supports special cases like literals, unions, and custom types.
+Schemas allow you to validate a specific data type. They are similar to type definitions in TypeScript. Besides primitive values like strings and complex values like objects, Valibot also supports special cases like literals, unions and custom types.
 
 ## Primitive values
 
@@ -50,7 +50,7 @@ const UndefinedSchema = v.undefined(); // undefined
 
 ## Complex values
 
-Support for complex values includes objects, records, arrays, tuples, and various other classes.
+Among complex values, Valibot supports objects, records, arrays, tuples, and several other classes.
 
 > There are various methods for objects such as <Link href="/api/pick/">`pick`</Link>, <Link href="/api/omit/">`omit`</Link>, <Link href="/api/partial/">`partial`</Link> and <Link href="/api/required/">`required`</Link>. Learn more about them <Link href="/guides/methods/#object-methods">here</Link>.
 

--- a/website/src/routes/guides/(main-concepts)/schemas/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/schemas/index.mdx
@@ -17,11 +17,11 @@ import { ApiList } from '~/components';
 
 # Schemas
 
-Schemas allow you to validate a specific data type. They are similar to type definitions in TypeScript. Besides primitive values like strings and complex values like objects, I also support special cases like literals, unions and custom types.
+Schemas allow you to validate a specific data type. They are similar to type definitions in TypeScript. Aside from primitive values (such as strings) and complex values (such as objects), Valibot also supports special cases like literals, unions, and custom types.
 
 ## Primitive values
 
-I support the creation of schemas for any primitive data type. These are immutable values that are stored directly in the stack, unlike objects where only a reference to the heap is stored.
+Valibot supports the creation of schemas for any primitive data type. These are immutable values that are stored directly in the stack, unlike objects where only a reference to the heap is stored.
 
 <ApiList
   label="Primitive schemas"
@@ -50,9 +50,9 @@ const UndefinedSchema = v.undefined(); // undefined
 
 ## Complex values
 
-Among complex values I support objects, records, arrays, tuples as well as various other classes.
+Support for complex values includes objects, records, arrays, tuples, and various other classes.
 
-> For objects I provide various methods like <Link href="/api/pick/">`pick`</Link>, <Link href="/api/omit/">`omit`</Link>, <Link href="/api/partial/">`partial`</Link> and <Link href="/api/required/">`required`</Link>. Learn more about them <Link href="/guides/methods/#object-methods">here</Link>.
+> There are various methods for objects such as <Link href="/api/pick/">`pick`</Link>, <Link href="/api/omit/">`omit`</Link>, <Link href="/api/partial/">`partial`</Link> and <Link href="/api/required/">`required`</Link>. Learn more about them <Link href="/guides/methods/#object-methods">here</Link>.
 
 <ApiList
   label="Complex schemas"
@@ -101,7 +101,7 @@ const TupleWithRestSchema = v.tupleWithRest([v.string(), v.number()], v.null());
 
 ## Special cases
 
-Beyond primitive and complex values, I also provide schema functions for more special cases.
+Beyond primitive and complex values, there are also schema functions for more special cases.
 
 <ApiList
   label="Special schemas"

--- a/website/src/routes/guides/(main-concepts)/schemas/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/schemas/index.mdx
@@ -9,6 +9,7 @@ contributors:
   - alonidiom
   - yicrotkd
   - gotnoklu
+  - BastiDood
 ---
 
 import { Link } from '@builder.io/qwik-city';

--- a/website/src/routes/guides/(migration)/migrate-from-ajv/index.mdx
+++ b/website/src/routes/guides/(migration)/migrate-from-ajv/index.mdx
@@ -6,4 +6,4 @@ contributors:
 
 # Migrate from Ajv
 
-> The content of this page is not yet ready. Check back in a few days.
+> The content of this page is not yet ready. Check back in a few weeks.

--- a/website/src/routes/guides/(migration)/migrate-from-joi/index.mdx
+++ b/website/src/routes/guides/(migration)/migrate-from-joi/index.mdx
@@ -6,4 +6,4 @@ contributors:
 
 # Migrate from Joi
 
-> The content of this page is not yet ready. Check back in a few days.
+> The content of this page is not yet ready. Check back in a few weeks.

--- a/website/src/routes/guides/(migration)/migrate-from-yup/index.mdx
+++ b/website/src/routes/guides/(migration)/migrate-from-yup/index.mdx
@@ -6,4 +6,4 @@ contributors:
 
 # Migrate from Yup
 
-> The content of this page is not yet ready. Check back in a few days.
+> The content of this page is not yet ready. Check back in a few weeks.

--- a/website/src/routes/guides/(migration)/migrate-to-v0.31.0/index.mdx
+++ b/website/src/routes/guides/(migration)/migrate-to-v0.31.0/index.mdx
@@ -43,7 +43,7 @@ const Schema = v.string([v.email()]);
 const Schema = v.pipe(v.string(), v.email());
 ```
 
-We will be publishing a blog post soon explaining all the benefits of this change. In the meantime, you can read the description of discussion [#463](https://github.com/fabian-hiller/valibot/discussions/463) and PR [#502](https://github.com/fabian-hiller/valibot/pull/502), which introduced this change.
+We will be publishing a [blog post](/blog/valibot-v0.31.0-is-finally-available/) soon explaining all the benefits of this change. In the meantime, you can read the description of discussion [#463](https://github.com/fabian-hiller/valibot/discussions/463) and PR [#502](https://github.com/fabian-hiller/valibot/pull/502), which introduced this change.
 
 ## Change names
 

--- a/website/src/routes/guides/(schemas)/intersections/index.mdx
+++ b/website/src/routes/guides/(schemas)/intersections/index.mdx
@@ -11,7 +11,7 @@ import { Link } from '@builder.io/qwik-city';
 
 # Intersections
 
-An intersection represents a logical AND relationship. You can apply this concept to your schemas with <Link href="/api/intersect/">`intersect`</Link> and partially by merging multiple object schemas into a new one. I recommend this approach for simple object schemas, and <Link href="/api/intersect/">`intersect`</Link> for all other cases.
+An intersection represents a logical AND relationship. You can apply this concept to your schemas with <Link href="/api/intersect/">`intersect`</Link> and partially by merging multiple object schemas into a new one. We recommend this approach for simple object schemas, and <Link href="/api/intersect/">`intersect`</Link> for all other cases.
 
 ## Intersect schema
 

--- a/website/src/routes/guides/(schemas)/objects/index.mdx
+++ b/website/src/routes/guides/(schemas)/objects/index.mdx
@@ -53,7 +53,7 @@ const ObjectSchema = v.objectWithRest(
 
 To validate the value of an entry based on another entry, you can wrap you schema with the <Link href="/api/check/">`check`</Link> validation action in a pipeline. You can also use <Link href="/api/forward/">`forward`</Link> to assign the issue to a specific object key in the event of an error.
 
-> If you only want to validate specific entries, I recommend using <Link href="/api/partialCheck/">`partialCheck`</Link> instead as <Link href="/api/check/">`check`</Link> can only be executed if the input is fully typed.
+> If you only want to validate specific entries, we recommend using <Link href="/api/partialCheck/">`partialCheck`</Link> instead as <Link href="/api/check/">`check`</Link> can only be executed if the input is fully typed.
 
 ```ts
 import * as v from 'valibot';

--- a/website/src/routes/guides/(schemas)/optionals/index.mdx
+++ b/website/src/routes/guides/(schemas)/optionals/index.mdx
@@ -2,7 +2,8 @@
 title: Optionals
 description: >-
   It often happens that `undefined` or `null` should also be accepted. To make
-  the API more readable for this and to reduce boilerplate, I offer a shortcut.
+  the API more readable for this and to reduce boilerplate, Valibot offers a
+  shortcut.
 contributors:
   - fabian-hiller
 ---
@@ -11,11 +12,11 @@ import { Link } from '@builder.io/qwik-city';
 
 # Optionals
 
-It often happens that `undefined` or `null` should also be accepted instead of the value. To make the API more readable for this and to reduce boilerplate, I offer a shortcut for this functionality with <Link href="/api/optional/">`optional`</Link>, <Link href="/api/nullable/">`nullable`</Link>, <Link href="/api/nullish/">`nullish`</Link> and <Link href="/api/undefinedable/">`undefinedable`</Link>.
+It often happens that `undefined` or `null` should also be accepted instead of the value. To make the API more readable for this and to reduce boilerplate, Valibot offers a shortcut for this functionality with <Link href="/api/optional/">`optional`</Link>, <Link href="/api/nullable/">`nullable`</Link>, <Link href="/api/nullish/">`nullish`</Link> and <Link href="/api/undefinedable/">`undefinedable`</Link>.
 
 ## How it works
 
-To accept `undefined` or `null` besides your actual value, you just have to wrap the schema in <Link href="/api/optional/">`optional`</Link>, <Link href="/api/nullable/">`nullable`</Link>, and <Link href="/api/undefinedable/">`undefinedable`</Link>.
+To accept `undefined` and/or `null` besides your actual value, you just have to wrap the schema in <Link href="/api/optional/">`optional`</Link>, <Link href="/api/nullable/">`nullable`</Link>, <Link href="/api/nullish/">`nullish`</Link>, or <Link href="/api/undefinedable/">`undefinedable`</Link>.
 
 ```ts
 import * as v from 'valibot';

--- a/website/src/routes/guides/(schemas)/other/index.mdx
+++ b/website/src/routes/guides/(schemas)/other/index.mdx
@@ -27,7 +27,7 @@ const BooleanLiteralSchema = v.literal(true); // true
 
 ## Instance schema
 
-With schema functions like <Link href="/api/blob/">`blob`</Link>, <Link href="/api/date/">`date`</Link>, <Link href="/api/map/">`map`</Link> and <Link href="/api/set/">`set`</Link> I already cover the most common JavaScript classes. However, there are many more classes that you may want to validate. For this purpose, you can use the <Link href="/api/instance/">`instance`</Link> schema function. It takes a class as its first argument and returns a schema that matches only instances of that class.
+With schema functions like <Link href="/api/blob/">`blob`</Link>, <Link href="/api/date/">`date`</Link>, <Link href="/api/map/">`map`</Link> and <Link href="/api/set/">`set`</Link> Valibot already covers the most common JavaScript classes. However, there are many more classes that you may want to validate. For this purpose, you can use the <Link href="/api/instance/">`instance`</Link> schema function. It takes a class as its first argument and returns a schema that matches only instances of that class.
 
 ```ts
 import * as v from 'valibot';

--- a/website/src/routes/guides/(schemas)/unions/index.mdx
+++ b/website/src/routes/guides/(schemas)/unions/index.mdx
@@ -64,7 +64,7 @@ The following issues are returned if the input is `null` instead of a string or 
 
 ## Variant schema
 
-For better performance, more type safety, and a more targeted output of issues, you can use <Link href="/api/variant/">`variant`</Link> for discriminated unions. Therefore, I recommend using <Link href="/api/variant/">`variant`</Link> over <Link href="/api/union/">`union`</Link> whenever possible. A discriminated union is an OR relationship between objects that can be distinguished by a specific key.
+For better performance, more type safety, and a more targeted output of issues, you can use <Link href="/api/variant/">`variant`</Link> for discriminated unions. Therefore, we recommend using <Link href="/api/variant/">`variant`</Link> over <Link href="/api/union/">`union`</Link> whenever possible. A discriminated union is an OR relationship between objects that can be distinguished by a specific key.
 
 When you call the schema function, you first specify the discriminator key. This is used to determine the schema to use for validation based on the input. The object schemas, in the form of an array, follow as the second argument.
 


### PR DESCRIPTION
In line with #687, I have begun work towards the migration of the documentation from first-person to a more neutral tone. I was personally amused by the personality at first, but as suggested by many others, it did get old pretty quick.

This PR only adjusts the text for the Main Concepts section of the Guides page. There is a lot more work to do, but I'd like to keep this PR well-scoped in the meantime. Let me know if you have any concerns regarding the updated version of the text.

> [!NOTE]
> As an aside, I'd like to invite you in accepting this PR as a valid submission for this year's [Hacktoberfest](https://hacktoberfest.com/). There are [two ways](https://hacktoberfest.com/participation/) to do this: (1) add the `hacktoberfest` topic to the repository or (2) add the `hacktoberfest-accepted` label only to this PR if the previous option is not preferable. Thanks! 🚀