### PR TITLE
toJsonSchema: Only disallow additionalProperties for strictObject

### DIFF
--- a/packages/to-json-schema/CHANGELOG.md
+++ b/packages/to-json-schema/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the library will be documented in this file.
 - Change Valibot peer dependency to v1.0.0
 - Change extraction of default value from `nullable`, `nullish` and `optional` schema
 - Change `force` to `errorMode` in config for better control (issue #889)
+- Change `additionalProperties` for `object` and `looseObject` schema (pull request #1001)
 
 ## v0.2.1 (September 30, 2024)
 

--- a/packages/to-json-schema/src/convertSchema.test.ts
+++ b/packages/to-json-schema/src/convertSchema.test.ts
@@ -275,7 +275,6 @@ describe('convertSchema', () => {
           key4: { anyOf: [{ type: 'number' }, { type: 'null' }] },
         },
         required: ['key1', 'key3'],
-        additionalProperties: true,
       });
     });
 

--- a/packages/to-json-schema/src/convertSchema.test.ts
+++ b/packages/to-json-schema/src/convertSchema.test.ts
@@ -221,7 +221,6 @@ describe('convertSchema', () => {
           key4: { anyOf: [{ type: 'number' }, { type: 'null' }] },
         },
         required: ['key1', 'key3'],
-        additionalProperties: false,
       });
     });
 
@@ -669,7 +668,6 @@ describe('convertSchema', () => {
               foo: { type: 'string' },
             },
             required: ['type', 'foo'],
-            additionalProperties: false,
           },
           {
             type: 'object',
@@ -678,7 +676,6 @@ describe('convertSchema', () => {
               bar: { type: 'number' },
             },
             required: ['type', 'bar'],
-            additionalProperties: false,
           },
         ],
       });
@@ -703,7 +700,6 @@ describe('convertSchema', () => {
               foo: { type: 'string' },
             },
             required: ['foo'],
-            additionalProperties: false,
           },
           {
             type: 'object',
@@ -711,7 +707,6 @@ describe('convertSchema', () => {
               bar: { type: 'number' },
             },
             required: ['bar'],
-            additionalProperties: false,
           },
         ],
       });
@@ -772,7 +767,6 @@ describe('convertSchema', () => {
         type: 'object',
         properties: { node: { $ref: '#/$defs/1' } },
         required: [],
-        additionalProperties: false,
       });
       expect(context).toStrictEqual({
         definitions: {
@@ -780,7 +774,6 @@ describe('convertSchema', () => {
             type: 'object',
             properties: { node: { $ref: '#/$defs/1' } },
             required: [],
-            additionalProperties: false,
           },
         },
         referenceMap: new Map().set(nodeSchema, '1'),
@@ -807,7 +800,6 @@ describe('convertSchema', () => {
         type: 'object',
         properties: { node: { $ref: '#/$defs/2' } },
         required: ['node'],
-        additionalProperties: false,
       });
       expect(context).toStrictEqual({
         definitions: {
@@ -817,7 +809,6 @@ describe('convertSchema', () => {
                 type: 'object',
                 properties: { node: { $ref: '#/$defs/2' } },
                 required: ['node'],
-                additionalProperties: false,
               },
               { type: 'null' },
             ],

--- a/packages/to-json-schema/src/convertSchema.ts
+++ b/packages/to-json-schema/src/convertSchema.ts
@@ -267,9 +267,6 @@ export function convertSchema(
           config,
           context
         );
-      } else if (valibotSchema.type === 'loose_object') {
-        // `true` has no validation effect, but might as well be explicit
-        jsonSchema.additionalProperties = true;
       } else if (valibotSchema.type === 'strict_object') {
         jsonSchema.additionalProperties = false;
       }

--- a/packages/to-json-schema/src/convertSchema.ts
+++ b/packages/to-json-schema/src/convertSchema.ts
@@ -267,8 +267,11 @@ export function convertSchema(
           config,
           context
         );
-      } else {
-        jsonSchema.additionalProperties = valibotSchema.type === 'loose_object';
+      } else if (valibotSchema.type === 'loose_object') {
+        // `true` has no validation effect, but might as well be explicit
+        jsonSchema.additionalProperties = true;
+      } else if (valibotSchema.type === 'strict_object') {
+        jsonSchema.additionalProperties = false;
       }
 
       break;

--- a/packages/to-json-schema/src/toJsonSchema.test.ts
+++ b/packages/to-json-schema/src/toJsonSchema.test.ts
@@ -40,7 +40,6 @@ describe('toJsonSchema', () => {
               age: { type: 'number' },
             },
             required: ['name', 'email'],
-            additionalProperties: false,
             description: 'foo',
           },
         },
@@ -65,7 +64,6 @@ describe('toJsonSchema', () => {
         $ref: '#/$defs/ul',
         $defs: {
           ul: {
-            additionalProperties: false,
             properties: {
               children: {
                 items: { $ref: '#/$defs/li' },
@@ -77,7 +75,6 @@ describe('toJsonSchema', () => {
             type: 'object',
           },
           li: {
-            additionalProperties: false,
             properties: {
               children: {
                 items: {


### PR DESCRIPTION
`additionalProperties: true` was preventing validation of valid intersected objects.

- Fixes #990.