### PR TITLE
perf: mark functions as `@__NO_SIDE_EFFECTS__`

### DIFF
--- a/library/.eslintrc.cjs
+++ b/library/.eslintrc.cjs
@@ -50,7 +50,7 @@ module.exports = {
     'jsdoc/check-tag-names': [
       'error',
       {
-        definedTags: ['alpha', 'beta'],
+        definedTags: ['alpha', 'beta', '__NO_SIDE_EFFECTS__'],
       },
     ],
 

--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the library will be documented in this file.
 - Add `words`, `maxWords`, `minWords` and `notWords` action
 - Add `args` and `returns` action to transform functions (issue #243)
 - Add new overload signature to `pipe` and `pipeAync` method to support unlimited pipe items of same input and output type (issue #852)
+- Add `@__NO_SIDE_EFFECTS__` notation to improve tree shaking (pull request #995)
 - Change types and implementation to support Standard Schema
 - Change behaviour of `minValue` and `maxValue` for `NaN` (pull request #843)
 - Change type and behaviour of `nullable`, `nullableAsync`, `nullish`, `nullishAsync`, `optional`, `optionalAsync`, `undefinedable` and `undefinedableAsync` for undefined default value (issue #878)

--- a/library/src/actions/args/args.ts
+++ b/library/src/actions/args/args.ts
@@ -74,6 +74,7 @@ export function args<
   TSchema extends Schema,
 >(schema: TSchema): ArgsAction<TInput, TSchema>;
 
+// @__NO_SIDE_EFFECTS__
 export function args(
   schema: Schema
 ): ArgsAction<(...args: unknown[]) => unknown, Schema> {

--- a/library/src/actions/args/argsAsync.ts
+++ b/library/src/actions/args/argsAsync.ts
@@ -96,6 +96,7 @@ export function argsAsync<
   TSchema extends Schema,
 >(schema: TSchema): ArgsActionAsync<TInput, TSchema>;
 
+// @__NO_SIDE_EFFECTS__
 export function argsAsync(
   schema: Schema
 ): ArgsActionAsync<(...args: unknown[]) => unknown, Schema> {

--- a/library/src/actions/await/awaitAsync.ts
+++ b/library/src/actions/await/awaitAsync.ts
@@ -22,9 +22,8 @@ export interface AwaitActionAsync<TInput extends Promise<unknown>>
  * Creates an await transformation action.
  *
  * @returns An await action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function awaitAsync<
   TInput extends Promise<unknown>,
 >(): AwaitActionAsync<TInput> {

--- a/library/src/actions/await/awaitAsync.ts
+++ b/library/src/actions/await/awaitAsync.ts
@@ -22,6 +22,8 @@ export interface AwaitActionAsync<TInput extends Promise<unknown>>
  * Creates an await transformation action.
  *
  * @returns An await action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function awaitAsync<
   TInput extends Promise<unknown>,

--- a/library/src/actions/base64/base64.ts
+++ b/library/src/actions/base64/base64.ts
@@ -83,6 +83,7 @@ export function base64<
   const TMessage extends ErrorMessage<Base64Issue<TInput>> | undefined,
 >(message: TMessage): Base64Action<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function base64(
   message?: ErrorMessage<Base64Issue<string>>
 ): Base64Action<string, ErrorMessage<Base64Issue<string>> | undefined> {

--- a/library/src/actions/bic/bic.ts
+++ b/library/src/actions/bic/bic.ts
@@ -80,6 +80,7 @@ export function bic<
   const TMessage extends ErrorMessage<BicIssue<TInput>> | undefined,
 >(message: TMessage): BicAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function bic(
   message?: ErrorMessage<BicIssue<string>>
 ): BicAction<string, ErrorMessage<BicIssue<string>> | undefined> {

--- a/library/src/actions/brand/brand.ts
+++ b/library/src/actions/brand/brand.ts
@@ -42,9 +42,8 @@ export interface BrandAction<TInput, TName extends BrandName>
  * @param name The brand name.
  *
  * @returns A brand action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function brand<TInput, TName extends BrandName>(
   name: TName
 ): BrandAction<TInput, TName> {

--- a/library/src/actions/brand/brand.ts
+++ b/library/src/actions/brand/brand.ts
@@ -42,6 +42,8 @@ export interface BrandAction<TInput, TName extends BrandName>
  * @param name The brand name.
  *
  * @returns A brand action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function brand<TInput, TName extends BrandName>(
   name: TName

--- a/library/src/actions/bytes/bytes.ts
+++ b/library/src/actions/bytes/bytes.ts
@@ -92,6 +92,7 @@ export function bytes<
   message: TMessage
 ): BytesAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function bytes(
   requirement: number,
   message?: ErrorMessage<BytesIssue<string, number>>

--- a/library/src/actions/check/check.ts
+++ b/library/src/actions/check/check.ts
@@ -58,6 +58,7 @@ export function check<
   message: TMessage
 ): CheckAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function check(
   requirement: (input: unknown) => boolean,
   message?: ErrorMessage<CheckIssue<unknown>>

--- a/library/src/actions/check/checkAsync.ts
+++ b/library/src/actions/check/checkAsync.ts
@@ -62,6 +62,7 @@ export function checkAsync<
   message: TMessage
 ): CheckActionAsync<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function checkAsync(
   requirement: (input: unknown) => MaybePromise<boolean>,
   message?: ErrorMessage<CheckIssue<unknown>>

--- a/library/src/actions/checkItems/checkItems.ts
+++ b/library/src/actions/checkItems/checkItems.ts
@@ -59,6 +59,7 @@ export function checkItems<
   message: TMessage
 ): CheckItemsAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function checkItems(
   requirement: ArrayRequirement<unknown[]>,
   message?: ErrorMessage<CheckItemsIssue<unknown[]>>

--- a/library/src/actions/checkItems/checkItemsAsync.ts
+++ b/library/src/actions/checkItems/checkItemsAsync.ts
@@ -59,6 +59,7 @@ export function checkItemsAsync<
   message: TMessage
 ): CheckItemsActionAsync<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function checkItemsAsync(
   requirement: ArrayRequirementAsync<unknown[]>,
   message?: ErrorMessage<CheckItemsIssue<unknown[]>>

--- a/library/src/actions/creditCard/creditCard.ts
+++ b/library/src/actions/creditCard/creditCard.ts
@@ -114,6 +114,7 @@ export function creditCard<
   const TMessage extends ErrorMessage<CreditCardIssue<TInput>> | undefined,
 >(message: TMessage): CreditCardAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function creditCard(
   message?: ErrorMessage<CreditCardIssue<string>>
 ): CreditCardAction<string, ErrorMessage<CreditCardIssue<string>> | undefined> {

--- a/library/src/actions/cuid2/cuid2.ts
+++ b/library/src/actions/cuid2/cuid2.ts
@@ -80,6 +80,7 @@ export function cuid2<
   const TMessage extends ErrorMessage<Cuid2Issue<TInput>> | undefined,
 >(message: TMessage): Cuid2Action<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function cuid2(
   message?: ErrorMessage<Cuid2Issue<string>>
 ): Cuid2Action<string, ErrorMessage<Cuid2Issue<string>> | undefined> {

--- a/library/src/actions/decimal/decimal.ts
+++ b/library/src/actions/decimal/decimal.ts
@@ -83,6 +83,7 @@ export function decimal<
   const TMessage extends ErrorMessage<DecimalIssue<TInput>> | undefined,
 >(message: TMessage): DecimalAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function decimal(
   message?: ErrorMessage<DecimalIssue<string>>
 ): DecimalAction<string, ErrorMessage<DecimalIssue<string>> | undefined> {

--- a/library/src/actions/description/description.ts
+++ b/library/src/actions/description/description.ts
@@ -25,9 +25,8 @@ export interface DescriptionAction<TInput, TDescription extends string>
  * @param description_ The description text.
  *
  * @returns A description action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function description<TInput, TDescription extends string>(
   description_: TDescription
 ): DescriptionAction<TInput, TDescription> {

--- a/library/src/actions/description/description.ts
+++ b/library/src/actions/description/description.ts
@@ -25,6 +25,8 @@ export interface DescriptionAction<TInput, TDescription extends string>
  * @param description_ The description text.
  *
  * @returns A description action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function description<TInput, TDescription extends string>(
   description_: TDescription

--- a/library/src/actions/digits/digits.ts
+++ b/library/src/actions/digits/digits.ts
@@ -83,6 +83,7 @@ export function digits<
   const TMessage extends ErrorMessage<DigitsIssue<TInput>> | undefined,
 >(message: TMessage): DigitsAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function digits(
   message?: ErrorMessage<DigitsIssue<string>>
 ): DigitsAction<string, ErrorMessage<DigitsIssue<string>> | undefined> {

--- a/library/src/actions/email/email.ts
+++ b/library/src/actions/email/email.ts
@@ -90,6 +90,7 @@ export function email<
   const TMessage extends ErrorMessage<EmailIssue<TInput>> | undefined,
 >(message: TMessage): EmailAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function email(
   message?: ErrorMessage<EmailIssue<string>>
 ): EmailAction<string, ErrorMessage<EmailIssue<string>> | undefined> {

--- a/library/src/actions/emoji/emoji.ts
+++ b/library/src/actions/emoji/emoji.ts
@@ -80,6 +80,7 @@ export function emoji<
   const TMessage extends ErrorMessage<EmojiIssue<TInput>> | undefined,
 >(message: TMessage): EmojiAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function emoji(
   message?: ErrorMessage<EmojiIssue<string>>
 ): EmojiAction<string, ErrorMessage<EmojiIssue<string>> | undefined> {

--- a/library/src/actions/empty/empty.ts
+++ b/library/src/actions/empty/empty.ts
@@ -76,6 +76,7 @@ export function empty<
   const TMessage extends ErrorMessage<EmptyIssue<TInput>> | undefined,
 >(message: TMessage): EmptyAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function empty(
   message?: ErrorMessage<EmptyIssue<LengthInput>>
 ): EmptyAction<LengthInput, ErrorMessage<EmptyIssue<LengthInput>> | undefined> {

--- a/library/src/actions/endsWith/endsWith.ts
+++ b/library/src/actions/endsWith/endsWith.ts
@@ -97,6 +97,7 @@ export function endsWith<
   message: TMessage
 ): EndsWithAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function endsWith(
   requirement: string,
   message?: ErrorMessage<EndsWithIssue<string, string>>

--- a/library/src/actions/everyItem/everyItem.ts
+++ b/library/src/actions/everyItem/everyItem.ts
@@ -85,6 +85,7 @@ export function everyItem<
   message: TMessage
 ): EveryItemAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function everyItem(
   requirement: ArrayRequirement<unknown[]>,
   message?: ErrorMessage<EveryItemIssue<unknown[]>>

--- a/library/src/actions/excludes/excludes.ts
+++ b/library/src/actions/excludes/excludes.ts
@@ -94,6 +94,7 @@ export function excludes<
   message: TMessage
 ): ExcludesAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function excludes(
   requirement: ContentRequirement<ContentInput>,
   message?: ErrorMessage<

--- a/library/src/actions/filterItems/filterItems.ts
+++ b/library/src/actions/filterItems/filterItems.ts
@@ -31,6 +31,7 @@ export function filterItems<TInput extends ArrayInput>(
   operation: ArrayRequirement<TInput>
 ): FilterItemsAction<TInput>;
 
+// @__NO_SIDE_EFFECTS__
 export function filterItems(
   operation: ArrayRequirement<unknown[]>
 ): FilterItemsAction<unknown[]> {

--- a/library/src/actions/findItem/findItem.ts
+++ b/library/src/actions/findItem/findItem.ts
@@ -44,6 +44,7 @@ export function findItem<
   TOuput extends TInput[number],
 >(operation: ArrayRequirement<TInput, TOuput>): FindItemAction<TInput, TOuput>;
 
+// @__NO_SIDE_EFFECTS__
 export function findItem(
   operation: ArrayRequirement<unknown[], unknown>
 ): FindItemAction<unknown[], unknown> {

--- a/library/src/actions/finite/finite.ts
+++ b/library/src/actions/finite/finite.ts
@@ -82,6 +82,7 @@ export function finite<
   const TMessage extends ErrorMessage<FiniteIssue<TInput>> | undefined,
 >(message: TMessage): FiniteAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function finite(
   message?: ErrorMessage<FiniteIssue<number>>
 ): FiniteAction<number, ErrorMessage<FiniteIssue<number>> | undefined> {

--- a/library/src/actions/graphemes/graphemes.ts
+++ b/library/src/actions/graphemes/graphemes.ts
@@ -97,6 +97,7 @@ export function graphemes<
   message: TMessage
 ): GraphemesAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function graphemes(
   requirement: number,
   message?: ErrorMessage<GraphemesIssue<string, number>>

--- a/library/src/actions/hash/hash.ts
+++ b/library/src/actions/hash/hash.ts
@@ -112,6 +112,7 @@ export function hash<
   message: TMessage
 ): HashAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function hash(
   types: [HashType, ...HashType[]],
   message?: ErrorMessage<HashIssue<string>>

--- a/library/src/actions/hexColor/hexColor.ts
+++ b/library/src/actions/hexColor/hexColor.ts
@@ -84,6 +84,7 @@ export function hexColor<
   const TMessage extends ErrorMessage<HexColorIssue<TInput>> | undefined,
 >(message: TMessage): HexColorAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function hexColor(
   message?: ErrorMessage<HexColorIssue<string>>
 ): HexColorAction<string, ErrorMessage<HexColorIssue<string>> | undefined> {

--- a/library/src/actions/hexadecimal/hexadecimal.ts
+++ b/library/src/actions/hexadecimal/hexadecimal.ts
@@ -84,6 +84,7 @@ export function hexadecimal<
   const TMessage extends ErrorMessage<HexadecimalIssue<TInput>> | undefined,
 >(message: TMessage): HexadecimalAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function hexadecimal(
   message?: ErrorMessage<HexadecimalIssue<string>>
 ): HexadecimalAction<

--- a/library/src/actions/imei/imei.ts
+++ b/library/src/actions/imei/imei.ts
@@ -88,6 +88,7 @@ export function imei<
   const TMessage extends ErrorMessage<ImeiIssue<TInput>> | undefined,
 >(message: TMessage): ImeiAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function imei(
   message?: ErrorMessage<ImeiIssue<string>>
 ): ImeiAction<string, ErrorMessage<ImeiIssue<string>> | undefined> {

--- a/library/src/actions/includes/includes.ts
+++ b/library/src/actions/includes/includes.ts
@@ -94,6 +94,7 @@ export function includes<
   message: TMessage
 ): IncludesAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function includes(
   requirement: ContentRequirement<ContentInput>,
   message?: ErrorMessage<

--- a/library/src/actions/integer/integer.ts
+++ b/library/src/actions/integer/integer.ts
@@ -82,6 +82,7 @@ export function integer<
   const TMessage extends ErrorMessage<IntegerIssue<TInput>> | undefined,
 >(message: TMessage): IntegerAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function integer(
   message?: ErrorMessage<IntegerIssue<number>>
 ): IntegerAction<number, ErrorMessage<IntegerIssue<number>> | undefined> {

--- a/library/src/actions/ip/ip.ts
+++ b/library/src/actions/ip/ip.ts
@@ -80,6 +80,7 @@ export function ip<
   const TMessage extends ErrorMessage<IpIssue<TInput>> | undefined,
 >(message: TMessage): IpAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function ip(
   message?: ErrorMessage<IpIssue<string>>
 ): IpAction<string, ErrorMessage<IpIssue<string>> | undefined> {

--- a/library/src/actions/ipv4/ipv4.ts
+++ b/library/src/actions/ipv4/ipv4.ts
@@ -80,6 +80,7 @@ export function ipv4<
   const TMessage extends ErrorMessage<Ipv4Issue<TInput>> | undefined,
 >(message: TMessage): Ipv4Action<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function ipv4(
   message?: ErrorMessage<Ipv4Issue<string>>
 ): Ipv4Action<string, ErrorMessage<Ipv4Issue<string>> | undefined> {

--- a/library/src/actions/ipv6/ipv6.ts
+++ b/library/src/actions/ipv6/ipv6.ts
@@ -80,6 +80,7 @@ export function ipv6<
   const TMessage extends ErrorMessage<Ipv6Issue<TInput>> | undefined,
 >(message: TMessage): Ipv6Action<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function ipv6(
   message?: ErrorMessage<Ipv6Issue<string>>
 ): Ipv6Action<string, ErrorMessage<Ipv6Issue<string>> | undefined> {

--- a/library/src/actions/isoDate/isoDate.ts
+++ b/library/src/actions/isoDate/isoDate.ts
@@ -95,6 +95,7 @@ export function isoDate<
   const TMessage extends ErrorMessage<IsoDateIssue<TInput>> | undefined,
 >(message: TMessage): IsoDateAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function isoDate(
   message?: ErrorMessage<IsoDateIssue<string>>
 ): IsoDateAction<string, ErrorMessage<IsoDateIssue<string>> | undefined> {

--- a/library/src/actions/isoDateTime/isoDateTime.ts
+++ b/library/src/actions/isoDateTime/isoDateTime.ts
@@ -96,6 +96,7 @@ export function isoDateTime<
   const TMessage extends ErrorMessage<IsoDateTimeIssue<TInput>> | undefined,
 >(message: TMessage): IsoDateTimeAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function isoDateTime(
   message?: ErrorMessage<IsoDateTimeIssue<string>>
 ): IsoDateTimeAction<

--- a/library/src/actions/isoTime/isoTime.ts
+++ b/library/src/actions/isoTime/isoTime.ts
@@ -87,6 +87,7 @@ export function isoTime<
   const TMessage extends ErrorMessage<IsoTimeIssue<TInput>> | undefined,
 >(message: TMessage): IsoTimeAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function isoTime(
   message?: ErrorMessage<IsoTimeIssue<string>>
 ): IsoTimeAction<string, ErrorMessage<IsoTimeIssue<string>> | undefined> {

--- a/library/src/actions/isoTimeSecond/isoTimeSecond.ts
+++ b/library/src/actions/isoTimeSecond/isoTimeSecond.ts
@@ -88,6 +88,7 @@ export function isoTimeSecond<
   const TMessage extends ErrorMessage<IsoTimeSecondIssue<TInput>> | undefined,
 >(message: TMessage): IsoTimeSecondAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function isoTimeSecond(
   message?: ErrorMessage<IsoTimeSecondIssue<string>>
 ): IsoTimeSecondAction<

--- a/library/src/actions/isoTimestamp/isoTimestamp.ts
+++ b/library/src/actions/isoTimestamp/isoTimestamp.ts
@@ -111,6 +111,7 @@ export function isoTimestamp<
   const TMessage extends ErrorMessage<IsoTimestampIssue<TInput>> | undefined,
 >(message: TMessage): IsoTimestampAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function isoTimestamp(
   message?: ErrorMessage<IsoTimestampIssue<string>>
 ): IsoTimestampAction<

--- a/library/src/actions/isoWeek/isoWeek.ts
+++ b/library/src/actions/isoWeek/isoWeek.ts
@@ -93,6 +93,7 @@ export function isoWeek<
   const TMessage extends ErrorMessage<IsoWeekIssue<TInput>> | undefined,
 >(message: TMessage): IsoWeekAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function isoWeek(
   message?: ErrorMessage<IsoWeekIssue<string>>
 ): IsoWeekAction<string, ErrorMessage<IsoWeekIssue<string>> | undefined> {

--- a/library/src/actions/length/length.ts
+++ b/library/src/actions/length/length.ts
@@ -96,6 +96,7 @@ export function length<
   message: TMessage
 ): LengthAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function length(
   requirement: number,
   message?: ErrorMessage<LengthIssue<LengthInput, number>>

--- a/library/src/actions/mac/mac.ts
+++ b/library/src/actions/mac/mac.ts
@@ -80,6 +80,7 @@ export function mac<
   const TMessage extends ErrorMessage<MacIssue<TInput>> | undefined,
 >(message: TMessage): MacAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function mac(
   message?: ErrorMessage<MacIssue<string>>
 ): MacAction<string, ErrorMessage<MacIssue<string>> | undefined> {

--- a/library/src/actions/mac48/mac48.ts
+++ b/library/src/actions/mac48/mac48.ts
@@ -80,6 +80,7 @@ export function mac48<
   const TMessage extends ErrorMessage<Mac48Issue<TInput>> | undefined,
 >(message: TMessage): Mac48Action<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function mac48(
   message?: ErrorMessage<Mac48Issue<string>>
 ): Mac48Action<string, ErrorMessage<Mac48Issue<string>> | undefined> {

--- a/library/src/actions/mac64/mac64.ts
+++ b/library/src/actions/mac64/mac64.ts
@@ -80,6 +80,7 @@ export function mac64<
   const TMessage extends ErrorMessage<Mac64Issue<TInput>> | undefined,
 >(message: TMessage): Mac64Action<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function mac64(
   message?: ErrorMessage<Mac64Issue<string>>
 ): Mac64Action<string, ErrorMessage<Mac64Issue<string>> | undefined> {

--- a/library/src/actions/mapItems/mapItems.ts
+++ b/library/src/actions/mapItems/mapItems.ts
@@ -40,6 +40,7 @@ export function mapItems<TInput extends ArrayInput, TOutput>(
   operation: ArrayAction<TInput, TOutput>
 ): MapItemsAction<TInput, TOutput>;
 
+// @__NO_SIDE_EFFECTS__
 export function mapItems(
   operation: ArrayAction<unknown[], unknown>
 ): MapItemsAction<unknown[], unknown> {

--- a/library/src/actions/maxBytes/maxBytes.ts
+++ b/library/src/actions/maxBytes/maxBytes.ts
@@ -97,6 +97,7 @@ export function maxBytes<
   message: TMessage
 ): MaxBytesAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function maxBytes(
   requirement: number,
   message?: ErrorMessage<MaxBytesIssue<string, number>>

--- a/library/src/actions/maxGraphemes/maxGraphemes.ts
+++ b/library/src/actions/maxGraphemes/maxGraphemes.ts
@@ -103,6 +103,7 @@ export function maxGraphemes<
   message: TMessage
 ): MaxGraphemesAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function maxGraphemes(
   requirement: number,
   message?: ErrorMessage<MaxGraphemesIssue<string, number>>

--- a/library/src/actions/maxLength/maxLength.ts
+++ b/library/src/actions/maxLength/maxLength.ts
@@ -98,6 +98,7 @@ export function maxLength<
   message: TMessage
 ): MaxLengthAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function maxLength(
   requirement: number,
   message?: ErrorMessage<MaxLengthIssue<LengthInput, number>>

--- a/library/src/actions/maxSize/maxSize.ts
+++ b/library/src/actions/maxSize/maxSize.ts
@@ -96,6 +96,7 @@ export function maxSize<
   message: TMessage
 ): MaxSizeAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function maxSize(
   requirement: number,
   message?: ErrorMessage<MaxSizeIssue<SizeInput, number>>

--- a/library/src/actions/maxValue/maxValue.ts
+++ b/library/src/actions/maxValue/maxValue.ts
@@ -94,6 +94,7 @@ export function maxValue<
   message: TMessage
 ): MaxValueAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function maxValue(
   requirement: ValueInput,
   message?: ErrorMessage<MaxValueIssue<ValueInput, ValueInput>>

--- a/library/src/actions/maxWords/maxWords.ts
+++ b/library/src/actions/maxWords/maxWords.ts
@@ -110,6 +110,7 @@ export function maxWords<
   message: TMessage
 ): MaxWordsAction<TInput, TLocales, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function maxWords(
   locales: Intl.LocalesArgument,
   requirement: number,

--- a/library/src/actions/metadata/metadata.ts
+++ b/library/src/actions/metadata/metadata.ts
@@ -28,6 +28,7 @@ export interface MetadataAction<
  *
  * @returns A metadata action.
  */
+// @__NO_SIDE_EFFECTS__
 export function metadata<
   TInput,
   const TMetadata extends Record<string, unknown>,

--- a/library/src/actions/mimeType/mimeType.ts
+++ b/library/src/actions/mimeType/mimeType.ts
@@ -102,6 +102,7 @@ export function mimeType<
   message: TMessage
 ): MimeTypeAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function mimeType(
   requirement: Requirement,
   message?: ErrorMessage<MimeTypeIssue<Blob, Requirement>>

--- a/library/src/actions/minBytes/minBytes.ts
+++ b/library/src/actions/minBytes/minBytes.ts
@@ -97,6 +97,7 @@ export function minBytes<
   message: TMessage
 ): MinBytesAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function minBytes(
   requirement: number,
   message?: ErrorMessage<MinBytesIssue<string, number>>

--- a/library/src/actions/minGraphemes/minGraphemes.ts
+++ b/library/src/actions/minGraphemes/minGraphemes.ts
@@ -103,6 +103,7 @@ export function minGraphemes<
   message: TMessage
 ): MinGraphemesAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function minGraphemes(
   requirement: number,
   message?: ErrorMessage<MinGraphemesIssue<string, number>>

--- a/library/src/actions/minLength/minLength.ts
+++ b/library/src/actions/minLength/minLength.ts
@@ -98,6 +98,7 @@ export function minLength<
   message: TMessage
 ): MinLengthAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function minLength(
   requirement: number,
   message?: ErrorMessage<MinLengthIssue<LengthInput, number>>

--- a/library/src/actions/minSize/minSize.ts
+++ b/library/src/actions/minSize/minSize.ts
@@ -96,6 +96,7 @@ export function minSize<
   message: TMessage
 ): MinSizeAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function minSize(
   requirement: number,
   message?: ErrorMessage<MinSizeIssue<SizeInput, number>>

--- a/library/src/actions/minValue/minValue.ts
+++ b/library/src/actions/minValue/minValue.ts
@@ -94,6 +94,7 @@ export function minValue<
   message: TMessage
 ): MinValueAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function minValue(
   requirement: ValueInput,
   message?: ErrorMessage<MinValueIssue<ValueInput, ValueInput>>

--- a/library/src/actions/minWords/minWords.ts
+++ b/library/src/actions/minWords/minWords.ts
@@ -110,6 +110,7 @@ export function minWords<
   message: TMessage
 ): MinWordsAction<TInput, TLocales, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function minWords(
   locales: Intl.LocalesArgument,
   requirement: number,

--- a/library/src/actions/multipleOf/multipleOf.ts
+++ b/library/src/actions/multipleOf/multipleOf.ts
@@ -101,6 +101,7 @@ export function multipleOf<
   message: TMessage
 ): MultipleOfAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function multipleOf(
   requirement: number,
   message?: ErrorMessage<MultipleOfIssue<number, number>>

--- a/library/src/actions/nanoid/nanoid.ts
+++ b/library/src/actions/nanoid/nanoid.ts
@@ -83,6 +83,7 @@ export function nanoid<
   const TMessage extends ErrorMessage<NanoIDIssue<TInput>> | undefined,
 >(message: TMessage): NanoIDAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function nanoid(
   message?: ErrorMessage<NanoIDIssue<string>>
 ): NanoIDAction<string, ErrorMessage<NanoIDIssue<string>> | undefined> {

--- a/library/src/actions/nonEmpty/nonEmpty.ts
+++ b/library/src/actions/nonEmpty/nonEmpty.ts
@@ -76,6 +76,7 @@ export function nonEmpty<
   const TMessage extends ErrorMessage<NonEmptyIssue<TInput>> | undefined,
 >(message: TMessage): NonEmptyAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function nonEmpty(
   message?: ErrorMessage<NonEmptyIssue<LengthInput>>
 ): NonEmptyAction<

--- a/library/src/actions/normalize/normalize.ts
+++ b/library/src/actions/normalize/normalize.ts
@@ -42,6 +42,7 @@ export function normalize<TForm extends NormalizeForm | undefined>(
   form: TForm
 ): NormalizeAction<TForm>;
 
+// @__NO_SIDE_EFFECTS__
 export function normalize(
   form?: NormalizeForm
 ): NormalizeAction<NormalizeForm | undefined> {

--- a/library/src/actions/notBytes/notBytes.ts
+++ b/library/src/actions/notBytes/notBytes.ts
@@ -97,6 +97,7 @@ export function notBytes<
   message: TMessage
 ): NotBytesAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function notBytes(
   requirement: number,
   message?: ErrorMessage<NotBytesIssue<string, number>>

--- a/library/src/actions/notGraphemes/notGraphemes.ts
+++ b/library/src/actions/notGraphemes/notGraphemes.ts
@@ -103,6 +103,7 @@ export function notGraphemes<
   message: TMessage
 ): NotGraphemesAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function notGraphemes(
   requirement: number,
   message?: ErrorMessage<NotGraphemesIssue<string, number>>

--- a/library/src/actions/notLength/notLength.ts
+++ b/library/src/actions/notLength/notLength.ts
@@ -98,6 +98,7 @@ export function notLength<
   message: TMessage
 ): NotLengthAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function notLength(
   requirement: number,
   message?: ErrorMessage<NotLengthIssue<LengthInput, number>>

--- a/library/src/actions/notSize/notSize.ts
+++ b/library/src/actions/notSize/notSize.ts
@@ -96,6 +96,7 @@ export function notSize<
   message: TMessage
 ): NotSizeAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function notSize(
   requirement: number,
   message?: ErrorMessage<NotSizeIssue<SizeInput, number>>

--- a/library/src/actions/notValue/notValue.ts
+++ b/library/src/actions/notValue/notValue.ts
@@ -94,6 +94,7 @@ export function notValue<
   message: TMessage
 ): NotValueAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function notValue(
   requirement: ValueInput,
   message?: ErrorMessage<NotValueIssue<ValueInput, ValueInput>>

--- a/library/src/actions/notWords/notWords.ts
+++ b/library/src/actions/notWords/notWords.ts
@@ -110,6 +110,7 @@ export function notWords<
   message: TMessage
 ): NotWordsAction<TInput, TLocales, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function notWords(
   locales: Intl.LocalesArgument,
   requirement: number,

--- a/library/src/actions/octal/octal.ts
+++ b/library/src/actions/octal/octal.ts
@@ -80,6 +80,7 @@ export function octal<
   const TMessage extends ErrorMessage<OctalIssue<TInput>> | undefined,
 >(message: TMessage): OctalAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function octal(
   message?: ErrorMessage<OctalIssue<string>>
 ): OctalAction<string, ErrorMessage<OctalIssue<string>> | undefined> {

--- a/library/src/actions/partialCheck/partialCheck.ts
+++ b/library/src/actions/partialCheck/partialCheck.ts
@@ -82,6 +82,7 @@ export function partialCheck<
   message: TMessage
 ): PartialCheckAction<TInput, TPathList, TSelection, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function partialCheck(
   pathList: PathKeys<PartialInput>[],
   requirement: (input: PartialInput) => boolean,

--- a/library/src/actions/partialCheck/partialCheckAsync.ts
+++ b/library/src/actions/partialCheck/partialCheckAsync.ts
@@ -83,6 +83,7 @@ export function partialCheckAsync<
   message: TMessage
 ): PartialCheckActionAsync<TInput, TPathList, TSelection, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function partialCheckAsync(
   pathList: PathKeys<PartialInput>[],
   requirement: (input: PartialInput) => MaybePromise<boolean>,

--- a/library/src/actions/partialCheck/utils/_isPartiallyTyped/_isPartiallyTyped.ts
+++ b/library/src/actions/partialCheck/utils/_isPartiallyTyped/_isPartiallyTyped.ts
@@ -8,6 +8,7 @@ import type { BaseIssue, OutputDataset } from '../../../../types/index.ts';
  *
  * @returns Whether it is partially typed.
  */
+// @__NO_SIDE_EFFECTS__
 export function _isPartiallyTyped(
   dataset: OutputDataset<unknown, BaseIssue<unknown>>,
   pathList: readonly (readonly (string | number)[])[]

--- a/library/src/actions/rawCheck/rawCheck.ts
+++ b/library/src/actions/rawCheck/rawCheck.ts
@@ -27,6 +27,8 @@ export interface RawCheckAction<TInput>
  * @param action The validation action.
  *
  * @returns A raw check action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function rawCheck<TInput>(
   action: (context: Context<TInput>) => void

--- a/library/src/actions/rawCheck/rawCheck.ts
+++ b/library/src/actions/rawCheck/rawCheck.ts
@@ -27,9 +27,8 @@ export interface RawCheckAction<TInput>
  * @param action The validation action.
  *
  * @returns A raw check action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function rawCheck<TInput>(
   action: (context: Context<TInput>) => void
 ): RawCheckAction<TInput> {

--- a/library/src/actions/rawCheck/rawCheckAsync.ts
+++ b/library/src/actions/rawCheck/rawCheckAsync.ts
@@ -27,6 +27,8 @@ export interface RawCheckActionAsync<TInput>
  * @param action The validation action.
  *
  * @returns A raw check action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function rawCheckAsync<TInput>(
   action: (context: Context<TInput>) => MaybePromise<void>

--- a/library/src/actions/rawCheck/rawCheckAsync.ts
+++ b/library/src/actions/rawCheck/rawCheckAsync.ts
@@ -27,9 +27,8 @@ export interface RawCheckActionAsync<TInput>
  * @param action The validation action.
  *
  * @returns A raw check action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function rawCheckAsync<TInput>(
   action: (context: Context<TInput>) => MaybePromise<void>
 ): RawCheckActionAsync<TInput> {

--- a/library/src/actions/rawTransform/rawTransform.ts
+++ b/library/src/actions/rawTransform/rawTransform.ts
@@ -27,9 +27,8 @@ export interface RawTransformAction<TInput, TOutput>
  * @param action The transformation action.
  *
  * @returns A raw transform action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function rawTransform<TInput, TOutput>(
   action: (context: Context<TInput>) => TOutput
 ): RawTransformAction<TInput, TOutput> {

--- a/library/src/actions/rawTransform/rawTransform.ts
+++ b/library/src/actions/rawTransform/rawTransform.ts
@@ -27,6 +27,8 @@ export interface RawTransformAction<TInput, TOutput>
  * @param action The transformation action.
  *
  * @returns A raw transform action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function rawTransform<TInput, TOutput>(
   action: (context: Context<TInput>) => TOutput

--- a/library/src/actions/rawTransform/rawTransformAsync.ts
+++ b/library/src/actions/rawTransform/rawTransformAsync.ts
@@ -28,9 +28,8 @@ export interface RawTransformActionAsync<TInput, TOutput>
  * @param action The transformation action.
  *
  * @returns A raw transform action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function rawTransformAsync<TInput, TOutput>(
   action: (context: Context<TInput>) => MaybePromise<TOutput>
 ): RawTransformActionAsync<TInput, TOutput> {

--- a/library/src/actions/rawTransform/rawTransformAsync.ts
+++ b/library/src/actions/rawTransform/rawTransformAsync.ts
@@ -28,6 +28,8 @@ export interface RawTransformActionAsync<TInput, TOutput>
  * @param action The transformation action.
  *
  * @returns A raw transform action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function rawTransformAsync<TInput, TOutput>(
   action: (context: Context<TInput>) => MaybePromise<TOutput>

--- a/library/src/actions/readonly/readonly.ts
+++ b/library/src/actions/readonly/readonly.ts
@@ -19,6 +19,8 @@ export interface ReadonlyAction<TInput>
  * Creates a readonly transformation action.
  *
  * @returns A readonly action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function readonly<TInput>(): ReadonlyAction<TInput> {
   return {

--- a/library/src/actions/readonly/readonly.ts
+++ b/library/src/actions/readonly/readonly.ts
@@ -19,9 +19,8 @@ export interface ReadonlyAction<TInput>
  * Creates a readonly transformation action.
  *
  * @returns A readonly action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function readonly<TInput>(): ReadonlyAction<TInput> {
   return {
     kind: 'transformation',

--- a/library/src/actions/reduceItems/reduceItems.ts
+++ b/library/src/actions/reduceItems/reduceItems.ts
@@ -47,6 +47,7 @@ export function reduceItems<TInput extends ArrayInput, TOutput>(
   initial: TOutput
 ): ReduceItemsAction<TInput, TOutput>;
 
+// @__NO_SIDE_EFFECTS__
 export function reduceItems(
   operation: ArrayAction<unknown[], unknown>,
   initial: unknown

--- a/library/src/actions/regex/regex.ts
+++ b/library/src/actions/regex/regex.ts
@@ -84,6 +84,7 @@ export function regex<
   const TMessage extends ErrorMessage<RegexIssue<TInput>> | undefined,
 >(requirement: RegExp, message: TMessage): RegexAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function regex(
   requirement: RegExp,
   message?: ErrorMessage<RegexIssue<string>>

--- a/library/src/actions/returns/returns.ts
+++ b/library/src/actions/returns/returns.ts
@@ -49,6 +49,7 @@ export function returns<
   TSchema extends BaseSchema<unknown, unknown, BaseIssue<unknown>>,
 >(schema: TSchema): ReturnsAction<TInput, TSchema>;
 
+// @__NO_SIDE_EFFECTS__
 export function returns(
   schema: BaseSchema<unknown, unknown, BaseIssue<unknown>>
 ): ReturnsAction<

--- a/library/src/actions/returns/returnsAsync.ts
+++ b/library/src/actions/returns/returnsAsync.ts
@@ -55,6 +55,7 @@ export function returnsAsync<
     | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
 >(schema: TSchema): ReturnsActionAsync<TInput, TSchema>;
 
+// @__NO_SIDE_EFFECTS__
 export function returnsAsync(
   schema:
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/actions/safeInteger/safeInteger.ts
+++ b/library/src/actions/safeInteger/safeInteger.ts
@@ -83,6 +83,7 @@ export function safeInteger<
   const TMessage extends ErrorMessage<SafeIntegerIssue<TInput>> | undefined,
 >(message: TMessage): SafeIntegerAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function safeInteger(
   message?: ErrorMessage<SafeIntegerIssue<number>>
 ): SafeIntegerAction<

--- a/library/src/actions/size/size.ts
+++ b/library/src/actions/size/size.ts
@@ -96,6 +96,7 @@ export function size<
   message: TMessage
 ): SizeAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function size(
   requirement: number,
   message?: ErrorMessage<SizeIssue<SizeInput, number>>

--- a/library/src/actions/someItem/someItem.ts
+++ b/library/src/actions/someItem/someItem.ts
@@ -85,6 +85,7 @@ export function someItem<
   message: TMessage
 ): SomeItemAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function someItem(
   requirement: ArrayRequirement<unknown[]>,
   message?: ErrorMessage<SomeItemIssue<unknown[]>>

--- a/library/src/actions/sortItems/sortItems.ts
+++ b/library/src/actions/sortItems/sortItems.ts
@@ -39,6 +39,7 @@ export function sortItems<TInput extends ArrayInput>(
   operation?: ArrayAction<TInput>
 ): SortItemsAction<TInput>;
 
+// @__NO_SIDE_EFFECTS__
 export function sortItems(
   operation?: ArrayAction<unknown[]>
 ): SortItemsAction<unknown[]> {

--- a/library/src/actions/startsWith/startsWith.ts
+++ b/library/src/actions/startsWith/startsWith.ts
@@ -101,6 +101,7 @@ export function startsWith<
   message: TMessage
 ): StartsWithAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function startsWith(
   requirement: string,
   message?: ErrorMessage<StartsWithIssue<string, string>>

--- a/library/src/actions/title/title.ts
+++ b/library/src/actions/title/title.ts
@@ -25,9 +25,8 @@ export interface TitleAction<TInput, TTitle extends string>
  * @param title_ The title text.
  *
  * @returns A title action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function title<TInput, TTitle extends string>(
   title_: TTitle
 ): TitleAction<TInput, TTitle> {

--- a/library/src/actions/title/title.ts
+++ b/library/src/actions/title/title.ts
@@ -25,6 +25,8 @@ export interface TitleAction<TInput, TTitle extends string>
  * @param title_ The title text.
  *
  * @returns A title action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function title<TInput, TTitle extends string>(
   title_: TTitle

--- a/library/src/actions/toLowerCase/toLowerCase.ts
+++ b/library/src/actions/toLowerCase/toLowerCase.ts
@@ -19,6 +19,8 @@ export interface ToLowerCaseAction
  * Creates a to lower case transformation action.
  *
  * @returns A to lower case action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function toLowerCase(): ToLowerCaseAction {
   return {

--- a/library/src/actions/toLowerCase/toLowerCase.ts
+++ b/library/src/actions/toLowerCase/toLowerCase.ts
@@ -19,9 +19,8 @@ export interface ToLowerCaseAction
  * Creates a to lower case transformation action.
  *
  * @returns A to lower case action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function toLowerCase(): ToLowerCaseAction {
   return {
     kind: 'transformation',

--- a/library/src/actions/toMaxValue/toMaxValue.ts
+++ b/library/src/actions/toMaxValue/toMaxValue.ts
@@ -28,9 +28,8 @@ export interface ToMaxValueAction<
  * @param requirement The maximum value.
  *
  * @returns A to max value action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function toMaxValue<
   TInput extends ValueInput,
   const TRequirement extends TInput,

--- a/library/src/actions/toMaxValue/toMaxValue.ts
+++ b/library/src/actions/toMaxValue/toMaxValue.ts
@@ -28,6 +28,8 @@ export interface ToMaxValueAction<
  * @param requirement The maximum value.
  *
  * @returns A to max value action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function toMaxValue<
   TInput extends ValueInput,

--- a/library/src/actions/toMinValue/toMinValue.ts
+++ b/library/src/actions/toMinValue/toMinValue.ts
@@ -28,9 +28,8 @@ export interface ToMinValueAction<
  * @param requirement The minimum value.
  *
  * @returns A to min value action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function toMinValue<
   TInput extends ValueInput,
   const TRequirement extends TInput,

--- a/library/src/actions/toMinValue/toMinValue.ts
+++ b/library/src/actions/toMinValue/toMinValue.ts
@@ -28,6 +28,8 @@ export interface ToMinValueAction<
  * @param requirement The minimum value.
  *
  * @returns A to min value action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function toMinValue<
   TInput extends ValueInput,

--- a/library/src/actions/toUpperCase/toUpperCase.ts
+++ b/library/src/actions/toUpperCase/toUpperCase.ts
@@ -19,6 +19,8 @@ export interface ToUpperCaseAction
  * Creates a to upper case transformation action.
  *
  * @returns A to upper case action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function toUpperCase(): ToUpperCaseAction {
   return {

--- a/library/src/actions/toUpperCase/toUpperCase.ts
+++ b/library/src/actions/toUpperCase/toUpperCase.ts
@@ -19,9 +19,8 @@ export interface ToUpperCaseAction
  * Creates a to upper case transformation action.
  *
  * @returns A to upper case action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function toUpperCase(): ToUpperCaseAction {
   return {
     kind: 'transformation',

--- a/library/src/actions/transform/transform.ts
+++ b/library/src/actions/transform/transform.ts
@@ -25,6 +25,8 @@ export interface TransformAction<TInput, TOutput>
  * @param operation The transformation operation.
  *
  * @returns A transform action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function transform<TInput, TOutput>(
   operation: (input: TInput) => TOutput

--- a/library/src/actions/transform/transform.ts
+++ b/library/src/actions/transform/transform.ts
@@ -25,9 +25,8 @@ export interface TransformAction<TInput, TOutput>
  * @param operation The transformation operation.
  *
  * @returns A transform action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function transform<TInput, TOutput>(
   operation: (input: TInput) => TOutput
 ): TransformAction<TInput, TOutput> {

--- a/library/src/actions/transform/transformAsync.ts
+++ b/library/src/actions/transform/transformAsync.ts
@@ -28,9 +28,8 @@ export interface TransformActionAsync<TInput, TOutput>
  * @param operation The transformation operation.
  *
  * @returns A transform action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function transformAsync<TInput, TOutput>(
   operation: (input: TInput) => Promise<TOutput>
 ): TransformActionAsync<TInput, TOutput> {

--- a/library/src/actions/transform/transformAsync.ts
+++ b/library/src/actions/transform/transformAsync.ts
@@ -28,6 +28,8 @@ export interface TransformActionAsync<TInput, TOutput>
  * @param operation The transformation operation.
  *
  * @returns A transform action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function transformAsync<TInput, TOutput>(
   operation: (input: TInput) => Promise<TOutput>

--- a/library/src/actions/trim/trim.ts
+++ b/library/src/actions/trim/trim.ts
@@ -18,6 +18,8 @@ export interface TrimAction extends BaseTransformation<string, string, never> {
  * Creates a trim transformation action.
  *
  * @returns A trim action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function trim(): TrimAction {
   return {

--- a/library/src/actions/trim/trim.ts
+++ b/library/src/actions/trim/trim.ts
@@ -18,9 +18,8 @@ export interface TrimAction extends BaseTransformation<string, string, never> {
  * Creates a trim transformation action.
  *
  * @returns A trim action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function trim(): TrimAction {
   return {
     kind: 'transformation',

--- a/library/src/actions/trimEnd/trimEnd.ts
+++ b/library/src/actions/trimEnd/trimEnd.ts
@@ -19,9 +19,8 @@ export interface TrimEndAction
  * Creates a trim end transformation action.
  *
  * @returns A trim end action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function trimEnd(): TrimEndAction {
   return {
     kind: 'transformation',

--- a/library/src/actions/trimEnd/trimEnd.ts
+++ b/library/src/actions/trimEnd/trimEnd.ts
@@ -19,6 +19,8 @@ export interface TrimEndAction
  * Creates a trim end transformation action.
  *
  * @returns A trim end action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function trimEnd(): TrimEndAction {
   return {

--- a/library/src/actions/trimStart/trimStart.ts
+++ b/library/src/actions/trimStart/trimStart.ts
@@ -20,6 +20,7 @@ export interface TrimStartAction
  *
  * @returns A trim start action.
  */
+// @__NO_SIDE_EFFECTS__
 export function trimStart(): TrimStartAction {
   return {
     kind: 'transformation',

--- a/library/src/actions/ulid/ulid.ts
+++ b/library/src/actions/ulid/ulid.ts
@@ -80,6 +80,7 @@ export function ulid<
   const TMessage extends ErrorMessage<UlidIssue<TInput>> | undefined,
 >(message: TMessage): UlidAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function ulid(
   message?: ErrorMessage<UlidIssue<string>>
 ): UlidAction<string, ErrorMessage<UlidIssue<string>> | undefined> {

--- a/library/src/actions/url/url.ts
+++ b/library/src/actions/url/url.ts
@@ -85,6 +85,7 @@ export function url<
   const TMessage extends ErrorMessage<UrlIssue<TInput>> | undefined,
 >(message: TMessage): UrlAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function url(
   message?: ErrorMessage<UrlIssue<string>> | undefined
 ): UrlAction<string, ErrorMessage<UrlIssue<string>> | undefined> {

--- a/library/src/actions/uuid/uuid.ts
+++ b/library/src/actions/uuid/uuid.ts
@@ -80,6 +80,7 @@ export function uuid<
   const TMessage extends ErrorMessage<UuidIssue<TInput>> | undefined,
 >(message: TMessage): UuidAction<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function uuid(
   message?: ErrorMessage<UuidIssue<string>>
 ): UuidAction<string, ErrorMessage<UuidIssue<string>> | undefined> {

--- a/library/src/actions/value/value.ts
+++ b/library/src/actions/value/value.ts
@@ -92,6 +92,7 @@ export function value<
   message: TMessage
 ): ValueAction<TInput, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function value(
   requirement: ValueInput,
   message?: ErrorMessage<ValueIssue<ValueInput, ValueInput>>

--- a/library/src/actions/words/words.ts
+++ b/library/src/actions/words/words.ts
@@ -106,6 +106,7 @@ export function words<
   message: TMessage
 ): WordsAction<TInput, TLocales, TRequirement, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function words(
   locales: Intl.LocalesArgument,
   requirement: number,

--- a/library/src/methods/assert/assert.ts
+++ b/library/src/methods/assert/assert.ts
@@ -7,6 +7,8 @@ import { ValiError } from '../../utils/index.ts';
  *
  * @param schema The schema to be used.
  * @param input The input to be tested.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function assert<
   const TSchema extends BaseSchema<unknown, unknown, BaseIssue<unknown>>,

--- a/library/src/methods/assert/assert.ts
+++ b/library/src/methods/assert/assert.ts
@@ -7,9 +7,8 @@ import { ValiError } from '../../utils/index.ts';
  *
  * @param schema The schema to be used.
  * @param input The input to be tested.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function assert<
   const TSchema extends BaseSchema<unknown, unknown, BaseIssue<unknown>>,
 >(schema: TSchema, input: unknown): asserts input is InferInput<TSchema> {

--- a/library/src/methods/config/config.ts
+++ b/library/src/methods/config/config.ts
@@ -14,9 +14,8 @@ import { _getStandardProps } from '../../utils/index.ts';
  * @param config The parse configuration.
  *
  * @returns The configured schema.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function config<
   const TSchema extends
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/methods/config/config.ts
+++ b/library/src/methods/config/config.ts
@@ -14,6 +14,8 @@ import { _getStandardProps } from '../../utils/index.ts';
  * @param config The parse configuration.
  *
  * @returns The configured schema.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function config<
   const TSchema extends

--- a/library/src/methods/fallback/fallback.ts
+++ b/library/src/methods/fallback/fallback.ts
@@ -41,9 +41,8 @@ export type SchemaWithFallback<
  * @param fallback The fallback value.
  *
  * @returns The passed schema.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function fallback<
   const TSchema extends BaseSchema<unknown, unknown, BaseIssue<unknown>>,
   const TFallback extends Fallback<TSchema>,

--- a/library/src/methods/fallback/fallback.ts
+++ b/library/src/methods/fallback/fallback.ts
@@ -41,6 +41,8 @@ export type SchemaWithFallback<
  * @param fallback The fallback value.
  *
  * @returns The passed schema.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function fallback<
   const TSchema extends BaseSchema<unknown, unknown, BaseIssue<unknown>>,

--- a/library/src/methods/fallback/fallbackAsync.ts
+++ b/library/src/methods/fallback/fallbackAsync.ts
@@ -77,6 +77,8 @@ export type SchemaWithFallbackAsync<
  * @param fallback The fallback value.
  *
  * @returns The passed schema.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function fallbackAsync<
   const TSchema extends

--- a/library/src/methods/fallback/fallbackAsync.ts
+++ b/library/src/methods/fallback/fallbackAsync.ts
@@ -77,9 +77,8 @@ export type SchemaWithFallbackAsync<
  * @param fallback The fallback value.
  *
  * @returns The passed schema.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function fallbackAsync<
   const TSchema extends
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/methods/flatten/flatten.ts
+++ b/library/src/methods/flatten/flatten.ts
@@ -79,6 +79,7 @@ export function flatten<
     | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
 >(issues: [InferIssue<TSchema>, ...InferIssue<TSchema>[]]): FlatErrors<TSchema>;
 
+// @__NO_SIDE_EFFECTS__
 export function flatten(
   issues: [BaseIssue<unknown>, ...BaseIssue<unknown>[]]
 ): FlatErrors<undefined> {

--- a/library/src/methods/forward/forward.ts
+++ b/library/src/methods/forward/forward.ts
@@ -19,9 +19,8 @@ import type {
  * @param pathKeys The path keys.
  *
  * @returns The modified action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function forward<
   TInput extends Record<string, unknown> | ArrayLike<unknown>,
   TIssue extends BaseIssue<unknown>,

--- a/library/src/methods/forward/forward.ts
+++ b/library/src/methods/forward/forward.ts
@@ -19,6 +19,8 @@ import type {
  * @param pathKeys The path keys.
  *
  * @returns The modified action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function forward<
   TInput extends Record<string, unknown> | ArrayLike<unknown>,

--- a/library/src/methods/forward/forwardAsync.ts
+++ b/library/src/methods/forward/forwardAsync.ts
@@ -20,6 +20,8 @@ import type {
  * @param pathKeys The path keys.
  *
  * @returns The modified action.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function forwardAsync<
   TInput extends Record<string, unknown> | ArrayLike<unknown>,

--- a/library/src/methods/forward/forwardAsync.ts
+++ b/library/src/methods/forward/forwardAsync.ts
@@ -20,9 +20,8 @@ import type {
  * @param pathKeys The path keys.
  *
  * @returns The modified action.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function forwardAsync<
   TInput extends Record<string, unknown> | ArrayLike<unknown>,
   TIssue extends BaseIssue<unknown>,

--- a/library/src/methods/getDefault/getDefault.ts
+++ b/library/src/methods/getDefault/getDefault.ts
@@ -105,9 +105,8 @@ export type InferDefault<
  * @param config The config if available.
  *
  * @returns The default value.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function getDefault<
   const TSchema extends
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/methods/getDefault/getDefault.ts
+++ b/library/src/methods/getDefault/getDefault.ts
@@ -105,6 +105,8 @@ export type InferDefault<
  * @param config The config if available.
  *
  * @returns The default value.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function getDefault<
   const TSchema extends

--- a/library/src/methods/getDefaults/getDefaults.ts
+++ b/library/src/methods/getDefaults/getDefaults.ts
@@ -36,9 +36,8 @@ import type { InferDefaults } from './types.ts';
  * @param schema The schema to get them from.
  *
  * @returns The default values.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function getDefaults<
   const TSchema extends
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/methods/getDefaults/getDefaults.ts
+++ b/library/src/methods/getDefaults/getDefaults.ts
@@ -36,6 +36,8 @@ import type { InferDefaults } from './types.ts';
  * @param schema The schema to get them from.
  *
  * @returns The default values.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function getDefaults<
   const TSchema extends

--- a/library/src/methods/getDefaults/getDefaultsAsync.ts
+++ b/library/src/methods/getDefaults/getDefaultsAsync.ts
@@ -48,6 +48,7 @@ import type { InferDefaults } from './types.ts';
  *
  * @returns The default values.
  */
+// @__NO_SIDE_EFFECTS__
 export async function getDefaultsAsync<
   const TSchema extends
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/methods/getFallback/getFallback.ts
+++ b/library/src/methods/getFallback/getFallback.ts
@@ -46,6 +46,7 @@ export type InferFallback<
  *
  * @returns The fallback value.
  */
+// @__NO_SIDE_EFFECTS__
 export function getFallback<
   const TSchema extends
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/methods/getFallbacks/getFallbacks.ts
+++ b/library/src/methods/getFallbacks/getFallbacks.ts
@@ -36,9 +36,8 @@ import type { InferFallbacks } from './types.ts';
  * @param schema The schema to get them from.
  *
  * @returns The fallback values.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function getFallbacks<
   const TSchema extends
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/methods/getFallbacks/getFallbacks.ts
+++ b/library/src/methods/getFallbacks/getFallbacks.ts
@@ -36,6 +36,8 @@ import type { InferFallbacks } from './types.ts';
  * @param schema The schema to get them from.
  *
  * @returns The fallback values.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function getFallbacks<
   const TSchema extends

--- a/library/src/methods/getFallbacks/getFallbacksAsync.ts
+++ b/library/src/methods/getFallbacks/getFallbacksAsync.ts
@@ -48,6 +48,7 @@ import type { InferFallbacks } from './types.ts';
  *
  * @returns The fallback values.
  */
+// @__NO_SIDE_EFFECTS__
 export async function getFallbacksAsync<
   const TSchema extends
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/methods/is/is.ts
+++ b/library/src/methods/is/is.ts
@@ -8,9 +8,8 @@ import type { BaseIssue, BaseSchema, InferInput } from '../../types/index.ts';
  * @param input The input to be tested.
  *
  * @returns Whether the input matches the schema.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function is<
   const TSchema extends BaseSchema<unknown, unknown, BaseIssue<unknown>>,
 >(schema: TSchema, input: unknown): input is InferInput<TSchema> {

--- a/library/src/methods/is/is.ts
+++ b/library/src/methods/is/is.ts
@@ -8,6 +8,8 @@ import type { BaseIssue, BaseSchema, InferInput } from '../../types/index.ts';
  * @param input The input to be tested.
  *
  * @returns Whether the input matches the schema.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function is<
   const TSchema extends BaseSchema<unknown, unknown, BaseIssue<unknown>>,

--- a/library/src/methods/keyof/keyof.ts
+++ b/library/src/methods/keyof/keyof.ts
@@ -93,6 +93,7 @@ export function keyof<
   message: TMessage
 ): PicklistSchema<ObjectKeys<TSchema>, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function keyof(
   schema: Schema,
   message?: ErrorMessage<PicklistIssue>

--- a/library/src/methods/omit/omit.ts
+++ b/library/src/methods/omit/omit.ts
@@ -462,9 +462,8 @@ export type SchemaWithOmit<
  * @param keys The selected entries.
  *
  * @returns An object schema.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function omit<
   const TSchema extends Schema,
   const TKeys extends ObjectKeys<TSchema>,

--- a/library/src/methods/omit/omit.ts
+++ b/library/src/methods/omit/omit.ts
@@ -462,6 +462,8 @@ export type SchemaWithOmit<
  * @param keys The selected entries.
  *
  * @returns An object schema.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function omit<
   const TSchema extends Schema,

--- a/library/src/methods/parse/parse.ts
+++ b/library/src/methods/parse/parse.ts
@@ -16,9 +16,8 @@ import { ValiError } from '../../utils/index.ts';
  * @param config The parse configuration.
  *
  * @returns The parsed input.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function parse<
   const TSchema extends BaseSchema<unknown, unknown, BaseIssue<unknown>>,
 >(

--- a/library/src/methods/parse/parse.ts
+++ b/library/src/methods/parse/parse.ts
@@ -16,6 +16,8 @@ import { ValiError } from '../../utils/index.ts';
  * @param config The parse configuration.
  *
  * @returns The parsed input.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function parse<
   const TSchema extends BaseSchema<unknown, unknown, BaseIssue<unknown>>,

--- a/library/src/methods/parse/parseAsync.ts
+++ b/library/src/methods/parse/parseAsync.ts
@@ -18,6 +18,7 @@ import { ValiError } from '../../utils/index.ts';
  *
  * @returns The parsed input.
  */
+// @__NO_SIDE_EFFECTS__
 export async function parseAsync<
   const TSchema extends
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/methods/parser/parser.ts
+++ b/library/src/methods/parser/parser.ts
@@ -52,6 +52,7 @@ export function parser<
   const TConfig extends Config<InferIssue<TSchema>> | undefined,
 >(schema: TSchema, config: TConfig): Parser<TSchema, TConfig>;
 
+// @__NO_SIDE_EFFECTS__
 export function parser(
   schema: BaseSchema<unknown, unknown, BaseIssue<unknown>>,
   config?: Config<InferIssue<BaseSchema<unknown, unknown, BaseIssue<unknown>>>>

--- a/library/src/methods/parser/parserAsync.ts
+++ b/library/src/methods/parser/parserAsync.ts
@@ -59,6 +59,7 @@ export function parserAsync<
   const TConfig extends Config<InferIssue<TSchema>> | undefined,
 >(schema: TSchema, config: TConfig): ParserAsync<TSchema, TConfig>;
 
+// @__NO_SIDE_EFFECTS__
 export function parserAsync(
   schema:
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/methods/partial/partial.ts
+++ b/library/src/methods/partial/partial.ts
@@ -266,6 +266,7 @@ export function partial<
   const TKeys extends ObjectKeys<TSchema>,
 >(schema: TSchema, keys: TKeys): SchemaWithPartial<TSchema, TKeys>;
 
+// @__NO_SIDE_EFFECTS__
 export function partial(
   schema: Schema,
   keys?: ObjectKeys<Schema>

--- a/library/src/methods/partial/partialAsync.ts
+++ b/library/src/methods/partial/partialAsync.ts
@@ -277,6 +277,7 @@ export function partialAsync<
   const TKeys extends ObjectKeys<TSchema>,
 >(schema: TSchema, keys: TKeys): SchemaWithPartialAsync<TSchema, TKeys>;
 
+// @__NO_SIDE_EFFECTS__
 export function partialAsync(
   schema: Schema,
   keys?: ObjectKeys<Schema>

--- a/library/src/methods/pick/pick.ts
+++ b/library/src/methods/pick/pick.ts
@@ -462,6 +462,8 @@ export type SchemaWithPick<
  * @param keys The selected entries.
  *
  * @returns An object schema.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function pick<
   const TSchema extends Schema,

--- a/library/src/methods/pick/pick.ts
+++ b/library/src/methods/pick/pick.ts
@@ -462,9 +462,8 @@ export type SchemaWithPick<
  * @param keys The selected entries.
  *
  * @returns An object schema.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function pick<
   const TSchema extends Schema,
   const TKeys extends ObjectKeys<TSchema>,

--- a/library/src/methods/pipe/pipe.ts
+++ b/library/src/methods/pipe/pipe.ts
@@ -2666,6 +2666,7 @@ export function pipe<
   >[],
 >(schema: TSchema, ...items: TItems): SchemaWithPipe<[TSchema, ...TItems]>;
 
+// @__NO_SIDE_EFFECTS__
 export function pipe<
   const TSchema extends BaseSchema<unknown, unknown, BaseIssue<unknown>>,
   const TItems extends PipeItem<unknown, unknown, BaseIssue<unknown>>[],

--- a/library/src/methods/pipe/pipeAsync.ts
+++ b/library/src/methods/pipe/pipeAsync.ts
@@ -3051,6 +3051,7 @@ export function pipeAsync<
   )[],
 >(schema: TSchema, ...items: TItems): SchemaWithPipeAsync<[TSchema, ...TItems]>;
 
+// @__NO_SIDE_EFFECTS__
 export function pipeAsync<
   const TSchema extends
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/methods/required/required.ts
+++ b/library/src/methods/required/required.ts
@@ -311,6 +311,7 @@ export function required<
   message: TMessage
 ): SchemaWithRequired<TSchema, TKeys, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function required(
   schema: Schema,
   arg2?: ErrorMessage<NonOptionalIssue> | ObjectKeys<Schema>,

--- a/library/src/methods/required/requiredAsync.ts
+++ b/library/src/methods/required/requiredAsync.ts
@@ -325,6 +325,7 @@ export function requiredAsync<
   message: TMessage
 ): SchemaWithRequiredAsync<TSchema, TKeys, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function requiredAsync(
   schema: Schema,
   arg2?: ErrorMessage<NonOptionalIssue> | ObjectKeys<Schema>,

--- a/library/src/methods/safeParse/safeParse.ts
+++ b/library/src/methods/safeParse/safeParse.ts
@@ -15,6 +15,8 @@ import type { SafeParseResult } from './types.ts';
  * @param config The parse configuration.
  *
  * @returns The parse result.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function safeParse<
   const TSchema extends BaseSchema<unknown, unknown, BaseIssue<unknown>>,

--- a/library/src/methods/safeParse/safeParse.ts
+++ b/library/src/methods/safeParse/safeParse.ts
@@ -15,9 +15,8 @@ import type { SafeParseResult } from './types.ts';
  * @param config The parse configuration.
  *
  * @returns The parse result.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function safeParse<
   const TSchema extends BaseSchema<unknown, unknown, BaseIssue<unknown>>,
 >(

--- a/library/src/methods/safeParse/safeParseAsync.ts
+++ b/library/src/methods/safeParse/safeParseAsync.ts
@@ -17,6 +17,7 @@ import type { SafeParseResult } from './types.ts';
  *
  * @returns The parse result.
  */
+// @__NO_SIDE_EFFECTS__
 export async function safeParseAsync<
   const TSchema extends
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/methods/safeParser/safeParser.ts
+++ b/library/src/methods/safeParser/safeParser.ts
@@ -51,6 +51,7 @@ export function safeParser<
   const TConfig extends Config<InferIssue<TSchema>> | undefined,
 >(schema: TSchema, config: TConfig): SafeParser<TSchema, TConfig>;
 
+// @__NO_SIDE_EFFECTS__
 export function safeParser(
   schema: BaseSchema<unknown, unknown, BaseIssue<unknown>>,
   config?: Config<InferIssue<BaseSchema<unknown, unknown, BaseIssue<unknown>>>>

--- a/library/src/methods/safeParser/safeParserAsync.ts
+++ b/library/src/methods/safeParser/safeParserAsync.ts
@@ -58,6 +58,7 @@ export function safeParserAsync<
   const TConfig extends Config<InferIssue<TSchema>> | undefined,
 >(schema: TSchema, config: TConfig): SafeParserAsync<TSchema, TConfig>;
 
+// @__NO_SIDE_EFFECTS__
 export function safeParserAsync(
   schema:
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/methods/unwrap/unwrap.ts
+++ b/library/src/methods/unwrap/unwrap.ts
@@ -30,6 +30,8 @@ import type {
  * @param schema The schema to be unwrapped.
  *
  * @returns The unwrapped schema.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function unwrap<
   TSchema extends

--- a/library/src/methods/unwrap/unwrap.ts
+++ b/library/src/methods/unwrap/unwrap.ts
@@ -30,9 +30,8 @@ import type {
  * @param schema The schema to be unwrapped.
  *
  * @returns The unwrapped schema.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function unwrap<
   TSchema extends
     | NonNullableSchema<

--- a/library/src/schemas/any/any.ts
+++ b/library/src/schemas/any/any.ts
@@ -28,6 +28,8 @@ export interface AnySchema extends BaseSchema<any, any, never> {
  * unknown data.
  *
  * @returns An any schema.
+ *
+ * @__NO_SIDE_EFFECTS__
  */
 export function any(): AnySchema {
   return {

--- a/library/src/schemas/any/any.ts
+++ b/library/src/schemas/any/any.ts
@@ -28,9 +28,8 @@ export interface AnySchema extends BaseSchema<any, any, never> {
  * unknown data.
  *
  * @returns An any schema.
- *
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function any(): AnySchema {
   return {
     kind: 'schema',

--- a/library/src/schemas/array/array.ts
+++ b/library/src/schemas/array/array.ts
@@ -68,6 +68,7 @@ export function array<
   const TMessage extends ErrorMessage<ArrayIssue> | undefined,
 >(item: TItem, message: TMessage): ArraySchema<TItem, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function array(
   item: BaseSchema<unknown, unknown, BaseIssue<unknown>>,
   message?: ErrorMessage<ArrayIssue>

--- a/library/src/schemas/array/arrayAsync.ts
+++ b/library/src/schemas/array/arrayAsync.ts
@@ -75,6 +75,7 @@ export function arrayAsync<
   const TMessage extends ErrorMessage<ArrayIssue> | undefined,
 >(item: TItem, message: TMessage): ArraySchemaAsync<TItem, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function arrayAsync(
   item:
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/schemas/bigint/bigint.ts
+++ b/library/src/schemas/bigint/bigint.ts
@@ -66,6 +66,7 @@ export function bigint<
   const TMessage extends ErrorMessage<BigintIssue> | undefined,
 >(message: TMessage): BigintSchema<TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function bigint(
   message?: ErrorMessage<BigintIssue>
 ): BigintSchema<ErrorMessage<BigintIssue> | undefined> {

--- a/library/src/schemas/blob/blob.ts
+++ b/library/src/schemas/blob/blob.ts
@@ -66,6 +66,7 @@ export function blob<
   const TMessage extends ErrorMessage<BlobIssue> | undefined,
 >(message: TMessage): BlobSchema<TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function blob(
   message?: ErrorMessage<BlobIssue>
 ): BlobSchema<ErrorMessage<BlobIssue> | undefined> {

--- a/library/src/schemas/boolean/boolean.ts
+++ b/library/src/schemas/boolean/boolean.ts
@@ -66,6 +66,7 @@ export function boolean<
   const TMessage extends ErrorMessage<BooleanIssue> | undefined,
 >(message: TMessage): BooleanSchema<TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function boolean(
   message?: ErrorMessage<BooleanIssue>
 ): BooleanSchema<ErrorMessage<BooleanIssue> | undefined> {

--- a/library/src/schemas/custom/custom.ts
+++ b/library/src/schemas/custom/custom.ts
@@ -64,6 +64,7 @@ export function custom<
     | undefined,
 >(check: Check, message: TMessage): CustomSchema<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function custom<TInput>(
   check: Check,
   message?: ErrorMessage<CustomIssue>

--- a/library/src/schemas/custom/customAsync.ts
+++ b/library/src/schemas/custom/customAsync.ts
@@ -67,6 +67,7 @@ export function customAsync<
     | undefined,
 >(check: CheckAsync, message: TMessage): CustomSchemaAsync<TInput, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function customAsync<TInput>(
   check: CheckAsync,
   message?: ErrorMessage<CustomIssue>

--- a/library/src/schemas/date/date.ts
+++ b/library/src/schemas/date/date.ts
@@ -66,6 +66,7 @@ export function date<
   const TMessage extends ErrorMessage<DateIssue> | undefined,
 >(message: TMessage): DateSchema<TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function date(
   message?: ErrorMessage<DateIssue>
 ): DateSchema<ErrorMessage<DateIssue> | undefined> {

--- a/library/src/schemas/enum/enum.ts
+++ b/library/src/schemas/enum/enum.ts
@@ -89,6 +89,7 @@ export function enum_<
   const TMessage extends ErrorMessage<EnumIssue> | undefined,
 >(enum__: TEnum, message: TMessage): EnumSchema<TEnum, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function enum_(
   enum__: Enum,
   message?: ErrorMessage<EnumIssue>

--- a/library/src/schemas/file/file.ts
+++ b/library/src/schemas/file/file.ts
@@ -66,6 +66,7 @@ export function file<
   const TMessage extends ErrorMessage<FileIssue> | undefined,
 >(message: TMessage): FileSchema<TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function file(
   message?: ErrorMessage<FileIssue>
 ): FileSchema<ErrorMessage<FileIssue> | undefined> {

--- a/library/src/schemas/function/function.ts
+++ b/library/src/schemas/function/function.ts
@@ -70,6 +70,7 @@ export function function_<
   const TMessage extends ErrorMessage<FunctionIssue> | undefined,
 >(message: TMessage): FunctionSchema<TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function function_(
   message?: ErrorMessage<FunctionIssue>
 ): FunctionSchema<ErrorMessage<FunctionIssue> | undefined> {

--- a/library/src/schemas/instance/instance.ts
+++ b/library/src/schemas/instance/instance.ts
@@ -83,6 +83,7 @@ export function instance<
   const TMessage extends ErrorMessage<InstanceIssue> | undefined,
 >(class_: TClass, message: TMessage): InstanceSchema<TClass, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function instance(
   class_: Class,
   message?: ErrorMessage<InstanceIssue>

--- a/library/src/schemas/intersect/intersect.ts
+++ b/library/src/schemas/intersect/intersect.ts
@@ -71,6 +71,7 @@ export function intersect<
   const TMessage extends ErrorMessage<IntersectIssue> | undefined,
 >(options: TOptions, message: TMessage): IntersectSchema<TOptions, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function intersect(
   options: IntersectOptions,
   message?: ErrorMessage<IntersectIssue>

--- a/library/src/schemas/intersect/intersectAsync.ts
+++ b/library/src/schemas/intersect/intersectAsync.ts
@@ -74,6 +74,7 @@ export function intersectAsync<
   message: TMessage
 ): IntersectSchemaAsync<TOptions, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function intersectAsync(
   options: IntersectOptionsAsync,
   message?: ErrorMessage<IntersectIssue>

--- a/library/src/schemas/intersect/utils/_merge/_merge.ts
+++ b/library/src/schemas/intersect/utils/_merge/_merge.ts
@@ -15,6 +15,7 @@ type MergeDataset =
  *
  * @internal
  */
+// @__NO_SIDE_EFFECTS__
 export function _merge(value1: unknown, value2: unknown): MergeDataset {
   // Continue if data type of values match
   if (typeof value1 === typeof value2) {

--- a/library/src/schemas/lazy/lazy.ts
+++ b/library/src/schemas/lazy/lazy.ts
@@ -41,9 +41,8 @@ export interface LazySchema<
  * @param getter The schema getter.
  *
  * @returns A lazy schema.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function lazy<
   const TWrapped extends BaseSchema<unknown, unknown, BaseIssue<unknown>>,
 >(getter: (input: unknown) => TWrapped): LazySchema<TWrapped> {

--- a/library/src/schemas/lazy/lazy.ts
+++ b/library/src/schemas/lazy/lazy.ts
@@ -41,6 +41,8 @@ export interface LazySchema<
  * @param getter The schema getter.
  *
  * @returns A lazy schema.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function lazy<
   const TWrapped extends BaseSchema<unknown, unknown, BaseIssue<unknown>>,

--- a/library/src/schemas/lazy/lazyAsync.ts
+++ b/library/src/schemas/lazy/lazyAsync.ts
@@ -45,9 +45,8 @@ export interface LazySchemaAsync<
  * @param getter The schema getter.
  *
  * @returns A lazy schema.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function lazyAsync<
   const TWrapped extends
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/schemas/lazy/lazyAsync.ts
+++ b/library/src/schemas/lazy/lazyAsync.ts
@@ -45,6 +45,8 @@ export interface LazySchemaAsync<
  * @param getter The schema getter.
  *
  * @returns A lazy schema.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function lazyAsync<
   const TWrapped extends

--- a/library/src/schemas/literal/literal.ts
+++ b/library/src/schemas/literal/literal.ts
@@ -78,6 +78,7 @@ export function literal<
   const TMessage extends ErrorMessage<LiteralIssue> | undefined,
 >(literal_: TLiteral, message: TMessage): LiteralSchema<TLiteral, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function literal(
   literal_: Literal,
   message?: ErrorMessage<LiteralIssue>

--- a/library/src/schemas/looseObject/looseObject.ts
+++ b/library/src/schemas/looseObject/looseObject.ts
@@ -72,6 +72,7 @@ export function looseObject<
   const TMessage extends ErrorMessage<LooseObjectIssue> | undefined,
 >(entries: TEntries, message: TMessage): LooseObjectSchema<TEntries, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function looseObject(
   entries: ObjectEntries,
   message?: ErrorMessage<LooseObjectIssue>

--- a/library/src/schemas/looseObject/looseObjectAsync.ts
+++ b/library/src/schemas/looseObject/looseObjectAsync.ts
@@ -75,6 +75,7 @@ export function looseObjectAsync<
   message: TMessage
 ): LooseObjectSchemaAsync<TEntries, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function looseObjectAsync(
   entries: ObjectEntriesAsync,
   message?: ErrorMessage<LooseObjectIssue>

--- a/library/src/schemas/looseTuple/looseTuple.ts
+++ b/library/src/schemas/looseTuple/looseTuple.ts
@@ -69,6 +69,7 @@ export function looseTuple<
   const TMessage extends ErrorMessage<LooseTupleIssue> | undefined,
 >(items: TItems, message: TMessage): LooseTupleSchema<TItems, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function looseTuple(
   items: TupleItems,
   message?: ErrorMessage<LooseTupleIssue>

--- a/library/src/schemas/looseTuple/looseTupleAsync.ts
+++ b/library/src/schemas/looseTuple/looseTupleAsync.ts
@@ -69,6 +69,7 @@ export function looseTupleAsync<
   const TMessage extends ErrorMessage<LooseTupleIssue> | undefined,
 >(items: TItems, message: TMessage): LooseTupleSchemaAsync<TItems, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function looseTupleAsync(
   items: TupleItemsAsync,
   message?: ErrorMessage<LooseTupleIssue>

--- a/library/src/schemas/map/map.ts
+++ b/library/src/schemas/map/map.ts
@@ -79,6 +79,7 @@ export function map<
   message: TMessage
 ): MapSchema<TKey, TValue, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function map(
   key: BaseSchema<unknown, unknown, BaseIssue<unknown>>,
   value: BaseSchema<unknown, unknown, BaseIssue<unknown>>,

--- a/library/src/schemas/map/mapAsync.ts
+++ b/library/src/schemas/map/mapAsync.ts
@@ -92,6 +92,7 @@ export function mapAsync<
   message: TMessage
 ): MapSchemaAsync<TKey, TValue, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function mapAsync(
   key:
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/schemas/nan/nan.ts
+++ b/library/src/schemas/nan/nan.ts
@@ -65,6 +65,7 @@ export function nan<const TMessage extends ErrorMessage<NanIssue> | undefined>(
   message: TMessage
 ): NanSchema<TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function nan(
   message?: ErrorMessage<NanIssue>
 ): NanSchema<ErrorMessage<NanIssue> | undefined> {

--- a/library/src/schemas/never/never.ts
+++ b/library/src/schemas/never/never.ts
@@ -66,6 +66,7 @@ export function never<
   const TMessage extends ErrorMessage<NeverIssue> | undefined,
 >(message: TMessage): NeverSchema<TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function never(
   message?: ErrorMessage<NeverIssue>
 ): NeverSchema<ErrorMessage<NeverIssue> | undefined> {

--- a/library/src/schemas/nonNullable/nonNullable.ts
+++ b/library/src/schemas/nonNullable/nonNullable.ts
@@ -69,6 +69,7 @@ export function nonNullable<
   const TMessage extends ErrorMessage<NonNullableIssue> | undefined,
 >(wrapped: TWrapped, message: TMessage): NonNullableSchema<TWrapped, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function nonNullable(
   wrapped: BaseSchema<unknown, unknown, BaseIssue<unknown>>,
   message?: ErrorMessage<NonNullableIssue> | undefined

--- a/library/src/schemas/nonNullable/nonNullableAsync.ts
+++ b/library/src/schemas/nonNullable/nonNullableAsync.ts
@@ -79,6 +79,7 @@ export function nonNullableAsync<
   message: TMessage
 ): NonNullableSchemaAsync<TWrapped, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function nonNullableAsync(
   wrapped:
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/schemas/nonNullish/nonNullish.ts
+++ b/library/src/schemas/nonNullish/nonNullish.ts
@@ -69,6 +69,7 @@ export function nonNullish<
   const TMessage extends ErrorMessage<NonNullishIssue> | undefined,
 >(wrapped: TWrapped, message: TMessage): NonNullishSchema<TWrapped, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function nonNullish(
   wrapped: BaseSchema<unknown, unknown, BaseIssue<unknown>>,
   message?: ErrorMessage<NonNullishIssue> | undefined

--- a/library/src/schemas/nonNullish/nonNullishAsync.ts
+++ b/library/src/schemas/nonNullish/nonNullishAsync.ts
@@ -79,6 +79,7 @@ export function nonNullishAsync<
   message: TMessage
 ): NonNullishSchemaAsync<TWrapped, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function nonNullishAsync(
   wrapped:
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/schemas/nonOptional/nonOptional.ts
+++ b/library/src/schemas/nonOptional/nonOptional.ts
@@ -69,6 +69,7 @@ export function nonOptional<
   const TMessage extends ErrorMessage<NonOptionalIssue> | undefined,
 >(wrapped: TWrapped, message: TMessage): NonOptionalSchema<TWrapped, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function nonOptional(
   wrapped: BaseSchema<unknown, unknown, BaseIssue<unknown>>,
   message?: ErrorMessage<NonOptionalIssue> | undefined

--- a/library/src/schemas/nonOptional/nonOptionalAsync.ts
+++ b/library/src/schemas/nonOptional/nonOptionalAsync.ts
@@ -79,6 +79,7 @@ export function nonOptionalAsync<
   message: TMessage
 ): NonOptionalSchemaAsync<TWrapped, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function nonOptionalAsync(
   wrapped:
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/schemas/null/null.ts
+++ b/library/src/schemas/null/null.ts
@@ -66,6 +66,7 @@ export function null_<
   const TMessage extends ErrorMessage<NullIssue> | undefined,
 >(message: TMessage): NullSchema<TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function null_(
   message?: ErrorMessage<NullIssue>
 ): NullSchema<ErrorMessage<NullIssue> | undefined> {

--- a/library/src/schemas/nullable/nullable.ts
+++ b/library/src/schemas/nullable/nullable.ts
@@ -67,6 +67,7 @@ export function nullable<
   const TDefault extends Default<TWrapped, null>,
 >(wrapped: TWrapped, default_: TDefault): NullableSchema<TWrapped, TDefault>;
 
+// @__NO_SIDE_EFFECTS__
 export function nullable(
   wrapped: BaseSchema<unknown, unknown, BaseIssue<unknown>>,
   default_?: unknown

--- a/library/src/schemas/nullable/nullableAsync.ts
+++ b/library/src/schemas/nullable/nullableAsync.ts
@@ -77,6 +77,7 @@ export function nullableAsync<
   default_: TDefault
 ): NullableSchemaAsync<TWrapped, TDefault>;
 
+// @__NO_SIDE_EFFECTS__
 export function nullableAsync(
   wrapped:
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/schemas/nullish/nullish.ts
+++ b/library/src/schemas/nullish/nullish.ts
@@ -67,6 +67,7 @@ export function nullish<
   const TDefault extends Default<TWrapped, null | undefined>,
 >(wrapped: TWrapped, default_: TDefault): NullishSchema<TWrapped, TDefault>;
 
+// @__NO_SIDE_EFFECTS__
 export function nullish(
   wrapped: BaseSchema<unknown, unknown, BaseIssue<unknown>>,
   default_?: unknown

--- a/library/src/schemas/nullish/nullishAsync.ts
+++ b/library/src/schemas/nullish/nullishAsync.ts
@@ -77,6 +77,7 @@ export function nullishAsync<
   default_: TDefault
 ): NullishSchemaAsync<TWrapped, TDefault>;
 
+// @__NO_SIDE_EFFECTS__
 export function nullishAsync(
   wrapped:
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/schemas/number/number.ts
+++ b/library/src/schemas/number/number.ts
@@ -66,6 +66,7 @@ export function number<
   const TMessage extends ErrorMessage<NumberIssue> | undefined,
 >(message: TMessage): NumberSchema<TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function number(
   message?: ErrorMessage<NumberIssue>
 ): NumberSchema<ErrorMessage<NumberIssue> | undefined> {

--- a/library/src/schemas/object/object.ts
+++ b/library/src/schemas/object/object.ts
@@ -78,6 +78,7 @@ export function object<
   const TMessage extends ErrorMessage<ObjectIssue> | undefined,
 >(entries: TEntries, message: TMessage): ObjectSchema<TEntries, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function object(
   entries: ObjectEntries,
   message?: ErrorMessage<ObjectIssue>

--- a/library/src/schemas/object/objectAsync.ts
+++ b/library/src/schemas/object/objectAsync.ts
@@ -78,6 +78,7 @@ export function objectAsync<
   const TMessage extends ErrorMessage<ObjectIssue> | undefined,
 >(entries: TEntries, message: TMessage): ObjectSchemaAsync<TEntries, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function objectAsync(
   entries: ObjectEntriesAsync,
   message?: ErrorMessage<ObjectIssue>

--- a/library/src/schemas/objectWithRest/objectWithRest.ts
+++ b/library/src/schemas/objectWithRest/objectWithRest.ts
@@ -92,6 +92,7 @@ export function objectWithRest<
   message: TMessage
 ): ObjectWithRestSchema<TEntries, TRest, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function objectWithRest(
   entries: ObjectEntries,
   rest: BaseSchema<unknown, unknown, BaseIssue<unknown>>,

--- a/library/src/schemas/objectWithRest/objectWithRestAsync.ts
+++ b/library/src/schemas/objectWithRest/objectWithRestAsync.ts
@@ -99,6 +99,7 @@ export function objectWithRestAsync<
   message: TMessage
 ): ObjectWithRestSchemaAsync<TEntries, TRest, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function objectWithRestAsync(
   entries: ObjectEntriesAsync,
   rest:

--- a/library/src/schemas/optional/optional.ts
+++ b/library/src/schemas/optional/optional.ts
@@ -67,6 +67,7 @@ export function optional<
   const TDefault extends Default<TWrapped, undefined>,
 >(wrapped: TWrapped, default_: TDefault): OptionalSchema<TWrapped, TDefault>;
 
+// @__NO_SIDE_EFFECTS__
 export function optional(
   wrapped: BaseSchema<unknown, unknown, BaseIssue<unknown>>,
   default_?: unknown

--- a/library/src/schemas/optional/optionalAsync.ts
+++ b/library/src/schemas/optional/optionalAsync.ts
@@ -77,6 +77,7 @@ export function optionalAsync<
   default_: TDefault
 ): OptionalSchemaAsync<TWrapped, TDefault>;
 
+// @__NO_SIDE_EFFECTS__
 export function optionalAsync(
   wrapped:
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/schemas/picklist/picklist.ts
+++ b/library/src/schemas/picklist/picklist.ts
@@ -84,6 +84,7 @@ export function picklist<
   const TMessage extends ErrorMessage<PicklistIssue> | undefined,
 >(options: TOptions, message: TMessage): PicklistSchema<TOptions, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function picklist(
   options: PicklistOptions,
   message?: ErrorMessage<PicklistIssue>

--- a/library/src/schemas/promise/promise.ts
+++ b/library/src/schemas/promise/promise.ts
@@ -66,6 +66,7 @@ export function promise<
   const TMessage extends ErrorMessage<PromiseIssue> | undefined,
 >(message: TMessage): PromiseSchema<TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function promise(
   message?: ErrorMessage<PromiseIssue>
 ): PromiseSchema<ErrorMessage<PromiseIssue> | undefined> {

--- a/library/src/schemas/record/record.ts
+++ b/library/src/schemas/record/record.ts
@@ -95,6 +95,7 @@ export function record<
   message: TMessage
 ): RecordSchema<TKey, TValue, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function record(
   key: BaseSchema<string, string | number | symbol, BaseIssue<unknown>>,
   value: BaseSchema<unknown, unknown, BaseIssue<unknown>>,

--- a/library/src/schemas/record/recordAsync.ts
+++ b/library/src/schemas/record/recordAsync.ts
@@ -100,6 +100,7 @@ export function recordAsync<
   message: TMessage
 ): RecordSchemaAsync<TKey, TValue, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function recordAsync(
   key:
     | BaseSchema<string, string | number | symbol, BaseIssue<unknown>>

--- a/library/src/schemas/set/set.ts
+++ b/library/src/schemas/set/set.ts
@@ -66,6 +66,7 @@ export function set<
   const TMessage extends ErrorMessage<SetIssue> | undefined,
 >(value: TValue, message: TMessage): SetSchema<TValue, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function set(
   value: BaseSchema<unknown, unknown, BaseIssue<unknown>>,
   message?: ErrorMessage<SetIssue>

--- a/library/src/schemas/set/setAsync.ts
+++ b/library/src/schemas/set/setAsync.ts
@@ -73,6 +73,7 @@ export function setAsync<
   const TMessage extends ErrorMessage<SetIssue> | undefined,
 >(value: TValue, message: TMessage): SetSchemaAsync<TValue, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function setAsync(
   value:
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/schemas/strictObject/strictObject.ts
+++ b/library/src/schemas/strictObject/strictObject.ts
@@ -68,6 +68,7 @@ export function strictObject<
   const TMessage extends ErrorMessage<StrictObjectIssue> | undefined,
 >(entries: TEntries, message: TMessage): StrictObjectSchema<TEntries, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function strictObject(
   entries: ObjectEntries,
   message?: ErrorMessage<StrictObjectIssue>

--- a/library/src/schemas/strictObject/strictObjectAsync.ts
+++ b/library/src/schemas/strictObject/strictObjectAsync.ts
@@ -71,6 +71,7 @@ export function strictObjectAsync<
   message: TMessage
 ): StrictObjectSchemaAsync<TEntries, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function strictObjectAsync(
   entries: ObjectEntriesAsync,
   message?: ErrorMessage<StrictObjectIssue>

--- a/library/src/schemas/strictTuple/strictTuple.ts
+++ b/library/src/schemas/strictTuple/strictTuple.ts
@@ -69,6 +69,7 @@ export function strictTuple<
   const TMessage extends ErrorMessage<StrictTupleIssue> | undefined,
 >(items: TItems, message: TMessage): StrictTupleSchema<TItems, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function strictTuple(
   items: TupleItems,
   message?: ErrorMessage<StrictTupleIssue>

--- a/library/src/schemas/strictTuple/strictTupleAsync.ts
+++ b/library/src/schemas/strictTuple/strictTupleAsync.ts
@@ -69,6 +69,7 @@ export function strictTupleAsync<
   const TMessage extends ErrorMessage<StrictTupleIssue> | undefined,
 >(items: TItems, message: TMessage): StrictTupleSchemaAsync<TItems, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function strictTupleAsync(
   items: TupleItemsAsync,
   message?: ErrorMessage<StrictTupleIssue>

--- a/library/src/schemas/string/string.ts
+++ b/library/src/schemas/string/string.ts
@@ -66,6 +66,7 @@ export function string<
   const TMessage extends ErrorMessage<StringIssue> | undefined,
 >(message: TMessage): StringSchema<TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function string(
   message?: ErrorMessage<StringIssue>
 ): StringSchema<ErrorMessage<StringIssue> | undefined> {

--- a/library/src/schemas/symbol/symbol.ts
+++ b/library/src/schemas/symbol/symbol.ts
@@ -66,6 +66,7 @@ export function symbol<
   const TMessage extends ErrorMessage<SymbolIssue> | undefined,
 >(message: TMessage): SymbolSchema<TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function symbol(
   message?: ErrorMessage<SymbolIssue>
 ): SymbolSchema<ErrorMessage<SymbolIssue> | undefined> {

--- a/library/src/schemas/tuple/tuple.ts
+++ b/library/src/schemas/tuple/tuple.ts
@@ -79,6 +79,7 @@ export function tuple<
   const TMessage extends ErrorMessage<TupleIssue> | undefined,
 >(items: TItems, message: TMessage): TupleSchema<TItems, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function tuple(
   items: TupleItems,
   message?: ErrorMessage<TupleIssue>

--- a/library/src/schemas/tuple/tupleAsync.ts
+++ b/library/src/schemas/tuple/tupleAsync.ts
@@ -79,6 +79,7 @@ export function tupleAsync<
   const TMessage extends ErrorMessage<TupleIssue> | undefined,
 >(items: TItems, message: TMessage): TupleSchemaAsync<TItems, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function tupleAsync(
   items: TupleItemsAsync,
   message?: ErrorMessage<TupleIssue>

--- a/library/src/schemas/tupleWithRest/tupleWithRest.ts
+++ b/library/src/schemas/tupleWithRest/tupleWithRest.ts
@@ -85,6 +85,7 @@ export function tupleWithRest<
   message: TMessage
 ): TupleWithRestSchema<TItems, TRest, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function tupleWithRest(
   items: TupleItems,
   rest: BaseSchema<unknown, unknown, BaseIssue<unknown>>,

--- a/library/src/schemas/tupleWithRest/tupleWithRestAsync.ts
+++ b/library/src/schemas/tupleWithRest/tupleWithRestAsync.ts
@@ -95,6 +95,7 @@ export function tupleWithRestAsync<
   message: TMessage
 ): TupleWithRestSchemaAsync<TItems, TRest, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function tupleWithRestAsync(
   items: TupleItemsAsync,
   rest:

--- a/library/src/schemas/undefined/undefined.ts
+++ b/library/src/schemas/undefined/undefined.ts
@@ -66,6 +66,7 @@ export function undefined_<
   const TMessage extends ErrorMessage<UndefinedIssue> | undefined,
 >(message: TMessage): UndefinedSchema<TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function undefined_(
   message?: ErrorMessage<UndefinedIssue>
 ): UndefinedSchema<ErrorMessage<UndefinedIssue> | undefined> {

--- a/library/src/schemas/undefinedable/undefinedable.ts
+++ b/library/src/schemas/undefinedable/undefinedable.ts
@@ -70,6 +70,7 @@ export function undefinedable<
   default_: TDefault
 ): UndefinedableSchema<TWrapped, TDefault>;
 
+// @__NO_SIDE_EFFECTS__
 export function undefinedable(
   wrapped: BaseSchema<unknown, unknown, BaseIssue<unknown>>,
   default_?: unknown

--- a/library/src/schemas/undefinedable/undefinedableAsync.ts
+++ b/library/src/schemas/undefinedable/undefinedableAsync.ts
@@ -77,6 +77,7 @@ export function undefinedableAsync<
   default_: TDefault
 ): UndefinedableSchemaAsync<TWrapped, TDefault>;
 
+// @__NO_SIDE_EFFECTS__
 export function undefinedableAsync(
   wrapped:
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/schemas/union/union.ts
+++ b/library/src/schemas/union/union.ts
@@ -83,6 +83,7 @@ export function union<
     | undefined,
 >(options: TOptions, message: TMessage): UnionSchema<TOptions, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function union(
   options: UnionOptions,
   message?: ErrorMessage<UnionIssue<BaseIssue<unknown>>>

--- a/library/src/schemas/union/unionAsync.ts
+++ b/library/src/schemas/union/unionAsync.ts
@@ -87,6 +87,7 @@ export function unionAsync<
     | undefined,
 >(options: TOptions, message: TMessage): UnionSchemaAsync<TOptions, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function unionAsync(
   options: UnionOptionsAsync,
   message?: ErrorMessage<UnionIssue<BaseIssue<unknown>>>

--- a/library/src/schemas/union/utils/_subIssues/_subIssues.ts
+++ b/library/src/schemas/union/utils/_subIssues/_subIssues.ts
@@ -9,6 +9,7 @@ import type { BaseIssue, OutputDataset } from '../../../../types/index.ts';
  *
  * @internal
  */
+// @__NO_SIDE_EFFECTS__
 export function _subIssues(
   datasets: OutputDataset<unknown, BaseIssue<unknown>>[] | undefined
 ): [BaseIssue<unknown>, ...BaseIssue<unknown>[]] | undefined {

--- a/library/src/schemas/unknown/unknown.ts
+++ b/library/src/schemas/unknown/unknown.ts
@@ -23,9 +23,8 @@ export interface UnknownSchema extends BaseSchema<unknown, unknown, never> {
  * Creates a unknown schema.
  *
  * @returns A unknown schema.
- * 
- * @__NO_SIDE_EFFECTS__
  */
+// @__NO_SIDE_EFFECTS__
 export function unknown(): UnknownSchema {
   return {
     kind: 'schema',

--- a/library/src/schemas/unknown/unknown.ts
+++ b/library/src/schemas/unknown/unknown.ts
@@ -23,6 +23,8 @@ export interface UnknownSchema extends BaseSchema<unknown, unknown, never> {
  * Creates a unknown schema.
  *
  * @returns A unknown schema.
+ * 
+ * @__NO_SIDE_EFFECTS__
  */
 export function unknown(): UnknownSchema {
   return {

--- a/library/src/schemas/variant/variant.ts
+++ b/library/src/schemas/variant/variant.ts
@@ -88,6 +88,7 @@ export function variant<
   message: TMessage
 ): VariantSchema<TKey, TOptions, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function variant(
   key: string,
   options: VariantOptions<string>,

--- a/library/src/schemas/variant/variantAsync.ts
+++ b/library/src/schemas/variant/variantAsync.ts
@@ -89,6 +89,7 @@ export function variantAsync<
   message: TMessage
 ): VariantSchemaAsync<TKey, TOptions, TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function variantAsync(
   key: string,
   options: VariantOptionsAsync<string>,

--- a/library/src/schemas/void/void.ts
+++ b/library/src/schemas/void/void.ts
@@ -66,6 +66,7 @@ export function void_<
   const TMessage extends ErrorMessage<VoidIssue> | undefined,
 >(message: TMessage): VoidSchema<TMessage>;
 
+// @__NO_SIDE_EFFECTS__
 export function void_(
   message?: ErrorMessage<VoidIssue>
 ): VoidSchema<ErrorMessage<VoidIssue> | undefined> {

--- a/library/src/storages/globalConfig/globalConfig.ts
+++ b/library/src/storages/globalConfig/globalConfig.ts
@@ -24,6 +24,7 @@ export function setGlobalConfig(config: GlobalConfig): void {
  *
  * @returns The configuration.
  */
+// @__NO_SIDE_EFFECTS__
 export function getGlobalConfig<const TIssue extends BaseIssue<unknown>>(
   config?: Config<TIssue>
 ): Config<TIssue> {

--- a/library/src/storages/globalMessage/globalMessage.ts
+++ b/library/src/storages/globalMessage/globalMessage.ts
@@ -24,6 +24,7 @@ export function setGlobalMessage(
  *
  * @returns The error message.
  */
+// @__NO_SIDE_EFFECTS__
 export function getGlobalMessage(
   lang?: string
 ): ErrorMessage<BaseIssue<unknown>> | undefined {

--- a/library/src/storages/schemaMessage/schemaMessage.ts
+++ b/library/src/storages/schemaMessage/schemaMessage.ts
@@ -24,6 +24,7 @@ export function setSchemaMessage(
  *
  * @returns The error message.
  */
+// @__NO_SIDE_EFFECTS__
 export function getSchemaMessage(
   lang?: string
 ): ErrorMessage<BaseIssue<unknown>> | undefined {

--- a/library/src/storages/specificMessage/specificMessage.ts
+++ b/library/src/storages/specificMessage/specificMessage.ts
@@ -55,6 +55,7 @@ export function setSpecificMessage<const TReference extends Reference>(
  *
  * @returns The error message.
  */
+// @__NO_SIDE_EFFECTS__
 export function getSpecificMessage<const TReference extends Reference>(
   reference: TReference,
   lang?: string

--- a/library/src/utils/ValiError/ValiError.ts
+++ b/library/src/utils/ValiError/ValiError.ts
@@ -23,6 +23,7 @@ export class ValiError<
    *
    * @param issues The error issues.
    */
+  // @__NO_SIDE_EFFECTS__
   constructor(issues: [InferIssue<TSchema>, ...InferIssue<TSchema>[]]) {
     super(issues[0].message);
     this.name = 'ValiError';

--- a/library/src/utils/_addIssue/_addIssue.ts
+++ b/library/src/utils/_addIssue/_addIssue.ts
@@ -61,6 +61,7 @@ interface Other<TContext extends Context> {
  *
  * @internal
  */
+// @__NO_SIDE_EFFECTS__
 export function _addIssue<const TContext extends Context>(
   context: TContext & {
     expects?: string | null;

--- a/library/src/utils/_getByteCount/_getByteCount.ts
+++ b/library/src/utils/_getByteCount/_getByteCount.ts
@@ -9,6 +9,7 @@ let textEncoder: TextEncoder;
  *
  * @internal
  */
+// @__NO_SIDE_EFFECTS__
 export function _getByteCount(input: string): number {
   if (!textEncoder) {
     textEncoder = new TextEncoder();

--- a/library/src/utils/_getGraphemeCount/_getGraphemeCount.ts
+++ b/library/src/utils/_getGraphemeCount/_getGraphemeCount.ts
@@ -9,6 +9,7 @@ let segmenter: Intl.Segmenter;
  *
  * @internal
  */
+// @__NO_SIDE_EFFECTS__
 export function _getGraphemeCount(input: string): number {
   if (!segmenter) {
     segmenter = new Intl.Segmenter();

--- a/library/src/utils/_getStandardProps/_getStandardProps.ts
+++ b/library/src/utils/_getStandardProps/_getStandardProps.ts
@@ -16,6 +16,7 @@ import type {
  *
  * @returns The Standard Schema properties.
  */
+// @__NO_SIDE_EFFECTS__
 export function _getStandardProps<
   TSchema extends
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>

--- a/library/src/utils/_getWordCount/_getWordCount.ts
+++ b/library/src/utils/_getWordCount/_getWordCount.ts
@@ -10,6 +10,7 @@ let store: Map<Intl.LocalesArgument, Intl.Segmenter>;
  *
  * @internal
  */
+// @__NO_SIDE_EFFECTS__
 export function _getWordCount(
   locales: Intl.LocalesArgument,
   input: string

--- a/library/src/utils/_isLuhnAlgo/_isLuhnAlgo.ts
+++ b/library/src/utils/_isLuhnAlgo/_isLuhnAlgo.ts
@@ -12,6 +12,7 @@ const NON_DIGIT_REGEX = /\D/gu;
  *
  * @internal
  */
+// @__NO_SIDE_EFFECTS__
 export function _isLuhnAlgo(input: string): boolean {
   // Remove any non-digit chars
   const number = input.replace(NON_DIGIT_REGEX, '');

--- a/library/src/utils/_isValidObjectKey/_isValidObjectKey.ts
+++ b/library/src/utils/_isValidObjectKey/_isValidObjectKey.ts
@@ -9,6 +9,7 @@
  *
  * @internal
  */
+// @__NO_SIDE_EFFECTS__
 export function _isValidObjectKey(object: object, key: string): boolean {
   return (
     Object.hasOwn(object, key) &&

--- a/library/src/utils/_joinExpects/_joinExpects.ts
+++ b/library/src/utils/_joinExpects/_joinExpects.ts
@@ -8,6 +8,7 @@
  *
  * @internal
  */
+// @__NO_SIDE_EFFECTS__
 export function _joinExpects(values: string[], separator: '&' | '|'): string {
   // Create list without duplicates
   const list = [...new Set(values)];

--- a/library/src/utils/_stringify/_stringify.ts
+++ b/library/src/utils/_stringify/_stringify.ts
@@ -7,6 +7,7 @@
  *
  * @internal
  */
+// @__NO_SIDE_EFFECTS__
 export function _stringify(input: unknown): string {
   const type = typeof input;
   if (type === 'string') {

--- a/library/src/utils/entriesFromList/entriesFromList.ts
+++ b/library/src/utils/entriesFromList/entriesFromList.ts
@@ -12,6 +12,7 @@ import type {
  *
  * @returns The object entries.
  */
+// @__NO_SIDE_EFFECTS__
 export function entriesFromList<
   const TList extends readonly (string | number | symbol)[],
   const TSchema extends

--- a/library/src/utils/getDotPath/getDotPath.ts
+++ b/library/src/utils/getDotPath/getDotPath.ts
@@ -28,6 +28,7 @@ export function getDotPath<
     | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
 >(issue: InferIssue<TSchema>): IssueDotPath<TSchema> | null;
 
+// @__NO_SIDE_EFFECTS__
 export function getDotPath(issue: BaseIssue<unknown>): string | null {
   if (issue.path) {
     let key = '';

--- a/library/src/utils/isOfKind/isOfKind.ts
+++ b/library/src/utils/isOfKind/isOfKind.ts
@@ -6,6 +6,7 @@
  *
  * @returns Whether it matches.
  */
+// @__NO_SIDE_EFFECTS__
 export function isOfKind<
   const TKind extends TObject['kind'],
   const TObject extends { kind: string },

--- a/library/src/utils/isOfType/isOfType.ts
+++ b/library/src/utils/isOfType/isOfType.ts
@@ -6,6 +6,7 @@
  *
  * @returns Whether it matches.
  */
+// @__NO_SIDE_EFFECTS__
 export function isOfType<
   const TType extends TObject['type'],
   const TObject extends { type: string },

--- a/library/src/utils/isValiError/isValiError.ts
+++ b/library/src/utils/isValiError/isValiError.ts
@@ -12,6 +12,7 @@ import { ValiError } from '../../utils/index.ts';
  *
  * @returns Whether its a ValiError.
  */
+// @__NO_SIDE_EFFECTS__
 export function isValiError<
   TSchema extends
     | BaseSchema<unknown, unknown, BaseIssue<unknown>>


### PR DESCRIPTION
This PR adds `@__NO_SIDE_EFFECTS__` notation for all the schema functions:
https://github.com/javascript-compiler-hints/compiler-notations-spec/blob/main/no-side-effects-notation-spec.md

This would improve tree-shaking of Valibot on users side. For example, the snippet from the docs:

```ts
import * as v from 'valibot'

const LoginSchema = v.object({
  email: v.pipe(v.string(), v.email()),
  password: v.pipe(v.string(), v.minLength(8)),
})
```

Because the `object()` can not be treated as side-effects free, even `LoginSchema` is not used, the final bundle still contains an orphan `object()` call with it's all dependencies (bundle ~3KB).

One solution is to add `/* @__PURE__ */` on the user side,

```ts
import * as v from 'valibot'

const LoginSchema = /* @__PURE__ */ v.object({
  email: v.pipe(v.string(), v.email()),
  password: v.pipe(v.string(), v.minLength(8)),
})
```

The downside is this would require the user's manual effort on **every schema**.

With `@__NO_SIDE_EFFECTS__`, it will give a hint to the bundler to know `object()` is side-effects free, and eventually make the whole file shakable (bundle 0KB)

Example of bundling using Rollup: https://stackblitz.com/edit/node-5rxpc1jl

This PR is made from the discussion with @serkodev