### PR TITLE
chore: write output to disk when testing codemod

### DIFF
--- a/codemod/zod-to-valibot/.gitignore
+++ b/codemod/zod-to-valibot/.gitignore
@@ -1,0 +1,1 @@
+__testfixtures__/*/_actual.ts

--- a/codemod/zod-to-valibot/src/utils.ts
+++ b/codemod/zod-to-valibot/src/utils.ts
@@ -66,6 +66,7 @@ export function defineTests(transform: Transform, selectedTests?: string[]) {
         { j, jscodeshift: j, stats: () => {}, report: () => {} },
         {}
       );
+      fs.writeFileSync(path.join(testPath, '_actual.ts'), output?.trim() ?? '');
       expect(output?.trim()).toBe(expectedOutput.trim());
     });
   }

--- a/codemod/zod-to-valibot/src/utils.ts
+++ b/codemod/zod-to-valibot/src/utils.ts
@@ -66,7 +66,11 @@ export function defineTests(transform: Transform, selectedTests?: string[]) {
         { j, jscodeshift: j, stats: () => {}, report: () => {} },
         {}
       );
-      fs.writeFileSync(path.join(testPath, '_actual.ts'), output?.trim() ?? '');
+      fs.writeFile(
+        path.join(testPath, '_actual.ts'),
+        output?.trim() ?? '',
+        () => {}
+      );
       expect(output?.trim()).toBe(expectedOutput.trim());
     });
   }


### PR DESCRIPTION
I'm working on fixing the codemod and while doing so I found pretty hard working with it because you are going off the diff in the console (also since whitespace counts you can't even copy the new output if it's meant to change).

This is a small chore that makes everything easier to reason and work with: when we test something we also write the `_actual` transform to disk so that you can open it with your editor of choice, look at the diff and even copy paste the result once you are satisfied with it.

Obviously it's git-ignored so we don't flood the repo, it's just for debugging purpose.