### PR TITLE
Feat start with types

### DIFF
--- a/library/src/actions/endsWith/endsWith.test-d.ts
+++ b/library/src/actions/endsWith/endsWith.test-d.ts
@@ -37,7 +37,7 @@ describe('endsWith', () => {
     });
 
     test('of output', () => {
-      expectTypeOf<InferOutput<Action>>().toEqualTypeOf<string>();
+      expectTypeOf<InferOutput<Action>>().toEqualTypeOf<`${string}foo`>();
     });
 
     test('of issue', () => {

--- a/library/src/actions/endsWith/endsWith.ts
+++ b/library/src/actions/endsWith/endsWith.ts
@@ -43,7 +43,7 @@ export interface EndsWithAction<
   TMessage extends
     | ErrorMessage<EndsWithIssue<TInput, TRequirement>>
     | undefined,
-> extends BaseValidation<TInput, TInput, EndsWithIssue<TInput, TRequirement>> {
+> extends BaseValidation<TInput, `${TInput}${TRequirement}`, EndsWithIssue<TInput, TRequirement>> {
   /**
    * The action type.
    */

--- a/library/src/actions/startsWith/startsWith.test-d.ts
+++ b/library/src/actions/startsWith/startsWith.test-d.ts
@@ -37,7 +37,7 @@ describe('startsWith', () => {
     });
 
     test('of output', () => {
-      expectTypeOf<InferOutput<Action>>().toEqualTypeOf<string>();
+      expectTypeOf<InferOutput<Action>>().toEqualTypeOf<`foo${string}`>();
     });
 
     test('of issue', () => {

--- a/library/src/actions/startsWith/startsWith.ts
+++ b/library/src/actions/startsWith/startsWith.ts
@@ -45,7 +45,7 @@ export interface StartsWithAction<
     | undefined,
 > extends BaseValidation<
     TInput,
-    TInput,
+    `${TRequirement}${TInput}`,
     StartsWithIssue<TInput, TRequirement>
   > {
   /**


### PR DESCRIPTION
Changes the output type for `startsWith` and `endsWith` to actually reflect.

Previously:
`startsWith("abc")` -- output --> `string`
Now:
`startsWith("abc")` -- output --> `abc${string}`

Similarly with endsWith.