### PR TITLE
Set `typed` = true when the wrapped schema of nonOptional is typed

### DIFF
--- a/library/src/methods/forward/forward.ts
+++ b/library/src/methods/forward/forward.ts
@@ -34,7 +34,7 @@ export function forward<
       const prevIssues = dataset.issues && [...dataset.issues];
 
       // Run validation action
-      action['~run'](dataset, config);
+      dataset = action['~run'](dataset, config);
 
       // If dataset contains issues, forward newly added issues
       if (dataset.issues) {

--- a/library/src/methods/forward/forwardAsync.ts
+++ b/library/src/methods/forward/forwardAsync.ts
@@ -38,7 +38,7 @@ export function forwardAsync<
       const prevIssues = dataset.issues && [...dataset.issues];
 
       // Run validation action
-      await action['~run'](dataset, config);
+      dataset = await action['~run'](dataset, config);
 
       // If dataset contains issues, forward newly added issues
       if (dataset.issues) {

--- a/library/src/schemas/nonNullable/nonNullable.ts
+++ b/library/src/schemas/nonNullable/nonNullable.ts
@@ -90,7 +90,8 @@ export function nonNullable(
     '~run'(dataset, config) {
       // If value is not `null`, run wrapped schema
       if (dataset.value !== null) {
-        this.wrapped['~run'](dataset, config);
+        // @ts-expect-error
+        dataset = this.wrapped['~run'](dataset, config);
       }
 
       // If value is `null`, add issue to dataset

--- a/library/src/schemas/nonNullable/nonNullableAsync.ts
+++ b/library/src/schemas/nonNullable/nonNullableAsync.ts
@@ -103,7 +103,8 @@ export function nonNullableAsync(
     async '~run'(dataset, config) {
       // If value is not `null`, run wrapped schema
       if (dataset.value !== null) {
-        await this.wrapped['~run'](dataset, config);
+        // @ts-expect-error
+        dataset = await this.wrapped['~run'](dataset, config);
       }
 
       // If value is `null`, add issue to dataset

--- a/library/src/schemas/nonNullish/nonNullish.ts
+++ b/library/src/schemas/nonNullish/nonNullish.ts
@@ -90,7 +90,8 @@ export function nonNullish(
     '~run'(dataset, config) {
       // If value is not `null` and `undefined`, run wrapped schema
       if (!(dataset.value === null || dataset.value === undefined)) {
-        this.wrapped['~run'](dataset, config);
+        // @ts-expect-error
+        dataset = this.wrapped['~run'](dataset, config);
       }
 
       // If value is `null` or `undefined`, add issue to dataset

--- a/library/src/schemas/nonNullish/nonNullishAsync.ts
+++ b/library/src/schemas/nonNullish/nonNullishAsync.ts
@@ -103,7 +103,8 @@ export function nonNullishAsync(
     async '~run'(dataset, config) {
       // If value is not `null` and `undefined`, run wrapped schema
       if (!(dataset.value === null || dataset.value === undefined)) {
-        await this.wrapped['~run'](dataset, config);
+        // @ts-expect-error
+        dataset = await this.wrapped['~run'](dataset, config);
       }
 
       // If value is `null` or `undefined`, add issue to dataset

--- a/library/src/schemas/nonOptional/nonOptional.ts
+++ b/library/src/schemas/nonOptional/nonOptional.ts
@@ -90,11 +90,8 @@ export function nonOptional(
     '~run'(dataset, config) {
       // If value is not `undefined`, run wrapped schema
       if (dataset.value !== undefined) {
-        const outputDataset = this.wrapped['~run'](dataset, config);
-        if (outputDataset.typed) {
-          // @ts-expect-error
-          dataset.typed = true;
-        }
+        // @ts-expect-error
+        dataset = this.wrapped['~run'](dataset, config);
       }
 
       // If value is `undefined`, add issue to dataset

--- a/library/src/schemas/nonOptional/nonOptional.ts
+++ b/library/src/schemas/nonOptional/nonOptional.ts
@@ -90,7 +90,11 @@ export function nonOptional(
     '~run'(dataset, config) {
       // If value is not `undefined`, run wrapped schema
       if (dataset.value !== undefined) {
-        this.wrapped['~run'](dataset, config);
+        const outputDataset = this.wrapped['~run'](dataset, config);
+        if (outputDataset.typed) {
+          // @ts-expect-error
+          dataset.typed = true;
+        }
       }
 
       // If value is `undefined`, add issue to dataset

--- a/library/src/schemas/nonOptional/nonOptionalAsync.ts
+++ b/library/src/schemas/nonOptional/nonOptionalAsync.ts
@@ -103,11 +103,8 @@ export function nonOptionalAsync(
     async '~run'(dataset, config) {
       // If value is not `undefined`, run wrapped schema
       if (dataset.value !== undefined) {
-        const outputDataset = await this.wrapped['~run'](dataset, config);
-        if (outputDataset.typed) {
-          // @ts-expect-error
-          dataset.typed = true;
-        }
+        // @ts-expect-error
+        dataset = await this.wrapped['~run'](dataset, config);
       }
 
       // If value is `undefined`, add issue to dataset

--- a/library/src/schemas/nonOptional/nonOptionalAsync.ts
+++ b/library/src/schemas/nonOptional/nonOptionalAsync.ts
@@ -103,7 +103,11 @@ export function nonOptionalAsync(
     async '~run'(dataset, config) {
       // If value is not `undefined`, run wrapped schema
       if (dataset.value !== undefined) {
-        await this.wrapped['~run'](dataset, config);
+        const outputDataset = await this.wrapped['~run'](dataset, config);
+        if (outputDataset.typed) {
+          // @ts-expect-error
+          dataset.typed = true;
+        }
       }
 
       // If value is `undefined`, add issue to dataset


### PR DESCRIPTION
This fixes #925 

The `nonOptional` schema has not been `typed = true` when its wrapping schema becomes `typed = true`.
I did changed it to be typed.