### PR TITLE
style(website): fix hover transition

### DIFF
--- a/website/src/components/PostCover.tsx
+++ b/website/src/components/PostCover.tsx
@@ -12,7 +12,7 @@ type PostCoverProps = {
 export const PostCover = component$<PostCoverProps>(({ variant, label }) => (
   <div
     class={clsx(
-      'relative flex aspect-video select-none items-center justify-center overflow-hidden rounded-xl border-2 border-slate-200 dark:border-slate-800',
+      'relative flex aspect-video select-none items-center justify-center overflow-hidden rounded-xl border-2 border-slate-200 will-change-transform dark:border-slate-800',
       variant === 'blog' && 'duration-100 hover:-translate-y-1 lg:rounded-2xl',
       variant === 'post' &&
         'mx-3 lg:mx-10 lg:rounded-[32px] lg:border-[3px] 2xl:mx-0'

--- a/website/src/components/PostCover.tsx
+++ b/website/src/components/PostCover.tsx
@@ -12,8 +12,9 @@ type PostCoverProps = {
 export const PostCover = component$<PostCoverProps>(({ variant, label }) => (
   <div
     class={clsx(
-      'relative flex aspect-video select-none items-center justify-center overflow-hidden rounded-xl border-2 border-slate-200 will-change-transform dark:border-slate-800',
-      variant === 'blog' && 'duration-100 hover:-translate-y-1 lg:rounded-2xl',
+      'relative flex aspect-video select-none items-center justify-center overflow-hidden rounded-xl border-2 border-slate-200 dark:border-slate-800',
+      variant === 'blog' &&
+        'duration-100 will-change-transform hover:-translate-y-1 lg:rounded-2xl',
       variant === 'post' &&
         'mx-3 lg:mx-10 lg:rounded-[32px] lg:border-[3px] 2xl:mx-0'
     )}


### PR DESCRIPTION
When hovering over the blog posts, the hover transition snaps into place.

Move the transition to the GPU by adding the CSS declaration `will-change: transform;`.
This makes the hover transition smooth and fixes the snapping.

The video demonstrates the snapping issue first and the fix afterwards:

https://github.com/user-attachments/assets/9ed766c9-3c9e-40f8-b1e7-e5a41483404c