### PR TITLE
feat: add `or` migration

### DIFF
--- a/codemod/zod-to-valibot/__testfixtures__/or/input.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/or/input.ts
@@ -1,0 +1,3 @@
+import { z } from "zod";
+
+const Schema1 = z.string().or(z.number());

--- a/codemod/zod-to-valibot/__testfixtures__/or/input.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/or/input.ts
@@ -1,3 +1,4 @@
 import { z } from "zod";
 
 const Schema1 = z.string().or(z.number());
+const Schema2 = z.string().or(z.number()).or(z.boolean());

--- a/codemod/zod-to-valibot/__testfixtures__/or/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/or/output.ts
@@ -1,0 +1,3 @@
+import * as v from "valibot";
+
+const Schema1 = v.union(v.string(), v.number());

--- a/codemod/zod-to-valibot/__testfixtures__/or/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/or/output.ts
@@ -1,3 +1,4 @@
 import * as v from "valibot";
 
-const Schema1 = v.union(v.string(), v.number());
+const Schema1 = v.union([v.string(), v.number()]);
+const Schema2 = v.union([v.union([v.string(), v.number()]), v.boolean()]);

--- a/codemod/zod-to-valibot/src/test-setup.test.ts
+++ b/codemod/zod-to-valibot/src/test-setup.test.ts
@@ -51,6 +51,7 @@ defineTests(transform, [
   'object-strict',
   'object-strip',
   'optional-schema',
+  'or',
   'parsing',
   'readonly',
   'record-schema',

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/constants.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/constants.ts
@@ -144,6 +144,7 @@ export const ZOD_METHODS = [
   'keyof',
   'omit',
   'optional',
+  'or',
   'merge',
   'nullable',
   'nullish',

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/index.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/index.ts
@@ -11,6 +11,7 @@ export * from './nullable';
 export * from './nullish';
 export * from './omit';
 export * from './optional';
+export * from './or';
 export * from './parse';
 export * from './parseAsync';
 export * from './partial';

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/or/index.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/or/index.ts
@@ -1,0 +1,1 @@
+export * from './or';

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/or/or.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/or/or.ts
@@ -7,6 +7,6 @@ export function transformOr(
 ) {
   return j.callExpression(
     j.memberExpression(j.identifier(valibotIdentifier), j.identifier('union')),
-    [schemaExp, ...inputArgs]
+    [j.arrayExpression([schemaExp, ...inputArgs])]
   );
 }

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/or/or.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/or/or.ts
@@ -1,0 +1,12 @@
+import j from 'jscodeshift';
+
+export function transformOr(
+  valibotIdentifier: string,
+  schemaExp: j.CallExpression | j.MemberExpression | j.Identifier,
+  inputArgs: j.CallExpression['arguments']
+) {
+  return j.callExpression(
+    j.memberExpression(j.identifier(valibotIdentifier), j.identifier('union')),
+    [schemaExp, ...inputArgs]
+  );
+}

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
@@ -23,6 +23,7 @@ import {
   transformNullish,
   transformOmit,
   transformOptional as transformOptionalMethod,
+  transformOr,
   transformParse,
   transformParseAsync,
   transformPartial,
@@ -359,6 +360,8 @@ function toValibotMethodExp(
       return transformKeyof(...args);
     case 'omit':
       return transformOmit(...args);
+    case 'or':
+      return transformOr(...args);
     case 'optional':
       return transformOptionalMethod(...args);
     case 'merge':


### PR DESCRIPTION
Currently migrating `or` produces a runtime error

```ts
import * as z from 'zod';

const Schema = z.string().or(z.number())
```

proudces

```ts
import * as v from "valibot";

const Schema = v.string()(v.number())
```

this fixes it migrating or to an union.