### PR TITLE
fix(library): correct type inference in `ArgsAction`

### DIFF
--- a/library/src/actions/args/args.ts
+++ b/library/src/actions/args/args.ts
@@ -13,7 +13,7 @@ import type {
   BaseSchema,
   BaseTransformation,
   ErrorMessage,
-  InferInput,
+  InferOutput,
   TupleItems,
 } from '../../types/index.ts';
 import { ValiError } from '../../utils/index.ts';
@@ -42,7 +42,7 @@ export interface ArgsAction<
   TSchema extends Schema,
 > extends BaseTransformation<
     TInput,
-    (...args: InferInput<TSchema>) => ReturnType<TInput>,
+    (...args: InferOutput<TSchema>) => ReturnType<TInput>,
     never
   > {
   /**


### PR DESCRIPTION
Actually, I found that `type Output = v.InferOutput<typeof ComplexSchema>` will be deduced as:
```ts
type Output = {
    fn: (args_0: string) => boolean;
    argsWithFn: (args_0: (...args: unknown[]) => unknown) => unknown;
}
```
Is this the expected behavior?  Is there a problem with my writing for the `args_0` of the `argsWithFn`?

_Originally posted by @shulaoda in https://github.com/fabian-hiller/valibot/issues/968#issuecomment-2537846099_


The second generic of `BaseTransformation` should be `InferOutput<...>`.

Playground: https://valibot.dev/playground/?code=JYWwDg9gTgLgBAKjgQwM5wG5wGZQiOAcg2QBtgAjCGQgbgCh6BjCAO1XgGF8xSBTAB4BlJgAs+IZHAC8mAHQcowJjADyFAFZ8VACgDe9ODlYAueWGBg+Ow0fnYArqxXA2OgJQAaW0YxzkUADmqDp+MA681gDaforArIEeALruXj7yUHzhUOyhclQQ-MisHmlGZShBqADqwDCiAGKm5pbW6X6OzjCuJRW+-lU2dnZhEfw6UenDfhZWQ8MLHU4ubn0L-QHBeeGRE34FRb0pa+t+mdm5sTBKCaXe6+X3CylPj+1y5w45IVc3ialPNIAX3cDHoMAAnlY4KoHDAwHCZPIAJKsbB8KCw+FwgA8kKsEGwcG44H4wjEEmQAD4wSx2PAIHCETAzFjmUiDEZsM0dJszHEEu4ZFS4Ho4J8cnB8XxCZVAjJpLJCALAoQ4ECnpsanVGjzuWZeUEzAc+MUhdIRSrzSKxRLWMYdNgyKg+EKgfR3cw2KhCnw5KQIIlGdiYO56EA