### PR TITLE
Fix stringification of objects with null prototype

### DIFF
--- a/website/src/routes/playground/iframeCode.js
+++ b/website/src/routes/playground/iframeCode.js
@@ -45,11 +45,7 @@ function stringify(args) {
           // If it is a non supported object, convert it to its constructor name
           if (value && (type === 'object' || type === 'function')) {
             const name = Object.getPrototypeOf(value)?.constructor?.name;
-            if (
-              typeof name === 'string' &&
-              name !== 'Object' &&
-              name !== 'Array'
-            ) {
+            if (name && name !== 'Object' && name !== 'Array') {
               return `[${name}]`;
             }
           }

--- a/website/src/routes/playground/iframeCode.js
+++ b/website/src/routes/playground/iframeCode.js
@@ -44,8 +44,12 @@ function stringify(args) {
 
           // If it is a non supported object, convert it to its constructor name
           if (value && (type === 'object' || type === 'function')) {
-            const name = Object.getPrototypeOf(value).constructor.name;
-            if (name !== 'Object' && name !== 'Array') {
+            const name = Object.getPrototypeOf(value)?.constructor?.name;
+            if (
+              typeof name === 'string' &&
+              name !== 'Object' &&
+              name !== 'Array'
+            ) {
               return `[${name}]`;
             }
           }


### PR DESCRIPTION
`Object.getPrototypeOf` can return `null` if the object passed to it has a `null` prototype. If that is the case, we can not access any properties on the `null` prototype.

Use optional chaining after getting the object's prototype to attempt to get the name of the prototype's constructor. Then check to see if `name` is a string before checking to see if the constructor's name is something we want to use in place of the value in the stringified result.

This fixes fabian-hiller/valibot#1114.