### PR TITLE
docs: add isoDate with minValue example

### DIFF
--- a/website/src/routes/api/(actions)/isoDate/index.mdx
+++ b/website/src/routes/api/(actions)/isoDate/index.mdx
@@ -53,6 +53,18 @@ const IsoDateSchema = v.pipe(
 );
 ```
 
+### Minimum value schema
+
+Schema to validate an ISO date is after a certain date.
+
+```ts
+const MinValueSchema = v.pipe(
+  v.string(),
+  v.isoDate(),
+  v.minValue('2000-01-01', 'The date must be after the year 1999.')
+)
+```
+
 ## Related
 
 The following APIs can be combined with `isoDate`.


### PR DESCRIPTION
Following up a [discussion on Discord](https://discord.com/channels/1252985447273992222/1362417323478089789/1363277287507755119) this example shows how to use `v.isoDate` in combination with `v.minValue` to show how to validate that an incoming `v.string` is in the isoDate-Format and is after a certain point in time.