### PR TITLE
fix(intersect): do not fail on looseObject with pipe

### DIFF
--- a/library/src/schemas/intersect/intersect.test.ts
+++ b/library/src/schemas/intersect/intersect.test.ts
@@ -85,7 +85,7 @@ describe('intersect', () => {
       );
     });
 
-    test('for loose objects with pipes', () => {
+    test('for loose objects with transform', () => {
       expectNoSchemaIssue(
         intersect([
           looseObject({ key1: pipe(string(), toLowerCase()) }),

--- a/library/src/schemas/intersect/intersect.test.ts
+++ b/library/src/schemas/intersect/intersect.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'vitest';
-import { minLength, minValue, transform } from '../../actions/index.ts';
+import {
+  minLength,
+  minValue,
+  toLowerCase,
+  toUpperCase,
+  transform,
+} from '../../actions/index.ts';
 import { pipe } from '../../methods/index.ts';
 import type {
   FailureDataset,
@@ -10,6 +16,7 @@ import type {
 import { expectNoSchemaIssue } from '../../vitest/index.ts';
 import { array } from '../array/array.ts';
 import { date } from '../date/index.ts';
+import { looseObject } from '../looseObject/looseObject.ts';
 import { number } from '../number/index.ts';
 import { object } from '../object/index.ts';
 import { string } from '../string/index.ts';
@@ -74,6 +81,23 @@ describe('intersect', () => {
             { key1: 'foo', key2: 123, key3: new Date(), key4: ['foo', 'bar'] },
             { key1: 'bar', key2: -456, key3: new Date(), key4: ['baz'] },
           ],
+        ]
+      );
+    });
+
+    test('for loose objects with pipes', () => {
+      expectNoSchemaIssue(
+        intersect([
+          looseObject({ key1: pipe(string(), toLowerCase()) }),
+          looseObject({ key2: pipe(string(), toUpperCase()) }),
+        ]),
+        [
+          // both inputs matching the output
+          { key1: 'foo', key2: 'BAR' },
+          // one input matching the output, the other not
+          { key1: 'FOO', key2: 'BAR' },
+          // both inputs not matching the output
+          { key1: 'FOO', key2: 'bar' },
         ]
       );
     });

--- a/library/src/schemas/intersect/intersectAsync.test.ts
+++ b/library/src/schemas/intersect/intersectAsync.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'vitest';
-import { minLength, minValue, transform } from '../../actions/index.ts';
+import {
+  minLength,
+  minValue,
+  toLowerCase,
+  toUpperCase,
+  transform,
+} from '../../actions/index.ts';
 import { pipe } from '../../methods/index.ts';
 import type {
   FailureDataset,
@@ -11,6 +17,8 @@ import { expectNoSchemaIssueAsync } from '../../vitest/index.ts';
 import { array } from '../array/array.ts';
 import { arrayAsync } from '../array/arrayAsync.ts';
 import { date } from '../date/index.ts';
+import { looseObject } from '../looseObject/looseObject.ts';
+import { looseObjectAsync } from '../looseObject/looseObjectAsync.ts';
 import { number } from '../number/index.ts';
 import { object, objectAsync } from '../object/index.ts';
 import { string } from '../string/index.ts';
@@ -75,6 +83,23 @@ describe('intersectAsync', () => {
             { key1: 'foo', key2: 123, key3: new Date(), key4: ['foo', 'bar'] },
             { key1: 'bar', key2: -456, key3: new Date(), key4: ['baz'] },
           ],
+        ]
+      );
+    });
+
+    test('for loose objects with transform', async () => {
+      await expectNoSchemaIssueAsync(
+        intersectAsync([
+          looseObject({ key1: pipe(string(), toLowerCase()) }),
+          looseObjectAsync({ key2: pipe(string(), toUpperCase()) }),
+        ]),
+        [
+          // both inputs matching the output
+          { key1: 'foo', key2: 'BAR' },
+          // one input matching the output, the other not
+          { key1: 'FOO', key2: 'BAR' },
+          // both inputs not matching the output
+          { key1: 'FOO', key2: 'bar' },
         ]
       );
     });


### PR DESCRIPTION
Fixes #1147 