### PR TITLE
Add `valipass` to Ecosystem page

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -95,3 +95,4 @@ This page is for you if you are looking for frameworks or libraries that support
 - [valibotx](https://github.com/IlyaSemenov/valibotx): A collection of extensions and shortcuts to core Valibot functions
 - [valiload](https://github.com/JuerGenie/valiload): A simple and lightweight library for overloading functions in TypeScript
 - [valimock](https://github.com/saeris/valimock): Generate mock data using your Valibot schemas using [Faker](https://github.com/faker-js/faker)
+- [valipass](https://github.com/Saeris/valipass): Collection of password validation actions for Valibot schemas


### PR DESCRIPTION
Added a link to [`valipass`](https://github.com/Saeris/valipass) to the Ecosystem page.

This library consists of a handful of validation actions and a `password` schema with some sensible password requirement defaults. It is functionally a Valibot version of [`yup-password`](https://github.com/knicola/yup-password) and is meant to be used in client-side form validation scenarios.