### PR TITLE
fix: update nanoid to be more accurate

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the library will be documented in this file.
 - Add `minEntries` and `maxEntries` validation action to validate number of object entries (pull request #1100)
 - Add `entries` and `notEntries` validation action to validate number of object entries (pull request #1156)
 - Change implementation of `variant` and `variantAsync` schema to improve performance by aborting validation of discriminators early (pull request #1110)
+- Change name of `NanoIDAction` and `NanoIDIssue` interface to `NanoIdAction` and `NanoIdIssue` (pull request #1171)
 
 ## v1.0.0 (March 18, 2025)
 

--- a/library/src/actions/nanoid/nanoid.test-d.ts
+++ b/library/src/actions/nanoid/nanoid.test-d.ts
@@ -1,11 +1,11 @@
 import { describe, expectTypeOf, test } from 'vitest';
 import type { InferInput, InferIssue, InferOutput } from '../../types/index.ts';
-import { nanoid, type NanoIDAction, type NanoIDIssue } from './nanoid.ts';
+import { nanoid, type NanoIdAction, type NanoIdIssue } from './nanoid.ts';
 
 describe('nanoid', () => {
   describe('should return action object', () => {
     test('with undefined message', () => {
-      type Action = NanoIDAction<string, undefined>;
+      type Action = NanoIdAction<string, undefined>;
       expectTypeOf(nanoid<string>()).toEqualTypeOf<Action>();
       expectTypeOf(
         nanoid<string, undefined>(undefined)
@@ -14,19 +14,19 @@ describe('nanoid', () => {
 
     test('with string message', () => {
       expectTypeOf(nanoid<string, 'message'>('message')).toEqualTypeOf<
-        NanoIDAction<string, 'message'>
+        NanoIdAction<string, 'message'>
       >();
     });
 
     test('with function message', () => {
       expectTypeOf(nanoid<string, () => string>(() => 'message')).toEqualTypeOf<
-        NanoIDAction<string, () => string>
+        NanoIdAction<string, () => string>
       >();
     });
   });
 
   describe('should infer correct types', () => {
-    type Action = NanoIDAction<string, undefined>;
+    type Action = NanoIdAction<string, undefined>;
 
     test('of input', () => {
       expectTypeOf<InferInput<Action>>().toEqualTypeOf<string>();
@@ -37,7 +37,7 @@ describe('nanoid', () => {
     });
 
     test('of issue', () => {
-      expectTypeOf<InferIssue<Action>>().toEqualTypeOf<NanoIDIssue<string>>();
+      expectTypeOf<InferIssue<Action>>().toEqualTypeOf<NanoIdIssue<string>>();
     });
   });
 });

--- a/library/src/actions/nanoid/nanoid.test.ts
+++ b/library/src/actions/nanoid/nanoid.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, test } from 'vitest';
 import { NANO_ID_REGEX } from '../../regex.ts';
 import type { StringIssue } from '../../schemas/index.ts';
 import { expectActionIssue, expectNoActionIssue } from '../../vitest/index.ts';
-import { nanoid, type NanoIDAction, type NanoIDIssue } from './nanoid.ts';
+import { nanoid, type NanoIdAction, type NanoIdIssue } from './nanoid.ts';
 
 describe('nanoid', () => {
   describe('should return action object', () => {
-    const baseAction: Omit<NanoIDAction<string, never>, 'message'> = {
+    const baseAction: Omit<NanoIdAction<string, never>, 'message'> = {
       kind: 'validation',
       type: 'nanoid',
       reference: nanoid,
@@ -17,7 +17,7 @@ describe('nanoid', () => {
     };
 
     test('with undefined message', () => {
-      const action: NanoIDAction<string, undefined> = {
+      const action: NanoIdAction<string, undefined> = {
         ...baseAction,
         message: undefined,
       };
@@ -29,7 +29,7 @@ describe('nanoid', () => {
       expect(nanoid('message')).toStrictEqual({
         ...baseAction,
         message: 'message',
-      } satisfies NanoIDAction<string, string>);
+      } satisfies NanoIdAction<string, string>);
     });
 
     test('with function message', () => {
@@ -37,7 +37,7 @@ describe('nanoid', () => {
       expect(nanoid(message)).toStrictEqual({
         ...baseAction,
         message,
-      } satisfies NanoIDAction<string, typeof message>);
+      } satisfies NanoIdAction<string, typeof message>);
     });
   });
 
@@ -91,7 +91,7 @@ describe('nanoid', () => {
 
   describe('should return dataset with issues', () => {
     const action = nanoid('message');
-    const baseIssue: Omit<NanoIDIssue<string>, 'input' | 'received'> = {
+    const baseIssue: Omit<NanoIdIssue<string>, 'input' | 'received'> = {
       kind: 'validation',
       type: 'nanoid',
       expected: null,

--- a/library/src/actions/nanoid/nanoid.ts
+++ b/library/src/actions/nanoid/nanoid.ts
@@ -9,7 +9,7 @@ import { _addIssue } from '../../utils/index.ts';
 /**
  * Nano ID issue interface.
  */
-export interface NanoIDIssue<TInput extends string> extends BaseIssue<TInput> {
+export interface NanoIdIssue<TInput extends string> extends BaseIssue<TInput> {
   /**
    * The issue kind.
    */
@@ -35,10 +35,10 @@ export interface NanoIDIssue<TInput extends string> extends BaseIssue<TInput> {
 /**
  * Nano ID action interface.
  */
-export interface NanoIDAction<
+export interface NanoIdAction<
   TInput extends string,
-  TMessage extends ErrorMessage<NanoIDIssue<TInput>> | undefined,
-> extends BaseValidation<TInput, TInput, NanoIDIssue<TInput>> {
+  TMessage extends ErrorMessage<NanoIdIssue<TInput>> | undefined,
+> extends BaseValidation<TInput, TInput, NanoIdIssue<TInput>> {
   /**
    * The action type.
    */
@@ -66,7 +66,7 @@ export interface NanoIDAction<
  *
  * @returns A Nano ID action.
  */
-export function nanoid<TInput extends string>(): NanoIDAction<
+export function nanoid<TInput extends string>(): NanoIdAction<
   TInput,
   undefined
 >;
@@ -80,13 +80,13 @@ export function nanoid<TInput extends string>(): NanoIDAction<
  */
 export function nanoid<
   TInput extends string,
-  const TMessage extends ErrorMessage<NanoIDIssue<TInput>> | undefined,
->(message: TMessage): NanoIDAction<TInput, TMessage>;
+  const TMessage extends ErrorMessage<NanoIdIssue<TInput>> | undefined,
+>(message: TMessage): NanoIdAction<TInput, TMessage>;
 
 // @__NO_SIDE_EFFECTS__
 export function nanoid(
-  message?: ErrorMessage<NanoIDIssue<string>>
-): NanoIDAction<string, ErrorMessage<NanoIDIssue<string>> | undefined> {
+  message?: ErrorMessage<NanoIdIssue<string>>
+): NanoIdAction<string, ErrorMessage<NanoIdIssue<string>> | undefined> {
   return {
     kind: 'validation',
     type: 'nanoid',

--- a/library/src/actions/nanoid/nanoid.ts
+++ b/library/src/actions/nanoid/nanoid.ts
@@ -33,6 +33,13 @@ export interface NanoIdIssue<TInput extends string> extends BaseIssue<TInput> {
 }
 
 /**
+ * Nano ID issue type.
+ *
+ * @deprecated Use `NanoIdIssue` instead.
+ */
+export type NanoIDIssue<TInput extends string> = NanoIdIssue<TInput>;
+
+/**
  * Nano ID action interface.
  */
 export interface NanoIdAction<
@@ -60,6 +67,16 @@ export interface NanoIdAction<
    */
   readonly message: TMessage;
 }
+
+/**
+ * Nano ID action type.
+ *
+ * @deprecated Use `NanoIdAction` instead.
+ */
+export type NanoIDAction<
+  TInput extends string,
+  TMessage extends ErrorMessage<NanoIdIssue<TInput>> | undefined,
+> = NanoIdAction<TInput, TMessage>;
 
 /**
  * Creates a [Nano ID](https://github.com/ai/nanoid) validation action.

--- a/library/src/regex.ts
+++ b/library/src/regex.ts
@@ -135,9 +135,7 @@ export const MAC_REGEX: RegExp =
 /**
  * [Nano ID](https://github.com/ai/nanoid) regex.
  */
-export const NANO_ID_REGEX: RegExp =
-  // eslint-disable-next-line regexp/prefer-w
-  /^[A-Za-z0-9_-]+$/u;
+export const NANO_ID_REGEX: RegExp = /^[\w-]+$/u;
 
 /**
  * [Octal](https://en.wikipedia.org/wiki/Octal) regex.

--- a/library/src/regex.ts
+++ b/library/src/regex.ts
@@ -135,7 +135,9 @@ export const MAC_REGEX: RegExp =
 /**
  * [Nano ID](https://github.com/ai/nanoid) regex.
  */
-export const NANO_ID_REGEX: RegExp = /^[\w-]+$/u;
+export const NANO_ID_REGEX: RegExp =
+  // eslint-disable-next-line regexp/prefer-w
+  /^[A-Za-z0-9_-]+$/u;
 
 /**
  * [Octal](https://en.wikipedia.org/wiki/Octal) regex.

--- a/packages/to-json-schema/src/convertAction.ts
+++ b/packages/to-json-schema/src/convertAction.ts
@@ -85,7 +85,7 @@ type Action =
       number,
       v.ErrorMessage<v.MultipleOfIssue<number, number>> | undefined
     >
-  | v.NanoIDAction<string, v.ErrorMessage<v.NanoIDIssue<string>> | undefined>
+  | v.NanoIdAction<string, v.ErrorMessage<v.NanoIdIssue<string>> | undefined>
   | v.NonEmptyAction<
       v.LengthInput,
       v.ErrorMessage<v.NonEmptyIssue<v.LengthInput>> | undefined

--- a/website/src/routes/api/(actions)/nanoid/index.mdx
+++ b/website/src/routes/api/(actions)/nanoid/index.mdx
@@ -47,7 +47,7 @@ The following examples show how `nanoid` can be used.
 Schema to validate a Nano ID.
 
 ```ts
-const NanoIDSchema = v.pipe(
+const NanoIdSchema = v.pipe(
   v.string(),
   v.nanoid('The Nano ID is badly formatted.'),
   v.length(21, 'The Nano ID must be 21 characters long.')

--- a/website/src/routes/api/(actions)/nanoid/properties.ts
+++ b/website/src/routes/api/(actions)/nanoid/properties.ts
@@ -17,8 +17,8 @@ export const properties: Record<string, PropertyProps> = {
           generics: [
             {
               type: 'custom',
-              name: 'NanoIDIssue',
-              href: '../NanoIDIssue/',
+              name: 'NanoIdIssue',
+              href: '../NanoIdIssue/',
               generics: [
                 {
                   type: 'custom',
@@ -41,8 +41,8 @@ export const properties: Record<string, PropertyProps> = {
   Action: {
     type: {
       type: 'custom',
-      name: 'NanoIDAction',
-      href: '../NanoIDAction/',
+      name: 'NanoIdAction',
+      href: '../NanoIdAction/',
       generics: [
         {
           type: 'custom',


### PR DESCRIPTION
Looking at my old commit, I realized that the old regex was partially wrong due to ESLint autofix. The old regex was less strict and allowed for certain characters that are invalid in Nano ID.

This PR also standardizes all the types and interface with regards to Nano ID to PascalCase.