### PR TITLE
improve `value` related API references

### DIFF
--- a/website/src/routes/api/(actions)/value/index.mdx
+++ b/website/src/routes/api/(actions)/value/index.mdx
@@ -4,6 +4,7 @@ description: Creates a value validation action.
 source: /actions/value/value.ts
 contributors:
   - fabian-hiller
+  - EltonLobo07
 ---
 
 import { ApiList, Property } from '~/components';

--- a/website/src/routes/api/(actions)/value/properties.ts
+++ b/website/src/routes/api/(actions)/value/properties.ts
@@ -35,6 +35,10 @@ export const properties: Record<string, PropertyProps> = {
                   type: 'custom',
                   name: 'TInput',
                 },
+                {
+                  type: 'custom',
+                  name: 'TRequirement',
+                },
               ],
             },
           ],

--- a/website/src/routes/api/(types)/ValueAction/index.mdx
+++ b/website/src/routes/api/(types)/ValueAction/index.mdx
@@ -1,14 +1,15 @@
 ---
-title: ValueValidation
+title: ValueAction
 description: Value action type.
 contributors:
   - fabian-hiller
+  - EltonLobo07
 ---
 
 import { Property } from '~/components';
 import { properties } from './properties';
 
-# ValueValidation
+# ValueAction
 
 Value action type.
 
@@ -20,7 +21,7 @@ Value action type.
 
 ## Definition
 
-- `ValueValidation` <Property {...properties.BaseValidation} />
+- `ValueAction` <Property {...properties.BaseValidation} />
   - `type` <Property {...properties.type} />
   - `reference` <Property {...properties.reference} />
   - `expects` <Property {...properties.expects} />


### PR DESCRIPTION
Improvements:
- add a missing type argument to the `ValueIssue` type in the `value` action page
- rename `ValueValidation` to `ValueAction` in the `ValueAction` page