### PR TITLE
feat: treat objects as loose in JSON schema intersections

### DIFF
--- a/packages/to-json-schema/src/convertSchema.test.ts
+++ b/packages/to-json-schema/src/convertSchema.test.ts
@@ -703,7 +703,6 @@ describe('convertSchema', () => {
               foo: { type: 'string' },
             },
             required: ['foo'],
-            additionalProperties: false,
           },
           {
             type: 'object',
@@ -711,7 +710,29 @@ describe('convertSchema', () => {
               bar: { type: 'number' },
             },
             required: ['bar'],
-            additionalProperties: false,
+          },
+        ],
+        unevaluatedProperties: false,
+      });
+    });
+
+    test('should unset unevaluatedProperties in extensible intersection', () => {
+      expect(
+        convertSchema(
+          {},
+          v.intersect([v.objectWithRest({ foo: v.string() }, v.string())]),
+          undefined,
+          createContext()
+        )
+      ).toStrictEqual({
+        allOf: [
+          {
+            type: 'object',
+            properties: {
+              foo: { type: 'string' },
+            },
+            required: ['foo'],
+            additionalProperties: { type: 'string' },
           },
         ],
       });

--- a/packages/to-json-schema/src/convertSchema.test.ts
+++ b/packages/to-json-schema/src/convertSchema.test.ts
@@ -703,6 +703,7 @@ describe('convertSchema', () => {
               foo: { type: 'string' },
             },
             required: ['foo'],
+            additionalProperties: true,
           },
           {
             type: 'object',
@@ -710,29 +711,7 @@ describe('convertSchema', () => {
               bar: { type: 'number' },
             },
             required: ['bar'],
-          },
-        ],
-        unevaluatedProperties: false,
-      });
-    });
-
-    test('should unset unevaluatedProperties in extensible intersection', () => {
-      expect(
-        convertSchema(
-          {},
-          v.intersect([v.objectWithRest({ foo: v.string() }, v.string())]),
-          undefined,
-          createContext()
-        )
-      ).toStrictEqual({
-        allOf: [
-          {
-            type: 'object',
-            properties: {
-              foo: { type: 'string' },
-            },
-            required: ['foo'],
-            additionalProperties: { type: 'string' },
+            additionalProperties: true,
           },
         ],
       });

--- a/packages/to-json-schema/src/convertSchema.ts
+++ b/packages/to-json-schema/src/convertSchema.ts
@@ -4,10 +4,6 @@ import { convertAction } from './convertAction.ts';
 import type { ConversionConfig, ConversionContext } from './type.ts';
 import { handleError } from './utils/index.ts';
 
-interface JSONSchema7Extended extends JSONSchema7 {
-  unevaluatedProperties?: boolean;
-}
-
 /**
  * Schema type.
  */
@@ -119,11 +115,11 @@ let refCount = 0;
  * @returns The converted JSON Schema.
  */
 export function convertSchema(
-  jsonSchema: JSONSchema7Extended,
+  jsonSchema: JSONSchema7,
   valibotSchema: SchemaOrPipe,
   config: ConversionConfig | undefined,
   context: ConversionContext
-): JSONSchema7Extended {
+): JSONSchema7 {
   // If schema is in reference map, use reference and skip conversion
   const referenceId = context.referenceMap.get(valibotSchema);
   if (referenceId && referenceId in context.definitions) {
@@ -395,8 +391,6 @@ export function convertSchema(
     }
 
     case 'intersect': {
-      let setUnevaluatedProperties = true;
-
       jsonSchema.allOf = valibotSchema.options.map((option) => {
         const childSchema = convertSchema(
           {},
@@ -405,20 +399,12 @@ export function convertSchema(
           context
         );
 
-        const { additionalProperties, ...withoutAdditionalProps } = childSchema;
-
-        if (additionalProperties === false) {
-          return withoutAdditionalProps;
+        if (option.type === 'object') {
+          childSchema.additionalProperties = true;
         }
-
-        setUnevaluatedProperties = false;
 
         return childSchema;
       });
-
-      if (setUnevaluatedProperties) {
-        jsonSchema.unevaluatedProperties = false;
-      }
       break;
     }
 


### PR DESCRIPTION
An alternative to #997 

Instead of doing smarter detection of if to use `unevaluatedProperties` or not, we simply loosen the type here as if it was a loose object. This results in `additionalProperties: true` for `object` schemas which are used in an intersection, but outside of intersections, leaves the schema as-is now.

Once we can support the newer draft of JSON schema, we should do #997 instead 