### PR TITLE
feat: allow custom error message to be empty

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to the library will be documented in this file.
 - Change `MarkOptional` type to fix order of entries and TS error when using generic schemas (issue #1021)
 - Change `VariantOption` and `VariantOptionAsync` type to fix TS error when using generic schemas (issue #842)
 - Change implementation of `variant` and `variantAsync` to support optional discriminators using `exactOptional`, `exactOptionalAsync`, `optional`, `optionalAsync`, `nullish` or `nullishAsync`
+- Change `_addIssue` to not ignore empty strings as error message (pull request #1065)
 - Refactor `bytes`, `maxBytes`, `minBytes` and `notBytes` action
 - Fix implementation of `nonOptional`, `nonOptionalAsync`, `nonNullable`, `nonNullableAsync`, `nonNullish` and `nonNullishAsync` schema in edge cases (issue #909)
 - Fix instantiation error for `any` in `PathKeys` type (issue #929)

--- a/library/src/utils/_addIssue/_addIssue.test.ts
+++ b/library/src/utils/_addIssue/_addIssue.test.ts
@@ -129,7 +129,7 @@ describe('_addIssue', () => {
       expect(dataset.issues?.[0].message).toBe(contextMessage);
     });
 
-    test("from context object even when it's empty", () => {
+    test('from context object with empty string', () => {
       setSpecificMessage(string, specificMessage);
       setSchemaMessage(() => schemaMessage);
       setGlobalMessage(globalMessage);
@@ -153,7 +153,7 @@ describe('_addIssue', () => {
       expect(dataset.issues?.[0].message).toBe(specificMessage);
     });
 
-    test("from specific storage even when it's empty", () => {
+    test('from specific storage with empty string', () => {
       setSpecificMessage(string, '');
       setSchemaMessage(() => schemaMessage);
       setGlobalMessage(globalMessage);
@@ -176,7 +176,7 @@ describe('_addIssue', () => {
       expect(dataset.issues?.[0].message).toBe(schemaMessage);
     });
 
-    test("from schema storage even when it's empty", () => {
+    test('from schema storage with empty string', () => {
       setSchemaMessage(() => '');
       setGlobalMessage(globalMessage);
       const dataset: UnknownDataset = { value: null };
@@ -211,7 +211,7 @@ describe('_addIssue', () => {
       expect(dataset.issues?.[0].message).toBe(configMessage);
     });
 
-    test("from config object even when it's empty", () => {
+    test('from config object with empty string', () => {
       setGlobalMessage(globalMessage);
       const dataset: UnknownDataset = { value: null };
       _addIssue(string(), 'type', dataset, {
@@ -229,7 +229,7 @@ describe('_addIssue', () => {
       expect(dataset.issues?.[0].message).toBe(globalMessage);
     });
 
-    test("from global storage even when it's empty", () => {
+    test('from global storage with empty string', () => {
       setGlobalMessage('');
       const dataset: UnknownDataset = { value: null };
       _addIssue(string(), 'type', dataset, {});

--- a/library/src/utils/_addIssue/_addIssue.test.ts
+++ b/library/src/utils/_addIssue/_addIssue.test.ts
@@ -129,6 +129,18 @@ describe('_addIssue', () => {
       expect(dataset.issues?.[0].message).toBe(contextMessage);
     });
 
+    test("from context object even when it's empty", () => {
+      setSpecificMessage(string, specificMessage);
+      setSchemaMessage(() => schemaMessage);
+      setGlobalMessage(globalMessage);
+      const dataset: UnknownDataset = { value: null };
+      _addIssue(string(''), 'type', dataset, {
+        message: () => configMessage,
+      });
+      // @ts-expect-error
+      expect(dataset.issues?.[0].message).toBe('');
+    });
+
     test('from specific storage', () => {
       setSpecificMessage(string, specificMessage);
       setSchemaMessage(() => schemaMessage);
@@ -141,6 +153,18 @@ describe('_addIssue', () => {
       expect(dataset.issues?.[0].message).toBe(specificMessage);
     });
 
+    test("from specific storage even when it's empty", () => {
+      setSpecificMessage(string, '');
+      setSchemaMessage(() => schemaMessage);
+      setGlobalMessage(globalMessage);
+      const dataset: UnknownDataset = { value: null };
+      _addIssue(string(), 'type', dataset, {
+        message: () => configMessage,
+      });
+      // @ts-expect-error
+      expect(dataset.issues?.[0].message).toBe('');
+    });
+
     test('from schema storage', () => {
       setSchemaMessage(() => schemaMessage);
       setGlobalMessage(globalMessage);
@@ -150,6 +174,17 @@ describe('_addIssue', () => {
       });
       // @ts-expect-error
       expect(dataset.issues?.[0].message).toBe(schemaMessage);
+    });
+
+    test("from schema storage even when it's empty", () => {
+      setSchemaMessage(() => '');
+      setGlobalMessage(globalMessage);
+      const dataset: UnknownDataset = { value: null };
+      _addIssue(string(), 'type', dataset, {
+        message: () => configMessage,
+      });
+      // @ts-expect-error
+      expect(dataset.issues?.[0].message).toBe('');
     });
 
     test('not from schema storage', () => {
@@ -176,12 +211,30 @@ describe('_addIssue', () => {
       expect(dataset.issues?.[0].message).toBe(configMessage);
     });
 
+    test("from config object even when it's empty", () => {
+      setGlobalMessage(globalMessage);
+      const dataset: UnknownDataset = { value: null };
+      _addIssue(string(), 'type', dataset, {
+        message: () => '',
+      });
+      // @ts-expect-error
+      expect(dataset.issues?.[0].message).toBe('');
+    });
+
     test('from global storage', () => {
       setGlobalMessage(globalMessage);
       const dataset: UnknownDataset = { value: null };
       _addIssue(string(), 'type', dataset, {});
       // @ts-expect-error
       expect(dataset.issues?.[0].message).toBe(globalMessage);
+    });
+
+    test("from global storage even when it's empty", () => {
+      setGlobalMessage('');
+      const dataset: UnknownDataset = { value: null };
+      _addIssue(string(), 'type', dataset, {});
+      // @ts-expect-error
+      expect(dataset.issues?.[0].message).toBe('');
     });
   });
 

--- a/library/src/utils/_addIssue/_addIssue.ts
+++ b/library/src/utils/_addIssue/_addIssue.ts
@@ -112,7 +112,7 @@ export function _addIssue<const TContext extends Context>(
     getGlobalMessage(issue.lang);
 
   // If custom message if specified, override default message
-  if (message != null) {
+  if (message !== undefined) {
     // @ts-expect-error
     issue.message =
       typeof message === 'function'

--- a/library/src/utils/_addIssue/_addIssue.ts
+++ b/library/src/utils/_addIssue/_addIssue.ts
@@ -112,7 +112,7 @@ export function _addIssue<const TContext extends Context>(
     getGlobalMessage(issue.lang);
 
   // If custom message if specified, override default message
-  if (message) {
+  if (message != null) {
     // @ts-expect-error
     issue.message =
       typeof message === 'function'


### PR DESCRIPTION
Hello!

I'm using Valibot together with [`@vee-validate/valibot`](http://npmjs.com/@vee-validate/valibot) for form validation on frontend.

In some cases, I'd like to give some fields an empty error message to indicate that the form is invalid, but no error message should be shown to an end user.

Currently valibot skips custom empty error messages as if it's missing and uses the default error message instead.

This PR allows custom empty error messages, which I also think was the initial intention, given the final error message is constructed in such a way that it respects empty strings:

https://github.com/fabian-hiller/valibot/blob/f25b7c7e1621e918f2670f0ba5b8abcfbe7aa550/library/src/utils/_addIssue/_addIssue.ts#L105-L112

