### PR TITLE
Doc improve `objects` guide with extraction and composition patterns

### DIFF
--- a/website/src/routes/guides/(schemas)/objects/index.mdx
+++ b/website/src/routes/guides/(schemas)/objects/index.mdx
@@ -117,3 +117,42 @@ const CalculationSchema = v.pipe(
   )
 );
 ```
+
+## Extract an object field schema
+
+Valibot tries to reflect all schema information and make it available for further processing. For example you can extract a field schema from an <Link href="/api/object/">`object`</Link> schema to reuse it in other parts of your code.
+
+```ts
+import * as v from 'valibot';
+
+const PersonSchema = v.object({
+  name: v.string(),
+  age: v.number(),
+  address: v.object({
+    street: v.string(),
+    city: v.string(),
+  }),
+});
+
+const NameSchema = PersonSchema.entries.name;
+const StreetSchema = PersonSchema.entries.address.entries.street;
+```
+
+### Extraction vs composition
+
+Extracted field are reusable but depending on your use case you might want to use a composition pattern instead to improve the modularity of your code.
+
+```ts
+import * as v from 'valibot';
+
+const AddressSchema = v.object({
+  street: v.string(),
+  city: v.string(),
+});
+
+const PersonSchema = v.object({
+  name: v.string(),
+  age: v.number(),
+  address: AddressSchema,
+});
+```


### PR DESCRIPTION
On the discord server we've seen few questions about how to extract a field's schema from an `object`.
Fabian suggested to explain it in the objects guide so here it is.