### PR TITLE
Feat: Add `exactOptionalProperties` config match `exactOptionalPropertyTypes` in TypeScript

### DIFF
--- a/library/src/storages/globalConfig/globalConfig.ts
+++ b/library/src/storages/globalConfig/globalConfig.ts
@@ -35,6 +35,8 @@ export function getGlobalConfig<const TIssue extends BaseIssue<unknown>>(
     message: config?.message,
     abortEarly: config?.abortEarly ?? store?.abortEarly,
     abortPipeEarly: config?.abortPipeEarly ?? store?.abortPipeEarly,
+    exactOptionalProperties:
+      config?.exactOptionalProperties ?? store?.exactOptionalProperties,
   };
 }
 

--- a/library/src/types/config.ts
+++ b/library/src/types/config.ts
@@ -14,11 +14,15 @@ export interface Config<TIssue extends BaseIssue<unknown>> {
    */
   readonly message?: ErrorMessage<TIssue> | undefined;
   /**
-   * Whether it was abort early.
+   * Whether it should be aborted early.
    */
   readonly abortEarly?: boolean | undefined;
   /**
-   * Whether the pipe was abort early.
+   * Whether a pipe should be aborted early.
    */
   readonly abortPipeEarly?: boolean | undefined;
+  /**
+   * Whether to apply stricter rules to optional properties.
+   */
+  readonly exactOptionalProperties?: boolean | undefined;
 }

--- a/library/src/utils/_addIssue/_addIssue.ts
+++ b/library/src/utils/_addIssue/_addIssue.ts
@@ -97,6 +97,7 @@ export function _addIssue<const TContext extends Context>(
     lang: config.lang,
     abortEarly: config.abortEarly,
     abortPipeEarly: config.abortPipeEarly,
+    exactOptionalProperties: config.exactOptionalProperties,
   };
 
   // Check if context is a schema


### PR DESCRIPTION
So far, this is just a draft to further investigate our final decision.

Fix: #983