### PR TITLE
Remove duplicate rawTransformAsync action

### DIFF
--- a/website/src/routes/api/menu.md
+++ b/website/src/routes/api/menu.md
@@ -159,7 +159,6 @@
 - [partialCheck](/api/partialCheck/)
 - [rawCheck](/api/rawCheck/)
 - [rawTransform](/api/rawTransform/)
-- [rawTransformAsync](/api/rawTransformAsync/)
 - [readonly](/api/readonly/)
 - [reduceItems](/api/reduceItems/)
 - [regex](/api/regex/)


### PR DESCRIPTION
This action belongs and is already included in the Async section, there's no need to list it twice under the Actions section as well.