### PR TITLE
feat: disallow additional props in intersections

### DIFF
--- a/packages/to-json-schema/src/convertSchema.test.ts
+++ b/packages/to-json-schema/src/convertSchema.test.ts
@@ -703,7 +703,6 @@ describe('convertSchema', () => {
               foo: { type: 'string' },
             },
             required: ['foo'],
-            additionalProperties: false,
           },
           {
             type: 'object',
@@ -711,7 +710,29 @@ describe('convertSchema', () => {
               bar: { type: 'number' },
             },
             required: ['bar'],
-            additionalProperties: false,
+          },
+        ],
+        unevaluatedProperties: false,
+      });
+    });
+
+    test('should unset unevaluatedProperties in extensible intersection', () => {
+      expect(
+        convertSchema(
+          {},
+          v.intersect([v.objectWithRest({ foo: v.string() }, v.string())]),
+          undefined,
+          createContext()
+        )
+      ).toStrictEqual({
+        allOf: [
+          {
+            type: 'object',
+            properties: {
+              foo: { type: 'string' },
+            },
+            required: ['foo'],
+            additionalProperties: { type: 'string' },
           },
         ],
       });


### PR DESCRIPTION
Sets `unevaluatedProperties: false` in intersections which have `additionalProperties` consistently set to `false`.

This will enforce that to validate against the JSON schema, your input must have only properties from each of the intersecting schemas.

If any of the sub-schemas have `additionalProperties` set to a non-false value, `unevaluatedProperties` will not be set.

