### PR TITLE
fix: getFallbacks use fallback value of an object

### DIFF
--- a/library/src/methods/getFallbacks/getFallbacks.test.ts
+++ b/library/src/methods/getFallbacks/getFallbacks.test.ts
@@ -47,7 +47,7 @@ describe('getFallbacks', () => {
       });
     });
 
-    test('for nested object', () => {
+    test.only('for nested object', () => {
       expect(
         getFallbacks(
           object({
@@ -56,6 +56,7 @@ describe('getFallbacks', () => {
               key2: fallback(number(), () => 123 as const),
               key3: fallback(boolean(), false as const),
             }),
+            objectWithFallback: fallback(object({ foo: string() }), { foo: "bar" }),
             other: string(),
           })
         )
@@ -65,6 +66,7 @@ describe('getFallbacks', () => {
           key2: 123,
           key3: false,
         },
+        objectWithFallback: { foo: "bar" },
         other: undefined,
       });
     });

--- a/library/src/methods/getFallbacks/getFallbacks.ts
+++ b/library/src/methods/getFallbacks/getFallbacks.ts
@@ -64,6 +64,12 @@ export function getFallbacks<
         ErrorMessage<TupleWithRestIssue> | undefined
       >,
 >(schema: TSchema): InferFallbacks<TSchema> {
+  
+  // If it's and object schema and it has a fallback, return it
+  if (schema.type === 'object' && 'fallback' in schema) {
+    return schema.fallback as InferFallbacks<TSchema>;
+  }
+
   // If it is an object schema, return fallbacks of entries
   if ('entries' in schema) {
     const object: Record<string, unknown> = {};


### PR DESCRIPTION
Resolves #1150 

This is, semi breaking change though I would assume, as it changes default behaviour.
Previously, it would check for fallbacks of an object, and ignore if it has a fallback itself, eg.:
```ts
const ObjectWithFallback = v.fallback(
  v.object({ foo: string() }), <-- checks if entries of this object has a fallback
  { foo: "bar" }, <-- completely ignored
);
```

