### PR TITLE
improve `base64` & its action's API references

### DIFF
--- a/website/src/routes/api/(actions)/base64/index.mdx
+++ b/website/src/routes/api/(actions)/base64/index.mdx
@@ -1,9 +1,11 @@
 ---
 title: base64
+description: Creates a Base64 validation action.
 source: /actions/base64/base64.ts
 contributors:
   - fabian-hiller
   - morinokami
+  - EltonLobo07
 ---
 
 import { ApiList, Property } from '~/components';

--- a/website/src/routes/api/(types)/Base64Action/index.mdx
+++ b/website/src/routes/api/(types)/Base64Action/index.mdx
@@ -3,6 +3,7 @@ title: Base64Action
 description: Base64 action interface.
 contributors:
   - fabian-hiller
+  - EltonLobo07
 ---
 
 import { Property } from '~/components';

--- a/website/src/routes/api/(types)/Base64Action/properties.ts
+++ b/website/src/routes/api/(types)/Base64Action/properties.ts
@@ -13,6 +13,7 @@ export const properties: Record<string, PropertyProps> = {
         {
           type: 'custom',
           name: 'ErrorMessage',
+          href: '../ErrorMessage/',
           generics: [
             {
               type: 'custom',


### PR DESCRIPTION
Improvements:
- Add a description to the `base64` page
- Add a missing link on the `Base64Action` page