### PR TITLE
Support readonly action in the JSON schema serialization package

### DIFF
--- a/packages/to-json-schema/README.md
+++ b/packages/to-json-schema/README.md
@@ -59,6 +59,7 @@ Some Valibot features can't be mapped to JSON schema. For example, transformatio
 | `minLength`    | ⚠️     | Only in combination with `string` and `array` schemas |
 | `minValue`     | ⚠️     | Only in combination with `number` schema              |
 | `multipleOf`   | ✅     |                                                       |
+| `readonly`     | ✅     |                                                       |
 | `regex`        | ⚠️     | RexExp flags are not supported in JSON schema         |
 | `uuid`         | ✅     |                                                       |
 | `value`        | ✅     |                                                       |

--- a/packages/to-json-schema/src/convertAction.test.ts
+++ b/packages/to-json-schema/src/convertAction.test.ts
@@ -633,6 +633,12 @@ describe('convertAction', () => {
     });
   });
 
+  test('should convert readonly action', () => {
+    expect(convertAction({}, v.readonly(), undefined)).toStrictEqual({
+      readOnly: true
+    });
+  });
+
   test('should convert supported regex action', () => {
     expect(
       convertAction({ type: 'string' }, v.regex<string>(/[a-zA-Z]/), undefined)

--- a/packages/to-json-schema/src/convertAction.ts
+++ b/packages/to-json-schema/src/convertAction.ts
@@ -76,6 +76,7 @@ type Action =
       v.ErrorMessage<v.NonEmptyIssue<v.LengthInput>> | undefined
     >
   | v.OctalAction<string, v.ErrorMessage<v.OctalIssue<string>> | undefined>
+  | v.ReadonlyAction<unknown>
   | v.RegexAction<string, v.ErrorMessage<v.RegexIssue<string>> | undefined>
   | v.TitleAction<unknown, string>
   | v.UlidAction<string, v.ErrorMessage<v.UlidIssue<string>> | undefined>
@@ -265,6 +266,11 @@ export function convertAction(
         }
         jsonSchema.minLength = 1;
       }
+      break;
+    }
+
+    case 'readonly': {
+      jsonSchema.readOnly = true;
       break;
     }
 


### PR DESCRIPTION
This adds support for the `v.readonly` action in the `to-json-schema` package. Per the [JSON Schema spec](https://json-schema.org/draft/2020-12/json-schema-validation#name-readonly-and-writeonly), this'll simply add the `readOnly: true` flag to the JSON output This is helpful for rendering UI forms where some properties should not be editable by the user.