### PR TITLE
Reduce TypeScript target to ES2020

### DIFF
--- a/library/tsconfig.json
+++ b/library/tsconfig.json
@@ -10,7 +10,7 @@
     "noEmit": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "ESNext"
+    "target": "ES2020"
   },
   "include": ["src"]
 }

--- a/packages/i18n/tsconfig.json
+++ b/packages/i18n/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "lib": ["ESNext", "DOM"],
-    "target": "ESNext",
+    "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "node",
     "allowImportingTsExtensions": true,

--- a/packages/to-json-schema/tsconfig.json
+++ b/packages/to-json-schema/tsconfig.json
@@ -10,7 +10,7 @@
     "noEmit": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "ESNext",
+    "target": "ES2020",
     "paths": {
       "valibot": ["../../library/src/index.ts"],
       "valibot/*": ["../../library/src/*"]


### PR DESCRIPTION
Support for extremely modern ES syntax still isn’t universal, and is totally unnecessary for us, since the only diff this results in is

```diff
--- library/dist/index.js
+++ library/dist/index.js
@@ -237,8 +237,4 @@
 var ValiError = class extends Error {
   /**
-   * The error issues.
-   */
-  issues;
-  /**
    * Creates a Valibot error with useful information.
    *
```

(The .d.ts file is unaffected, so no documentation is lost.)