### PR TITLE
feat(to-json-schema): support examples field

### DIFF
--- a/packages/to-json-schema/CHANGELOG.md
+++ b/packages/to-json-schema/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Add support for title, description and examples in `metadata` action (pull request #1189)
+
 ## v1.1.0 (May 06, 2025)
 
 - Add support for `minEntries` and `maxEntries` action (pull request #1100)

--- a/packages/to-json-schema/src/convertAction.test.ts
+++ b/packages/to-json-schema/src/convertAction.test.ts
@@ -457,6 +457,12 @@ describe('convertAction', () => {
     );
   });
 
+  test('should convert metadata action', () => {
+    expect(
+      convertAction({}, v.metadata({ examples: ['test'] }), undefined)
+    ).toStrictEqual({ examples: ['test'] });
+  });
+
   test('should convert min length action for strings', () => {
     expect(
       convertAction(

--- a/packages/to-json-schema/src/convertAction.test.ts
+++ b/packages/to-json-schema/src/convertAction.test.ts
@@ -459,8 +459,36 @@ describe('convertAction', () => {
 
   test('should convert metadata action', () => {
     expect(
-      convertAction({}, v.metadata({ examples: ['test'] }), undefined)
-    ).toStrictEqual({ examples: ['test'] });
+      convertAction(
+        {},
+        v.metadata({
+          title: 'title',
+          description: 'description',
+          examples: ['example'],
+          other: 'other',
+        }),
+        undefined
+      )
+    ).toStrictEqual({
+      title: 'title',
+      description: 'description',
+      examples: ['example'],
+    });
+  });
+
+  test('should skip invalid metadata properties', () => {
+    expect(
+      convertAction(
+        {},
+        v.metadata({
+          title: 123,
+          description: null,
+          examples: { foo: 'bar' },
+          other: 'other',
+        }),
+        undefined
+      )
+    ).toStrictEqual({});
   });
 
   test('should convert min length action for strings', () => {

--- a/packages/to-json-schema/src/convertAction.ts
+++ b/packages/to-json-schema/src/convertAction.ts
@@ -1,4 +1,4 @@
-import type { JSONSchema7, JSONSchema7Type } from 'json-schema';
+import type { JSONSchema7 } from 'json-schema';
 import type * as v from 'valibot';
 import type { ConversionConfig } from './type.ts';
 import { handleError } from './utils/index.ts';
@@ -249,12 +249,14 @@ export function convertAction(
     }
 
     case 'metadata': {
-      if (
-        valibotAction.metadata.examples !== undefined &&
-        valibotAction.metadata.examples !== null
-      ) {
-        jsonSchema.examples = valibotAction.metadata
-          .examples as JSONSchema7Type;
+      if (typeof valibotAction.metadata.title === 'string') {
+        jsonSchema.title = valibotAction.metadata.title;
+      }
+      if (typeof valibotAction.metadata.description === 'string') {
+        jsonSchema.description = valibotAction.metadata.description;
+      }
+      if (Array.isArray(valibotAction.metadata.examples)) {
+        jsonSchema.examples = valibotAction.metadata.examples;
       }
       break;
     }

--- a/packages/to-json-schema/src/convertAction.ts
+++ b/packages/to-json-schema/src/convertAction.ts
@@ -1,4 +1,4 @@
-import type { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7, JSONSchema7Type } from 'json-schema';
 import type * as v from 'valibot';
 import type { ConversionConfig } from './type.ts';
 import { handleError } from './utils/index.ts';
@@ -65,6 +65,7 @@ type Action =
       v.ValueInput,
       v.ErrorMessage<v.MaxValueIssue<v.ValueInput, v.ValueInput>> | undefined
     >
+  | v.MetadataAction<unknown, Record<string, unknown>>
   | v.MinEntriesAction<
       v.EntriesInput,
       number,
@@ -244,6 +245,17 @@ export function convertAction(
       }
       // @ts-expect-error
       jsonSchema.maximum = valibotAction.requirement;
+      break;
+    }
+
+    case 'metadata': {
+      if (
+        valibotAction.metadata.examples !== undefined &&
+        valibotAction.metadata.examples !== null
+      ) {
+        jsonSchema.examples = valibotAction.metadata
+          .examples as JSONSchema7Type;
+      }
       break;
     }
 


### PR DESCRIPTION
this pr adds support for the examples field to the to-json-schema conversion in valibot.

when a valibot schema includes a `metadata` action with an `examples` property, this property will now be translated to the `examples` field in the outputted `JSONSchema`.

this enhances the richness of the generated json schemas, allowing valibot schema examples to be available for documentation or tooling that consumes json schema.

open to iterating on the implementation.