### PR TITLE
improve `optionals` guide

### DIFF
--- a/website/src/routes/guides/(schemas)/optionals/index.mdx
+++ b/website/src/routes/guides/(schemas)/optionals/index.mdx
@@ -79,11 +79,9 @@ const CalculationSchema = v.pipe(
     b: v.number(),
     sum: v.optional(v.number()),
   }),
-  v.transform((input) => {
-    return {
-      ...input,
-      sum: input.sum === undefined ? input.a + input.b : input.sum,
-    };
-  })
+  v.transform((input) => ({
+    ...input,
+    sum: input.sum === undefined ? input.a + input.b : input.sum,
+  }))
 );
 ```

--- a/website/src/routes/guides/(schemas)/optionals/index.mdx
+++ b/website/src/routes/guides/(schemas)/optionals/index.mdx
@@ -7,6 +7,7 @@ description: >-
 contributors:
   - fabian-hiller
   - fartinmartin
+  - EltonLobo07
 ---
 
 import { Link } from '@builder.io/qwik-city';
@@ -47,8 +48,8 @@ import * as v from 'valibot';
 
 const OptionalStringSchema = v.optional(v.string(), "I'm the default!");
 
-type OptionalStringInput = v.Input<typeof OptionalStringSchema>; // string | undefined
-type OptionalStringOutput = v.Output<typeof OptionalStringSchema>; // string
+type OptionalStringInput = v.InferInput<typeof OptionalStringSchema>; // string | undefined
+type OptionalStringOutput = v.InferOutput<typeof OptionalStringSchema>; // string
 ```
 
 By providing a default value, the input type of the schema now differs from the output type. The schema in the example now accepts `string` and `undefined` as input, but returns a string as output in both cases.
@@ -70,6 +71,8 @@ The previous example thus creates a new instance of the [`Date`](https://develop
 In rare cases, a default value for an optional entry may depend on the values of another entries in the same object. This can be achieved by using <Link href="/api/transform/">`transform`</Link> in the <Link href="/api/pipe/">`pipe`</Link> of the object.
 
 ```ts
+import * as v from 'valibot';
+
 const CalculationSchema = v.pipe(
   v.object({
     a: v.number(),
@@ -77,10 +80,10 @@ const CalculationSchema = v.pipe(
     sum: v.optional(v.number()),
   }),
   v.transform((input) => {
-    if (input.sum === undefined) {
-      return { ...input, sum: input.a + input.b };
-    }
-    return input;
+    return {
+      ...input,
+      sum: input.sum === undefined ? input.a + input.b : input.sum,
+    };
   })
 );
 ```


### PR DESCRIPTION
Improvements:
1. Replace `Input` and `Output` with `InferInput` and `InferOutput` in one of the examples.
2. Change the behavior of the `Dependent default values` example to enable TypeScript to infer the correct output type.

More information related to the 2nd improvement:
The example without the improvement does not work as [intended](https://valibot.dev/playground/?code=JYWwDg9gTgLgBAKjgQwM5wG5wGZQiOAcg2QBtgAjCGQgbgCh6BjCAO1XgGEymBXU5DGBsAykwAWAUxDI4AXkwA6MMDCSAFPThKIFAFaSmMdQG8t2lAC4lrXiAqSo6gJQAac9orWMi2-ccu7hZwqHbeihBgQmxk6j5+Dk7ObuYAvinaPjBQyOzY0CDq6sCsYLwwzvIAfHBmwcDYcMWl5YqhBHKdcLysACaS2CWSvZV1wXBQkjC8UKy1cIqLJWUwriFhcMutsgDUmy0wihRwqQzBqR4TUzNzWzBnJ870zgz02QCeteYs7PC9gshrD0ANasCAAdzmChMgLgAEY1l44AAmNbtawAZlO3zYHCuoVI8AUPjAyCgqA03FIfAE0VYYikMjW-xgyBe5gA9By4AAVd5qOCOPBQOBSSY437rEDWBKOeT4-iHdoMVJwJiCCTqIXQUYS1AQUiSRTapwm9kXIA). This might be because TS does not narrow the type of a generic function parameter ([related](https://github.com/microsoft/TypeScript/issues/13995)) but using the ternary operator narrows the type and everything works as [intended](https://valibot.dev/playground/?code=JYWwDg9gTgLgBAKjgQwM5wG5wGZQiOAcg2QBtgAjCGQgbgCh6BjCAO1XgGEymBXU5DGBsAykwAWAUxDI4AXkwA6MMDCSAFPThKIFAFaSmMdQG8t2lAC4lrXiAqSo6gJQAac9orWMi2-ccu7hZwqHbeihBgQmxk6j5+Dk7ObuYAvinaPjBQyOzY0CDq6sCsYLwwzvIAfHBmwVCSMLxQrLUeFoqdJWUwQcEhYXDd5YqhBHITcLysACaS2CWSM3AA-EOlI7IA1Os9ihRw1sMwo3Z92qkMF870zgz02QCebdos7PAzgsjW0wDWrBAAO6tBQmb5wACMrjgXjgACZoWNrABmS7mN4cOANUKkeAKHxgZBQVAabikPgCaKsMRSGTQz4wZB3cwAehZcAAchA4DBHmo4I48FB0WxMUi4AlHPIsZIcScxgxUnAmIIJOpBdBKnVlaKIKRJIoNU4jczUvQgA). There is one major difference between the current and improved examples. The current example returned the same object reference but the improved example doesn't when `sum` is not `undefined` and I think it is fine because:
1. The `transform` action is meant to transform values, so relying on referential equality should be discouraged.
2. I wasn't able to find a better way to let TS infer the type of the output (without a type assertion or something similar).