### PR TITLE
Add `svelte-jsonschema-form` to ecosystem page

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -63,6 +63,7 @@ This page is for you if you are looking for frameworks or libraries that support
 - [React Hook Form](https://react-hook-form.com/): React Hooks for form state management and validation
 - [regle](https://github.com/victorgarciaesgi/regle): Headless form validation library for Vue.js
 - [Superforms](https://superforms.rocks): A comprehensive SvelteKit form library for server and client validation
+- [svelte-jsonschema-form](https://x0k.dev/svelte-jsonschema-form/validators/valibot/): Svelte 5 library for creating forms based on JSON schema
 - [TanStack Form](https://tanstack.com/form): Powerful and type-safe form state management for the web
 - [VeeValidate](https://vee-validate.logaretm.com/v4/): Painless Vue.js forms
 - [vue-valibot-form](https://github.com/IlyaSemenov/vue-valibot-form): Minimalistic Vue3 composable for handling form submit


### PR DESCRIPTION
I have implemented Valibot support in `svelte-jsonschema-form`.

- [Docs](https://x0k.dev/svelte-jsonschema-form/validators/valibot/)
- Related PR https://github.com/x0k/svelte-jsonschema-form/pull/156