### PR TITLE
RFC: feat: add llms.txt generation

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,1 +1,2 @@
 public/sitemap.xml
+public/llms.txt

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -1,7 +1,7 @@
 # Netlify build config
 [build]
   publish = "dist"
-  command = "cd ../library && npm run build && cd ../website && npm run sitemap && npm run build"
+  command = "cd ../library && npm run build && cd ../website && npm run sitemap && npm run llms && npm run build"
 
 # Netlify headers config
 [[headers]]

--- a/website/package.json
+++ b/website/package.json
@@ -25,6 +25,7 @@
     "lint": "eslint \"src/**/*.ts*\"",
     "preview": "qwik build preview && vite preview --open",
     "sitemap": "tsm ./scripts/sitemap.ts",
+    "llms": "tsm ./scripts/llms.ts",
     "sources": "tsm ./scripts/sources.ts",
     "start": "vite --open --mode ssr",
     "qwik": "qwik"

--- a/website/scripts/llms.ts
+++ b/website/scripts/llms.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import path from 'node:path';
+import { findNestedFiles } from "./utils/index";
+import graymatter from 'gray-matter';
+
+const apiFilePaths = findNestedFiles(
+  [path.join('src', 'routes', 'api')],
+  (fileName) => fileName === 'index.mdx'
+);
+
+const guidesFilePaths = findNestedFiles(
+  [path.join('src', 'routes', 'guides')],
+  (fileName) => fileName === 'index.mdx'
+);
+
+const output: string[] = [];
+apiFilePaths.map(filePath => {
+  const frontmatter = graymatter.read(filePath);
+  const content = frontmatter.content
+    .replace(/import.*'~\/components';\n/, '')
+    .replace(/import.*'.\/properties';\n/, '')
+    .replace(/import.*'@builder\.io\/qwik-city';\n/, '')
+    .trim();
+  output.push(content, '\n\n');
+});
+guidesFilePaths.map(filePath => {
+  if (filePath.includes('(migration)')) return;
+  const frontmatter = graymatter.read(filePath);
+  const content = frontmatter.content
+    .replace(/import.*'~\/components';\n/, '')
+    .replace(/import.*'.\/properties';\n/, '')
+    .replace(/import.*'@builder\.io\/qwik-city';\n/, '')
+    .replace('import MentalModelDark from \'./mental-model-dark.jpg?jsx\';\n', '')
+    .replace('import MentalModelLight from \'./mental-model-light.jpg?jsx\';\n', '')
+    .trim();
+  output.push(content, '\n\n');
+});
+
+fs.writeFileSync(
+  path.join('public', 'llms.txt'),
+  output.join('')
+);

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "cd ../library && npm run build && cd ../website && npm run sitemap && npm run build",
+  "buildCommand": "cd ../library && npm run build && cd ../website && npm run sitemap && npm run llms && npm run build",
   "headers": [
     {
       "source": "/(.*)?service-worker.js",


### PR DESCRIPTION
This adds generation of llms.txt, which is used there and there by various libraries, to expose API, documentationn, and information in format, which is easier to be consumed by LLMS. Not yet de-facto standard. Before merging however, would probably be good to agree on a format.

Right now it just strips frontmatter (subject to change/discussion) MDX's imports and trims empty space at start and end of each Markdown file. As a minimum, probably, worth to include description from frontmatter in each sectionz

---

More here :https://llmstxt.org/
Example in the wild: https://hono.dev/llms-full.txt, https://sdk.vercel.ai/llms.txt