### PR TITLE
fix: properly migrate `strict` and `passthrough`

### DIFF
--- a/codemod/zod-to-valibot/__testfixtures__/object-extend/input.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-extend/input.ts
@@ -33,36 +33,94 @@ const Schema21 = Schema20.extend({bar: z.string()});
 const Schema22 = z.object({foo: z.string()}).extend({bar: z.number()}).catchall(z.null());
 const Schema23 = Schema2.extend({bar: z.string()}).catchall(z.null());
 
+// i don't know which crazy person would do this, but it is valid
+// and we support it so we might as well test it
+const Schema24 = Schema23.extend(...[Schema22.shape]);
+
 // ------------ Expected transform ------------
 // // plain
-// const Schema1 = v.object({...{foo: v.string()}, ...{bar: v.number()}});
+// const Schema1 = v.object({
+//   foo: v.string(),
+//   bar: v.number()
+// });
 // const Schema2 = v.object({foo: v.number()});
-// const Schema3 = v.object({...Schema2.entries, ...{bar: v.string()}});
+// const Schema3 = v.object({
+//   ...Schema2.entries,
+//   bar: v.string()
+// });
 
 // // passthrough
-// const Schema4 = v.looseObject({...{foo: v.string()}, ...{bar: v.number()}});
+// const Schema4 = v.object({
+//   ...v.looseObject({foo: v.string()}).entries,
+//   bar: v.number()
+// });
 // const Schema5 = v.looseObject({foo: v.number()});
-// const Schema6 = v.looseObject({...Schema5.entries, ...{bar: v.string()}});
-// const Schema7 = v.looseObject({...{foo: v.string()}, ...{bar: v.number()}});
-// const Schema8 = v.looseObject({...Schema2.entries, ...{bar: v.string()}});
+// const Schema6 = v.object({
+//   ...Schema5.entries,
+//   bar: v.string()
+// });
+// const Schema7 = v.looseObject({
+//   ...v.looseObject({foo: v.string()}).entries,
+//   bar: v.number()
+// });
+// const Schema8 = v.looseObject({
+//   ...Schema2.entries,
+//   bar: v.string()
+// });
 
 // // strict
-// const Schema9 = v.strictObject({...{foo: v.string()}, ...{bar: v.number()}});
+// const Schema9 = v.object({
+//   ...v.strictObject({foo: v.string()}).entries,
+//   bar: v.number()
+// });
 // const Schema10 = v.strictObject({foo: v.number()});
-// const Schema11 = v.strictObject({...Schema10.entries, ...{bar: v.string()}});
-// const Schema12 = v.strictObject({...{foo: v.string()}, ...{bar: v.number()}});
-// const Schema13 = v.strictObject({...Schema2.entries, ...{bar: v.string()}});
+// const Schema11 = v.object({
+//   ...Schema10.entries,
+//   bar: v.string()
+// });
+// const Schema12 = v.strictObject({
+//   ...v.strictObject({foo: v.string()}).entries,
+//   bar: v.number()
+// });
+// const Schema13 = v.strictObject({
+//   ...Schema2.entries,
+//   bar: v.string()
+// });
 
 // // strip
-// const Schema14 = v.object({...{foo: v.string()}, ...{bar: v.number()}});
+// const Schema14 = v.object({
+//   foo: v.string(),
+//   bar: v.number()
+// });
 // const Schema15 = v.object({foo: v.number()});
-// const Schema16 = v.object({...Schema15.entries, ...{bar: v.string()}});
-// const Schema17 = v.object({...{foo: v.string()}, ...{bar: v.number()}});
-// const Schema18 = v.object({...Schema2.entries, ...{bar: v.string()}});
+// const Schema16 = v.object({
+//   ...Schema15.entries,
+//   bar: v.string()
+// });
+// const Schema17 = v.object({
+//   foo: v.string(),
+//   bar: v.number()
+// });
+// const Schema18 = v.object({
+//   ...Schema2.entries,
+//   bar: v.string()
+// });
 
 // // catchall
-// const Schema19 = v.objectWithRest({...{foo: v.string()}, ...{bar: v.number()}}, v.null());
+// const Schema19 = v.object({
+//   ...v.objectWithRest({foo: v.string()}, v.null()).entries,
+//   bar: v.number()
+// });
 // const Schema20 = v.objectWithRest({foo: v.number()}, v.null());
-// const Schema21 = v.objectWithRest({...Schema20.entries, ...{bar: v.string()}}, Schema20.rest);
-// const Schema22 = v.objectWithRest({...{foo: v.string()}, ...{bar: v.number()}}, v.null());
-// const Schema23 = v.objectWithRest({...Schema2.entries, ...{bar: v.string()}}, v.null());
+// const Schema21 = v.object({
+//   ...Schema20.entries,
+//   bar: v.string()
+// });
+// const Schema22 = v.objectWithRest({
+//   foo: v.string(),
+//   bar: v.number()
+// }, v.null());
+// const Schema23 = v.objectWithRest({
+//   ...Schema2.entries,
+//   bar: v.string()
+// }, v.null());

--- a/codemod/zod-to-valibot/__testfixtures__/object-extend/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-extend/output.ts
@@ -23,7 +23,7 @@ const Schema13 = v.strictObject(v.extend(Schema2, {bar: v.string()}).entries);
 const Schema14 = v.extend(v.object({foo: v.string()}), {bar: v.number()});
 const Schema15 = v.object({foo: v.number()});
 const Schema16 = v.extend(Schema15, {bar: v.string()});
-const Schema17 = v.object(v.extend(v.strictObject({foo: v.string()}), {bar: v.number()}).entries);
+const Schema17 = v.object(v.extend(v.object({foo: v.string()}), {bar: v.number()}).entries);
 const Schema18 = v.object(v.extend(Schema2, {bar: v.string()}).entries);
 
 // catchall

--- a/codemod/zod-to-valibot/__testfixtures__/object-extend/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-extend/output.ts
@@ -9,21 +9,21 @@ const Schema3 = v.extend(Schema2, {bar: v.string()});
 const Schema4 = v.extend(v.looseObject({foo: v.string()}), {bar: v.number()});
 const Schema5 = v.looseObject({foo: v.number()});
 const Schema6 = v.extend(Schema5, {bar: v.string()});
-const Schema7 = v.pipe(v.extend(v.object({foo: v.string()}), {bar: v.number()}), v.passthrough());
-const Schema8 = v.pipe(v.extend(Schema2, {bar: v.string()}), v.passthrough());
+const Schema7 = v.looseObject(v.extend(v.looseObject({foo: v.string()}), {bar: v.number()}).entries);
+const Schema8 = v.looseObject(v.extend(Schema2, {bar: v.string()}).entries);
 
 // strict
 const Schema9 = v.extend(v.strictObject({foo: v.string()}), {bar: v.number()});
 const Schema10 = v.strictObject({foo: v.number()});
 const Schema11 = v.extend(Schema10, {bar: v.string()});
-const Schema12 = v.strictObject(v.extend(v.object({foo: v.string()}), {bar: v.number()}).entries);
+const Schema12 = v.strictObject(v.extend(v.strictObject({foo: v.string()}), {bar: v.number()}).entries);
 const Schema13 = v.strictObject(v.extend(Schema2, {bar: v.string()}).entries);
 
 // strip
 const Schema14 = v.extend(v.object({foo: v.string()}), {bar: v.number()});
 const Schema15 = v.object({foo: v.number()});
 const Schema16 = v.extend(Schema15, {bar: v.string()});
-const Schema17 = v.object(v.extend(v.object({foo: v.string()}), {bar: v.number()}).entries);
+const Schema17 = v.object(v.extend(v.strictObject({foo: v.string()}), {bar: v.number()}).entries);
 const Schema18 = v.object(v.extend(Schema2, {bar: v.string()}).entries);
 
 // catchall

--- a/codemod/zod-to-valibot/__testfixtures__/object-extend/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-extend/output.ts
@@ -1,71 +1,203 @@
 import * as v from "valibot";
 
 // plain
-const Schema1 = v.extend(v.object({foo: v.string()}), {bar: v.number()});
+const Schema1 = v.object({
+  foo: v.string(),
+  bar: v.number()
+});
 const Schema2 = v.object({foo: v.number()});
-const Schema3 = v.extend(Schema2, {bar: v.string()});
+const Schema3 = v.object({
+  .../*@valibot-migrate we can't detect if Schema2 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema2.entries,
+
+  bar: v.string()
+});
 
 // passthrough
-const Schema4 = v.extend(v.looseObject({foo: v.string()}), {bar: v.number()});
+const Schema4 = v.object({
+  ...v.looseObject({foo: v.string()}).entries,
+  bar: v.number()
+});
 const Schema5 = v.looseObject({foo: v.number()});
-const Schema6 = v.extend(Schema5, {bar: v.string()});
-const Schema7 = v.looseObject(v.extend(v.looseObject({foo: v.string()}), {bar: v.number()}).entries);
-const Schema8 = v.looseObject(v.extend(Schema2, {bar: v.string()}).entries);
+const Schema6 = v.object({
+  .../*@valibot-migrate we can't detect if Schema5 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema5.entries,
+
+  bar: v.string()
+});
+const Schema7 = v.looseObject({
+  ...v.looseObject({foo: v.string()}).entries,
+  bar: v.number()
+});
+const Schema8 = v.looseObject({
+  .../*@valibot-migrate we can't detect if Schema2 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema2.entries,
+
+  bar: v.string()
+});
 
 // strict
-const Schema9 = v.extend(v.strictObject({foo: v.string()}), {bar: v.number()});
+const Schema9 = v.object({
+  ...v.strictObject({foo: v.string()}).entries,
+  bar: v.number()
+});
 const Schema10 = v.strictObject({foo: v.number()});
-const Schema11 = v.extend(Schema10, {bar: v.string()});
-const Schema12 = v.strictObject(v.extend(v.strictObject({foo: v.string()}), {bar: v.number()}).entries);
-const Schema13 = v.strictObject(v.extend(Schema2, {bar: v.string()}).entries);
+const Schema11 = v.object({
+  .../*@valibot-migrate we can't detect if Schema10 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema10.entries,
+
+  bar: v.string()
+});
+const Schema12 = v.strictObject({
+  ...v.strictObject({foo: v.string()}).entries,
+  bar: v.number()
+});
+const Schema13 = v.strictObject({
+  .../*@valibot-migrate we can't detect if Schema2 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema2.entries,
+
+  bar: v.string()
+});
 
 // strip
-const Schema14 = v.extend(v.object({foo: v.string()}), {bar: v.number()});
+const Schema14 = v.object({
+  foo: v.string(),
+  bar: v.number()
+});
 const Schema15 = v.object({foo: v.number()});
-const Schema16 = v.extend(Schema15, {bar: v.string()});
-const Schema17 = v.object(v.extend(v.object({foo: v.string()}), {bar: v.number()}).entries);
-const Schema18 = v.object(v.extend(Schema2, {bar: v.string()}).entries);
+const Schema16 = v.object({
+  .../*@valibot-migrate we can't detect if Schema15 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema15.entries,
+
+  bar: v.string()
+});
+const Schema17 = v.object({
+  foo: v.string(),
+  bar: v.number()
+});
+const Schema18 = v.object({
+  .../*@valibot-migrate we can't detect if Schema2 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema2.entries,
+
+  bar: v.string()
+});
 
 // catchall
-const Schema19 = v.extend(v.objectWithRest({foo: v.string()}, v.null()), {bar: v.number()});
+const Schema19 = v.object({
+  ...v.objectWithRest({foo: v.string()}, v.null()).entries,
+  bar: v.number()
+});
 const Schema20 = v.objectWithRest({foo: v.number()}, v.null());
-const Schema21 = v.extend(Schema20, {bar: v.string()});
-const Schema22 = v.pipe(
-  v.extend(v.object({foo: v.string()}), {bar: v.number()}),
-  v.catchall(v.null())
-);
-const Schema23 = v.pipe(v.extend(Schema2, {bar: v.string()}), v.catchall(v.null()));
+const Schema21 = v.object({
+  .../*@valibot-migrate we can't detect if Schema20 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema20.entries,
+
+  bar: v.string()
+});
+const Schema22 = v.objectWithRest({
+  foo: v.string(),
+  bar: v.number()
+}, v.null());
+const Schema23 = v.objectWithRest({
+  .../*@valibot-migrate we can't detect if Schema2 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema2.entries,
+
+  bar: v.string()
+}, v.null());
+
+// i don't know which crazy person would do this, but it is valid
+// and we support it so we might as well test it
+const Schema24 = v.object({
+  .../*@valibot-migrate we can't detect if Schema23 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema23.entries,
+
+  ...[Schema22.entries]
+});
 
 // ------------ Expected transform ------------
 // // plain
-// const Schema1 = v.object({...{foo: v.string()}, ...{bar: v.number()}});
+// const Schema1 = v.object({
+//   foo: v.string(),
+//   bar: v.number()
+// });
 // const Schema2 = v.object({foo: v.number()});
-// const Schema3 = v.object({...Schema2.entries, ...{bar: v.string()}});
+// const Schema3 = v.object({
+//   ...Schema2.entries,
+//   bar: v.string()
+// });
 
 // // passthrough
-// const Schema4 = v.looseObject({...{foo: v.string()}, ...{bar: v.number()}});
+// const Schema4 = v.object({
+//   ...v.looseObject({foo: v.string()}).entries,
+//   bar: v.number()
+// });
 // const Schema5 = v.looseObject({foo: v.number()});
-// const Schema6 = v.looseObject({...Schema5.entries, ...{bar: v.string()}});
-// const Schema7 = v.looseObject({...{foo: v.string()}, ...{bar: v.number()}});
-// const Schema8 = v.looseObject({...Schema2.entries, ...{bar: v.string()}});
+// const Schema6 = v.object({
+//   ...Schema5.entries,
+//   bar: v.string()
+// });
+// const Schema7 = v.looseObject({
+//   ...v.looseObject({foo: v.string()}).entries,
+//   bar: v.number()
+// });
+// const Schema8 = v.looseObject({
+//   ...Schema2.entries,
+//   bar: v.string()
+// });
 
 // // strict
-// const Schema9 = v.strictObject({...{foo: v.string()}, ...{bar: v.number()}});
+// const Schema9 = v.object({
+//   ...v.strictObject({foo: v.string()}).entries,
+//   bar: v.number()
+// });
 // const Schema10 = v.strictObject({foo: v.number()});
-// const Schema11 = v.strictObject({...Schema10.entries, ...{bar: v.string()}});
-// const Schema12 = v.strictObject({...{foo: v.string()}, ...{bar: v.number()}});
-// const Schema13 = v.strictObject({...Schema2.entries, ...{bar: v.string()}});
+// const Schema11 = v.object({
+//   ...Schema10.entries,
+//   bar: v.string()
+// });
+// const Schema12 = v.strictObject({
+//   ...v.strictObject({foo: v.string()}).entries,
+//   bar: v.number()
+// });
+// const Schema13 = v.strictObject({
+//   ...Schema2.entries,
+//   bar: v.string()
+// });
 
 // // strip
-// const Schema14 = v.object({...{foo: v.string()}, ...{bar: v.number()}});
+// const Schema14 = v.object({
+//   foo: v.string(),
+//   bar: v.number()
+// });
 // const Schema15 = v.object({foo: v.number()});
-// const Schema16 = v.object({...Schema15.entries, ...{bar: v.string()}});
-// const Schema17 = v.object({...{foo: v.string()}, ...{bar: v.number()}});
-// const Schema18 = v.object({...Schema2.entries, ...{bar: v.string()}});
+// const Schema16 = v.object({
+//   ...Schema15.entries,
+//   bar: v.string()
+// });
+// const Schema17 = v.object({
+//   foo: v.string(),
+//   bar: v.number()
+// });
+// const Schema18 = v.object({
+//   ...Schema2.entries,
+//   bar: v.string()
+// });
 
 // // catchall
-// const Schema19 = v.objectWithRest({...{foo: v.string()}, ...{bar: v.number()}}, v.null());
+// const Schema19 = v.object({
+//   ...v.objectWithRest({foo: v.string()}, v.null()).entries,
+//   bar: v.number()
+// });
 // const Schema20 = v.objectWithRest({foo: v.number()}, v.null());
-// const Schema21 = v.objectWithRest({...Schema20.entries, ...{bar: v.string()}}, Schema20.rest);
-// const Schema22 = v.objectWithRest({...{foo: v.string()}, ...{bar: v.number()}}, v.null());
-// const Schema23 = v.objectWithRest({...Schema2.entries, ...{bar: v.string()}}, v.null());
+// const Schema21 = v.object({
+//   ...Schema20.entries,
+//   bar: v.string()
+// });
+// const Schema22 = v.objectWithRest({
+//   foo: v.string(),
+//   bar: v.number()
+// }, v.null());
+// const Schema23 = v.objectWithRest({
+//   ...Schema2.entries,
+//   bar: v.string()
+// }, v.null());

--- a/codemod/zod-to-valibot/__testfixtures__/object-extend/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-extend/output.ts
@@ -16,19 +16,15 @@ const Schema8 = v.pipe(v.extend(Schema2, {bar: v.string()}), v.passthrough());
 const Schema9 = v.extend(v.strictObject({foo: v.string()}), {bar: v.number()});
 const Schema10 = v.strictObject({foo: v.number()});
 const Schema11 = v.extend(Schema10, {bar: v.string()});
-const Schema12 = v.pipe(v.extend(v.object({foo: v.string()}), {bar: v.number()}), v.strict());
-const Schema13 = v.pipe(v.extend(Schema2, {bar: v.string()}), v.strict());
+const Schema12 = v.strictObject(v.extend(v.object({foo: v.string()}), {bar: v.number()}).entries);
+const Schema13 = v.strictObject(v.extend(Schema2, {bar: v.string()}).entries);
 
 // strip
 const Schema14 = v.extend(v.object({foo: v.string()}), {bar: v.number()});
 const Schema15 = v.object({foo: v.number()});
 const Schema16 = v.extend(Schema15, {bar: v.string()});
-const Schema17 = v.pipe(
-  v.extend(v.object({foo: v.string()}), {bar: v.number()}),
-  v.strict(),
-  v.strip()
-);
-const Schema18 = v.pipe(v.extend(Schema2, {bar: v.string()}), v.strict(), v.strip());
+const Schema17 = v.object(v.extend(v.object({foo: v.string()}), {bar: v.number()}).entries);
+const Schema18 = v.object(v.extend(Schema2, {bar: v.string()}).entries);
 
 // catchall
 const Schema19 = v.extend(v.objectWithRest({foo: v.string()}, v.null()), {bar: v.number()});

--- a/codemod/zod-to-valibot/__testfixtures__/object-merge/input.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-merge/input.ts
@@ -36,39 +36,103 @@ const Schema24 = z.object({bar: z.number()}).catchall(z.null());
 const Schema25 = z.object({foo: z.string()}).merge(Schema24);
 const Schema26 = Schema2.merge(Schema24);
 
+// i don't know which crazy person would do this, but it is valid
+// and we support it so we might as well test it
+const Schema27 = Schema26.merge(...[Schema25]);
+
 // ------------ Expected transform ------------
 // // plain
-// const Schema1 = v.object({...{foo: v.string()}, ...{bar: v.number()}});
+// const Schema1 = v.object({
+//   foo: v.string(),
+//   bar: v.number()
+// });
 // const Schema2 = v.object({foo: v.number()});
-// const Schema3 = v.object({...Schema2.entries, ...{bar: v.string()}});
+// const Schema3 = v.object({
+//   ...Schema2.entries,
+//   bar: v.string()
+// });
 // const Schema4 = v.object({bar: v.number()});
-// const Schema5 = v.object({...{foo: v.string()}, ...Schema4.entries});
-// const Schema6 = v.object({...Schema2.entries, ...Schema4.entries});
+// const Schema5 = v.object({
+//   foo: v.string(),
+//   ...Schema4.entries
+// });
+// const Schema6 = v.object({
+//   ...Schema2.entries,
+//   ...Schema4.entries
+// });
 
 // // passthrough
-// const Schema7 = v.looseObject({...{foo: v.string()}, ...{bar: v.number()}});
-// const Schema8 = v.looseObject({...Schema2.entries, ...{bar: v.string()}});
+// const Schema7 = v.object({
+//   foo: v.string(),
+//   ...v.looseObject({bar: v.number()}).entries
+// });
+// const Schema8 = v.object({
+//   ...Schema2.entries,
+//   ...v.looseObject({bar: v.string()}).entries
+// });
 // const Schema9 = v.looseObject({bar: v.number()});
-// const Schema10 = v.looseObject({...{foo: v.string()}, ...Schema9.entries});
-// const Schema11 = v.looseObject({...Schema2.entries, ...Schema9.entries});
+// const Schema10 = v.object({
+//   foo: v.string(),
+//   ...Schema9.entries
+// });
+// const Schema11 = v.object({
+//   ...Schema2.entries,
+//   ...Schema9.entries
+// });
 
 // // strict
-// const Schema12 = v.strictObject({...{foo: v.string()}, ...{bar: v.number()}});
-// const Schema13 = v.strictObject({...Schema2.entries, ...{bar: v.string()}});
+// const Schema12 = v.object({
+//   foo: v.string(),
+//   ...v.strictObject({bar: v.number()}).entries
+// });
+// const Schema13 = v.object({
+//   ...Schema2.entries,
+//   ...v.strictObject({bar: v.string()}).entries
+// });
 // const Schema14 = v.strictObject({bar: v.number()});
-// const Schema15 = v.strictObject({...{foo: v.string()}, ...Schema14.entries});
-// const Schema16 = v.strictObject({...Schema2.entries, ...Schema14.entries});
+// const Schema15 = v.object({
+//   foo: v.string(),
+//   ...Schema14.entries
+// });
+// const Schema16 = v.object({
+//   ...Schema2.entries,
+//   ...Schema14.entries
+// });
 
 // // strip
-// const Schema17 = v.object({...{foo: v.string()}, ...{bar: v.number()}});
-// const Schema18 = v.object({...Schema2.entries, ...{bar: v.string()}});
+// const Schema17 = v.object({
+//   foo: v.string(),
+//   bar: v.number()
+// });
+// const Schema18 = v.object({
+//   ...Schema2.entries,
+//   bar: v.string()
+// });
 // const Schema19 = v.object({bar: v.number()});
-// const Schema20 = v.object({...{foo: v.string()}, ...Schema19.entries});
-// const Schema21 = v.object({...Schema2.entries, ...Schema19.entries});
+// const Schema20 = v.object({
+//   foo: v.string(),
+//   ...Schema19.entries
+// });
+// const Schema21 = v.object({
+//   ...Schema2.entries,
+//   ...Schema19.entries
+// });
 
 // // catchall
-// const Schema22 = v.objectWithRest({...{foo: v.string()}, ...{bar: v.number()}}, v.null());
-// const Schema23 = v.objectWithRest({...Schema2.entries, ...{bar: v.string()}}, v.null());
+// const Schema22 = v.object({
+//   foo: v.string(),
+//   ...v.objectWithRest({bar: v.number()}, v.null()).entries
+// });
+// const Schema23 = v.object({
+//   ...Schema2.entries,
+//   ...v.objectWithRest({bar: v.string()}, v.null()).entries
+// });
 // const Schema24 = v.objectWithRest({bar: v.number()}, v.null());
-// const Schema25 = v.objectWithRest({...{foo: v.string()}, ...Schema24.entries}, Schema24.rest);
-// const Schema26 = v.objectWithRest({...Schema2.entries, ...Schema24.entries}, Schema24.rest);
+// const Schema25 = v.object({
+//   foo: v.string(),
+//   ...Schema24.entries
+// });
+// const Schema26 = v.object({
+//   ...Schema2.entries,
+//   ...Schema24.entries
+// });

--- a/codemod/zod-to-valibot/__testfixtures__/object-merge/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-merge/output.ts
@@ -1,74 +1,238 @@
 import * as v from "valibot";
 
 // plain
-const Schema1 = v.merge(v.object({foo: v.string()}), v.object({bar: v.number()}));
+const Schema1 = v.object({
+  foo: v.string(),
+  bar: v.number()
+});
 const Schema2 = v.object({foo: v.number()});
-const Schema3 = v.merge(Schema2, v.object({bar: v.string()}));
+const Schema3 = v.object({
+  .../*@valibot-migrate we can't detect if Schema2 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema2.entries,
+
+  bar: v.string()
+});
 const Schema4 = v.object({bar: v.number()});
-const Schema5 = v.merge(v.object({foo: v.string()}), Schema4);
-const Schema6 = v.merge(Schema2, Schema4);
+const Schema5 = v.object({
+  foo: v.string(),
+
+  .../*@valibot-migrate we can't detect if Schema4 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema4.entries
+});
+const Schema6 = v.object({
+  .../*@valibot-migrate we can't detect if Schema2 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema2.entries,
+
+  .../*@valibot-migrate we can't detect if Schema4 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema4.entries
+});
 
 // passthrough
-const Schema7 = v.merge(v.object({foo: v.string()}), v.looseObject({bar: v.number()}));
-const Schema8 = v.merge(Schema2, v.looseObject({bar: v.string()}));
+const Schema7 = v.object({
+  foo: v.string(),
+  ...v.looseObject({bar: v.number()}).entries
+});
+const Schema8 = v.object({
+  .../*@valibot-migrate we can't detect if Schema2 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema2.entries,
+
+  ...v.looseObject({bar: v.string()}).entries
+});
 const Schema9 = v.looseObject({bar: v.number()});
-const Schema10 = v.merge(v.object({foo: v.string()}), Schema9);
-const Schema11 = v.merge(Schema2, Schema9);
+const Schema10 = v.object({
+  foo: v.string(),
+
+  .../*@valibot-migrate we can't detect if Schema9 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema9.entries
+});
+const Schema11 = v.object({
+  .../*@valibot-migrate we can't detect if Schema2 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema2.entries,
+
+  .../*@valibot-migrate we can't detect if Schema9 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema9.entries
+});
 
 // strict
-const Schema12 = v.merge(v.object({foo: v.string()}), v.strictObject({bar: v.number()}));
-const Schema13 = v.merge(Schema2, v.strictObject({bar: v.string()}));
+const Schema12 = v.object({
+  foo: v.string(),
+  ...v.strictObject({bar: v.number()}).entries
+});
+const Schema13 = v.object({
+  .../*@valibot-migrate we can't detect if Schema2 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema2.entries,
+
+  ...v.strictObject({bar: v.string()}).entries
+});
 const Schema14 = v.strictObject({bar: v.number()});
-const Schema15 = v.merge(v.object({foo: v.string()}), Schema14);
-const Schema16 = v.merge(Schema2, Schema14);
+const Schema15 = v.object({
+  foo: v.string(),
+
+  .../*@valibot-migrate we can't detect if Schema14 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema14.entries
+});
+const Schema16 = v.object({
+  .../*@valibot-migrate we can't detect if Schema2 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema2.entries,
+
+  .../*@valibot-migrate we can't detect if Schema14 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema14.entries
+});
 
 // strip
-const Schema17 = v.merge(v.object({foo: v.string()}), v.object({bar: v.number()}));
-const Schema18 = v.merge(Schema2, v.object({bar: v.string()}));
+const Schema17 = v.object({
+  foo: v.string(),
+  bar: v.number()
+});
+const Schema18 = v.object({
+  .../*@valibot-migrate we can't detect if Schema2 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema2.entries,
+
+  bar: v.string()
+});
 const Schema19 = v.object({bar: v.number()});
-const Schema20 = v.merge(v.object({foo: v.string()}), Schema19);
-const Schema21 = v.merge(Schema2, Schema19);
+const Schema20 = v.object({
+  foo: v.string(),
+
+  .../*@valibot-migrate we can't detect if Schema19 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema19.entries
+});
+const Schema21 = v.object({
+  .../*@valibot-migrate we can't detect if Schema2 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema2.entries,
+
+  .../*@valibot-migrate we can't detect if Schema19 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema19.entries
+});
 
 // catchall
-const Schema22 = v.merge(v.object({foo: v.string()}), v.objectWithRest({bar: v.number()}, v.null()));
-const Schema23 = v.merge(Schema2, v.objectWithRest({bar: v.string()}, v.null()));
+const Schema22 = v.object({
+  foo: v.string(),
+  ...v.objectWithRest({bar: v.number()}, v.null()).entries
+});
+const Schema23 = v.object({
+  .../*@valibot-migrate we can't detect if Schema2 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema2.entries,
+
+  ...v.objectWithRest({bar: v.string()}, v.null()).entries
+});
 const Schema24 = v.objectWithRest({bar: v.number()}, v.null());
-const Schema25 = v.merge(v.object({foo: v.string()}), Schema24);
-const Schema26 = v.merge(Schema2, Schema24);
+const Schema25 = v.object({
+  foo: v.string(),
+
+  .../*@valibot-migrate we can't detect if Schema24 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema24.entries
+});
+const Schema26 = v.object({
+  .../*@valibot-migrate we can't detect if Schema2 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema2.entries,
+
+  .../*@valibot-migrate we can't detect if Schema24 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema24.entries
+});
+
+// i don't know which crazy person would do this, but it is valid
+// and we support it so we might as well test it
+const Schema27 = v.object({
+  .../*@valibot-migrate we can't detect if Schema26 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema26.entries,
+
+  ...[Schema25].entries
+});
 
 // ------------ Expected transform ------------
 // // plain
-// const Schema1 = v.object({...{foo: v.string()}, ...{bar: v.number()}});
+// const Schema1 = v.object({
+//   foo: v.string(),
+//   bar: v.number()
+// });
 // const Schema2 = v.object({foo: v.number()});
-// const Schema3 = v.object({...Schema2.entries, ...{bar: v.string()}});
+// const Schema3 = v.object({
+//   ...Schema2.entries,
+//   bar: v.string()
+// });
 // const Schema4 = v.object({bar: v.number()});
-// const Schema5 = v.object({...{foo: v.string()}, ...Schema4.entries});
-// const Schema6 = v.object({...Schema2.entries, ...Schema4.entries});
+// const Schema5 = v.object({
+//   foo: v.string(),
+//   ...Schema4.entries
+// });
+// const Schema6 = v.object({
+//   ...Schema2.entries,
+//   ...Schema4.entries
+// });
 
 // // passthrough
-// const Schema7 = v.looseObject({...{foo: v.string()}, ...{bar: v.number()}});
-// const Schema8 = v.looseObject({...Schema2.entries, ...{bar: v.string()}});
+// const Schema7 = v.object({
+//   foo: v.string(),
+//   ...v.looseObject({bar: v.number()}).entries
+// });
+// const Schema8 = v.object({
+//   ...Schema2.entries,
+//   ...v.looseObject({bar: v.string()}).entries
+// });
 // const Schema9 = v.looseObject({bar: v.number()});
-// const Schema10 = v.looseObject({...{foo: v.string()}, ...Schema9.entries});
-// const Schema11 = v.looseObject({...Schema2.entries, ...Schema9.entries});
+// const Schema10 = v.object({
+//   foo: v.string(),
+//   ...Schema9.entries
+// });
+// const Schema11 = v.object({
+//   ...Schema2.entries,
+//   ...Schema9.entries
+// });
 
 // // strict
-// const Schema12 = v.strictObject({...{foo: v.string()}, ...{bar: v.number()}});
-// const Schema13 = v.strictObject({...Schema2.entries, ...{bar: v.string()}});
+// const Schema12 = v.object({
+//   foo: v.string(),
+//   ...v.strictObject({bar: v.number()}).entries
+// });
+// const Schema13 = v.object({
+//   ...Schema2.entries,
+//   ...v.strictObject({bar: v.string()}).entries
+// });
 // const Schema14 = v.strictObject({bar: v.number()});
-// const Schema15 = v.strictObject({...{foo: v.string()}, ...Schema14.entries});
-// const Schema16 = v.strictObject({...Schema2.entries, ...Schema14.entries});
+// const Schema15 = v.object({
+//   foo: v.string(),
+//   ...Schema14.entries
+// });
+// const Schema16 = v.object({
+//   ...Schema2.entries,
+//   ...Schema14.entries
+// });
 
 // // strip
-// const Schema17 = v.object({...{foo: v.string()}, ...{bar: v.number()}});
-// const Schema18 = v.object({...Schema2.entries, ...{bar: v.string()}});
+// const Schema17 = v.object({
+//   foo: v.string(),
+//   bar: v.number()
+// });
+// const Schema18 = v.object({
+//   ...Schema2.entries,
+//   bar: v.string()
+// });
 // const Schema19 = v.object({bar: v.number()});
-// const Schema20 = v.object({...{foo: v.string()}, ...Schema19.entries});
-// const Schema21 = v.object({...Schema2.entries, ...Schema19.entries});
+// const Schema20 = v.object({
+//   foo: v.string(),
+//   ...Schema19.entries
+// });
+// const Schema21 = v.object({
+//   ...Schema2.entries,
+//   ...Schema19.entries
+// });
 
 // // catchall
-// const Schema22 = v.objectWithRest({...{foo: v.string()}, ...{bar: v.number()}}, v.null());
-// const Schema23 = v.objectWithRest({...Schema2.entries, ...{bar: v.string()}}, v.null());
+// const Schema22 = v.object({
+//   foo: v.string(),
+//   ...v.objectWithRest({bar: v.number()}, v.null()).entries
+// });
+// const Schema23 = v.object({
+//   ...Schema2.entries,
+//   ...v.objectWithRest({bar: v.string()}, v.null()).entries
+// });
 // const Schema24 = v.objectWithRest({bar: v.number()}, v.null());
-// const Schema25 = v.objectWithRest({...{foo: v.string()}, ...Schema24.entries}, Schema24.rest);
-// const Schema26 = v.objectWithRest({...Schema2.entries, ...Schema24.entries}, Schema24.rest);
+// const Schema25 = v.object({
+//   foo: v.string(),
+//   ...Schema24.entries
+// });
+// const Schema26 = v.object({
+//   ...Schema2.entries,
+//   ...Schema24.entries
+// });

--- a/codemod/zod-to-valibot/__testfixtures__/object-passthrough/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-passthrough/output.ts
@@ -4,4 +4,7 @@ const Schema1 = v.looseObject({key: v.string()});
 const Schema2 = v.looseObject({key: v.string()}, "some message");
 const Schema3 = v.pipe(v.looseObject({key: v.string()}), v.description("some description"));
 const Schema4 = v.object({key: v.string()});
-const Schema5 = v.looseObject(Schema4.entries);
+const Schema5 = v.looseObject(
+  /*@valibot-migrate we can't detect if Schema4 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema4.entries
+);

--- a/codemod/zod-to-valibot/__testfixtures__/object-passthrough/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-passthrough/output.ts
@@ -2,10 +2,6 @@ import * as v from "valibot";
 
 const Schema1 = v.looseObject({key: v.string()});
 const Schema2 = v.looseObject({key: v.string()}, "some message");
-const Schema3 = v.pipe(
-  v.object({key: v.string()}),
-  v.description("some description"),
-  v.passthrough()
-);
+const Schema3 = v.pipe(v.looseObject({key: v.string()}), v.description("some description"));
 const Schema4 = v.object({key: v.string()});
-const Schema5 = v.pipe(Schema4, v.passthrough());
+const Schema5 = v.looseObject(Schema4.entries);

--- a/codemod/zod-to-valibot/__testfixtures__/object-strict/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-strict/output.ts
@@ -2,8 +2,6 @@ import * as v from "valibot";
 
 const Schema1 = v.strictObject({key: v.string()});
 const Schema2 = v.strictObject({key: v.string()}, "some message");
-const Schema3 = v.strictObject(
-  v.pipe(v.object({key: v.string()}), v.description("some description")).entries
-);
+const Schema3 = v.pipe(v.strictObject({key: v.string()}), v.description("some description"));
 const Schema4 = v.object({key: v.string()});
 const Schema5 = v.strictObject(Schema4.entries);

--- a/codemod/zod-to-valibot/__testfixtures__/object-strict/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-strict/output.ts
@@ -2,6 +2,8 @@ import * as v from "valibot";
 
 const Schema1 = v.strictObject({key: v.string()});
 const Schema2 = v.strictObject({key: v.string()}, "some message");
-const Schema3 = v.pipe(v.object({key: v.string()}), v.description("some description"), v.strict());
+const Schema3 = v.strictObject(
+  v.pipe(v.object({key: v.string()}), v.description("some description")).entries
+);
 const Schema4 = v.object({key: v.string()});
-const Schema5 = v.pipe(Schema4, v.strict());
+const Schema5 = v.strictObject(Schema4.entries);

--- a/codemod/zod-to-valibot/__testfixtures__/object-strict/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-strict/output.ts
@@ -4,4 +4,7 @@ const Schema1 = v.strictObject({key: v.string()});
 const Schema2 = v.strictObject({key: v.string()}, "some message");
 const Schema3 = v.pipe(v.strictObject({key: v.string()}), v.description("some description"));
 const Schema4 = v.object({key: v.string()});
-const Schema5 = v.strictObject(Schema4.entries);
+const Schema5 = v.strictObject(
+  /*@valibot-migrate we can't detect if Schema4 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema4.entries
+);

--- a/codemod/zod-to-valibot/__testfixtures__/object-strip/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-strip/output.ts
@@ -3,10 +3,8 @@ import * as v from "valibot";
 // passthrough
 const Schema1 = v.object({key: v.string()});
 const Schema2 = v.object({key: v.string()}, "some message");
-const Schema3 = v.pipe(
-  v.looseObject({key: v.string()}),
-  v.description("some description"),
-  v.strip()
+const Schema3 = v.object(
+  v.pipe(v.object({key: v.string()}), v.description("some description")).entries
 );
 const Schema4 = v.looseObject({key: v.string()});
 const Schema5 = v.pipe(Schema4, v.strip());
@@ -19,10 +17,8 @@ const Schema7 = v.object(
 // strict
 const Schema8 = v.object({key: v.string()});
 const Schema9 = v.object({key: v.string()}, "some message");
-const Schema10 = v.pipe(
-  v.strictObject({key: v.string()}),
-  v.description("some description"),
-  v.strip()
+const Schema10 = v.object(
+  v.pipe(v.object({key: v.string()}), v.description("some description")).entries
 );
 const Schema11 = v.strictObject({key: v.string()});
 const Schema12 = v.pipe(Schema11, v.strip());

--- a/codemod/zod-to-valibot/__testfixtures__/object-strip/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-strip/output.ts
@@ -17,13 +17,10 @@ const Schema7 = v.pipe(Schema6, v.passthrough(), v.strip());
 // strict
 const Schema8 = v.object({key: v.string()});
 const Schema9 = v.object({key: v.string()}, "some message");
-const Schema10 = v.pipe(
-  v.object({key: v.string()}),
-  v.description("some description"),
-  v.strict(),
-  v.strip()
+const Schema10 = v.object(
+  v.pipe(v.object({key: v.string()}), v.description("some description")).entries
 );
 const Schema11 = v.strictObject({key: v.string()});
 const Schema12 = v.pipe(Schema11, v.strip());
 const Schema13 = v.object({key: v.string()});
-const Schema14 = v.pipe(Schema13, v.strict(), v.strip());
+const Schema14 = v.object(Schema13.entries);

--- a/codemod/zod-to-valibot/__testfixtures__/object-strip/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-strip/output.ts
@@ -4,21 +4,22 @@ import * as v from "valibot";
 const Schema1 = v.object({key: v.string()});
 const Schema2 = v.object({key: v.string()}, "some message");
 const Schema3 = v.pipe(
-  v.object({key: v.string()}),
+  v.looseObject({key: v.string()}),
   v.description("some description"),
-  v.passthrough(),
   v.strip()
 );
 const Schema4 = v.looseObject({key: v.string()});
 const Schema5 = v.pipe(Schema4, v.strip());
 const Schema6 = v.object({key: v.string()});
-const Schema7 = v.pipe(Schema6, v.passthrough(), v.strip());
+const Schema7 = v.object(Schema6.entries);
 
 // strict
 const Schema8 = v.object({key: v.string()});
 const Schema9 = v.object({key: v.string()}, "some message");
-const Schema10 = v.object(
-  v.pipe(v.object({key: v.string()}), v.description("some description")).entries
+const Schema10 = v.pipe(
+  v.strictObject({key: v.string()}),
+  v.description("some description"),
+  v.strip()
 );
 const Schema11 = v.strictObject({key: v.string()});
 const Schema12 = v.pipe(Schema11, v.strip());

--- a/codemod/zod-to-valibot/__testfixtures__/object-strip/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-strip/output.ts
@@ -11,7 +11,10 @@ const Schema3 = v.pipe(
 const Schema4 = v.looseObject({key: v.string()});
 const Schema5 = v.pipe(Schema4, v.strip());
 const Schema6 = v.object({key: v.string()});
-const Schema7 = v.object(Schema6.entries);
+const Schema7 = v.object(
+  /*@valibot-migrate we can't detect if Schema6 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema6.entries
+);
 
 // strict
 const Schema8 = v.object({key: v.string()});
@@ -24,4 +27,7 @@ const Schema10 = v.pipe(
 const Schema11 = v.strictObject({key: v.string()});
 const Schema12 = v.pipe(Schema11, v.strip());
 const Schema13 = v.object({key: v.string()});
-const Schema14 = v.object(Schema13.entries);
+const Schema14 = v.object(
+  /*@valibot-migrate we can't detect if Schema13 has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Schema13.entries
+);

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/extend/extend.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/extend/extend.ts
@@ -1,12 +1,71 @@
 import j from 'jscodeshift';
 
+function isInlineObjectCall(exp: j.CallExpression): boolean {
+  return (
+    exp.callee.type === 'MemberExpression' &&
+    exp.callee.property.type === 'Identifier' &&
+    exp.callee.property.name === 'object'
+  );
+}
+
+function extractObjectProperties(
+  exp: j.CallExpression
+): j.ObjectExpression['properties'] {
+  const firstArg = exp.arguments[0];
+  if (firstArg && firstArg.type === 'ObjectExpression') {
+    return firstArg.properties;
+  }
+  return [];
+}
+
 export function transformExtend(
   valibotIdentifier: string,
   schemaExp: j.CallExpression | j.MemberExpression | j.Identifier,
   args: j.CallExpression['arguments']
 ) {
+  const extensionObject = args[0];
+  const objectProperties: j.ObjectExpression['properties'] = [];
+
+  // Handle base schema
+  if (schemaExp.type === 'CallExpression' && isInlineObjectCall(schemaExp)) {
+    // Inline the properties from the base schema
+    const baseSchemaProperties = extractObjectProperties(schemaExp);
+    objectProperties.push(...baseSchemaProperties);
+  } else {
+    // Use spread with .entries for schema reference
+    const schemaEntries = j.memberExpression(
+      schemaExp,
+      j.identifier('entries')
+    );
+
+    if (schemaExp.type === 'Identifier') {
+      schemaEntries.comments = [
+        j.block(
+          `@valibot-migrate we can't detect if ${schemaExp.name} has a \`pipe\` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline`,
+          true,
+          false
+        ),
+      ];
+    }
+
+    objectProperties.push(j.spreadElement(schemaEntries));
+  }
+
+  // Handle extension object
+  if (extensionObject.type === 'ObjectExpression') {
+    // Inline the extension properties
+    objectProperties.push(...extensionObject.properties);
+  } else if (extensionObject.type !== 'SpreadElement') {
+    // Spread the extension object
+    objectProperties.push(j.spreadElement(extensionObject));
+  } else {
+    objectProperties.push(j.spreadElement(extensionObject.argument));
+  }
+
+  const extendedObject = j.objectExpression(objectProperties);
+
   return j.callExpression(
-    j.memberExpression(j.identifier(valibotIdentifier), j.identifier('extend')),
-    [schemaExp, ...args]
+    j.memberExpression(j.identifier(valibotIdentifier), j.identifier('object')),
+    [extendedObject]
   );
 }

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/merge/merge.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/merge/merge.ts
@@ -1,12 +1,97 @@
 import j from 'jscodeshift';
 
+function isInlineObjectCall(exp: j.CallExpression): boolean {
+  return (
+    exp.callee.type === 'MemberExpression' &&
+    exp.callee.property.type === 'Identifier' &&
+    exp.callee.property.name === 'object'
+  );
+}
+
+function extractObjectProperties(
+  exp: j.CallExpression
+): j.ObjectExpression['properties'] {
+  const firstArg = exp.arguments[0];
+  if (firstArg && firstArg.type === 'ObjectExpression') {
+    return firstArg.properties;
+  }
+  return [];
+}
+
 export function transformMerge(
   valibotIdentifier: string,
   schemaExp: j.CallExpression | j.MemberExpression | j.Identifier,
   args: j.CallExpression['arguments']
 ) {
+  const secondSchema = args[0];
+  const objectProperties: j.ObjectExpression['properties'] = [];
+
+  // Handle first schema
+  if (schemaExp.type === 'CallExpression' && isInlineObjectCall(schemaExp)) {
+    // Inline the properties from the first schema
+    const firstSchemaProperties = extractObjectProperties(schemaExp);
+    objectProperties.push(...firstSchemaProperties);
+  } else {
+    // Use spread with .entries for schema reference
+    const firstSchemaEntries = j.memberExpression(
+      schemaExp,
+      j.identifier('entries')
+    );
+
+    if (schemaExp.type === 'Identifier') {
+      firstSchemaEntries.comments = [
+        j.block(
+          `@valibot-migrate we can't detect if ${schemaExp.name} has a \`pipe\` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline`,
+          true,
+          false
+        ),
+      ];
+    }
+
+    objectProperties.push(j.spreadElement(firstSchemaEntries));
+  }
+
+  // Handle second schema
+  if (
+    secondSchema.type === 'CallExpression' &&
+    isInlineObjectCall(secondSchema)
+  ) {
+    // Inline the properties from the second schema
+    const secondSchemaProperties = extractObjectProperties(
+      secondSchema as j.CallExpression
+    );
+    objectProperties.push(...secondSchemaProperties);
+    // this can technically never happen cause zod will yell at you if you spread the second element
+  } else if (secondSchema.type !== 'SpreadElement') {
+    // Use spread with .entries for schema reference
+    const secondSchemaEntries = j.memberExpression(
+      secondSchema,
+      j.identifier('entries')
+    );
+
+    if (secondSchema.type === 'Identifier') {
+      secondSchemaEntries.comments = [
+        j.block(
+          `@valibot-migrate we can't detect if ${secondSchema.name} has a \`pipe\` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline`,
+          true,
+          false
+        ),
+      ];
+    }
+
+    objectProperties.push(j.spreadElement(secondSchemaEntries));
+  } else {
+    const secondSchemaEntries = j.memberExpression(
+      secondSchema.argument,
+      j.identifier('entries')
+    );
+    objectProperties.push(j.spreadElement(secondSchemaEntries));
+  }
+
+  const mergedObject = j.objectExpression(objectProperties);
+
   return j.callExpression(
-    j.memberExpression(j.identifier(valibotIdentifier), j.identifier('merge')),
-    [schemaExp, ...args]
+    j.memberExpression(j.identifier(valibotIdentifier), j.identifier('object')),
+    [mergedObject]
   );
 }

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/passthrough/passthrough.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/passthrough/passthrough.ts
@@ -5,6 +5,38 @@ export function transformPassthrough(
   valibotIdentifier: string,
   schemaExp: j.CallExpression | j.MemberExpression | j.Identifier
 ) {
+  // If the schema is already a looseObject, return it as-is (no-op)
+  if (
+    schemaExp.type === 'CallExpression' &&
+    schemaExp.callee.type === 'MemberExpression' &&
+    schemaExp.callee.object.type === 'Identifier' &&
+    schemaExp.callee.object.name === valibotIdentifier &&
+    schemaExp.callee.property.type === 'Identifier' &&
+    schemaExp.callee.property.name === 'looseObject'
+  ) {
+    return schemaExp;
+  }
+
+  // If the schema is a pipe with looseObject, return it as-is (no-op)
+  if (
+    schemaExp.type === 'CallExpression' &&
+    schemaExp.callee.type === 'MemberExpression' &&
+    schemaExp.callee.object.type === 'Identifier' &&
+    schemaExp.callee.object.name === valibotIdentifier &&
+    schemaExp.callee.property.type === 'Identifier' &&
+    schemaExp.callee.property.name === 'pipe' &&
+    schemaExp.arguments.length > 0 &&
+    schemaExp.arguments[0].type === 'CallExpression' &&
+    schemaExp.arguments[0].callee.type === 'MemberExpression' &&
+    schemaExp.arguments[0].callee.object.type === 'Identifier' &&
+    schemaExp.arguments[0].callee.object.name === valibotIdentifier &&
+    schemaExp.arguments[0].callee.property.type === 'Identifier' &&
+    schemaExp.arguments[0].callee.property.name === 'looseObject'
+  ) {
+    return schemaExp;
+  }
+
+  // Transform regular object to looseObject
   if (
     schemaExp.type === 'CallExpression' &&
     schemaExp.callee.type === 'MemberExpression' &&
@@ -21,15 +53,13 @@ export function transformPassthrough(
       schemaExp.arguments
     );
   }
-  return addToPipe(
-    valibotIdentifier,
-    schemaExp,
-    j.callExpression(
-      j.memberExpression(
-        j.identifier(valibotIdentifier),
-        j.identifier('passthrough')
-      ),
-      []
-    )
+
+  // Handle other cases (like previously defined schemas)
+  return j.callExpression(
+    j.memberExpression(
+      j.identifier(valibotIdentifier),
+      j.identifier('looseObject')
+    ),
+    [j.memberExpression(schemaExp, j.identifier('entries'))]
   );
 }

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/passthrough/passthrough.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/passthrough/passthrough.ts
@@ -54,12 +54,24 @@ export function transformPassthrough(
     );
   }
 
+  const entries = j.memberExpression(schemaExp, j.identifier('entries'));
+
+  if (schemaExp.type === 'Identifier') {
+    entries.comments = [
+      j.block(
+        `@valibot-migrate we can't detect if ${schemaExp.name} has a \`pipe\` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline`,
+        true,
+        false
+      ),
+    ];
+  }
+
   // Handle other cases (like previously defined schemas)
   return j.callExpression(
     j.memberExpression(
       j.identifier(valibotIdentifier),
       j.identifier('looseObject')
     ),
-    [j.memberExpression(schemaExp, j.identifier('entries'))]
+    [entries]
   );
 }

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/strict/strict.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/strict/strict.ts
@@ -5,6 +5,38 @@ export function transformStrict(
   valibotIdentifier: string,
   schemaExp: j.CallExpression | j.MemberExpression | j.Identifier
 ) {
+  // If the schema is already a strictObject, return it as-is (no-op)
+  if (
+    schemaExp.type === 'CallExpression' &&
+    schemaExp.callee.type === 'MemberExpression' &&
+    schemaExp.callee.object.type === 'Identifier' &&
+    schemaExp.callee.object.name === valibotIdentifier &&
+    schemaExp.callee.property.type === 'Identifier' &&
+    schemaExp.callee.property.name === 'strictObject'
+  ) {
+    return schemaExp;
+  }
+  
+  // If the schema is a pipe with strictObject, return it as-is (no-op)
+  if (
+    schemaExp.type === 'CallExpression' &&
+    schemaExp.callee.type === 'MemberExpression' &&
+    schemaExp.callee.object.type === 'Identifier' &&
+    schemaExp.callee.object.name === valibotIdentifier &&
+    schemaExp.callee.property.type === 'Identifier' &&
+    schemaExp.callee.property.name === 'pipe' &&
+    schemaExp.arguments.length > 0 &&
+    schemaExp.arguments[0].type === 'CallExpression' &&
+    schemaExp.arguments[0].callee.type === 'MemberExpression' &&
+    schemaExp.arguments[0].callee.object.type === 'Identifier' &&
+    schemaExp.arguments[0].callee.object.name === valibotIdentifier &&
+    schemaExp.arguments[0].callee.property.type === 'Identifier' &&
+    schemaExp.arguments[0].callee.property.name === 'strictObject'
+  ) {
+    return schemaExp;
+  }
+  
+  // Transform regular object to strictObject
   if (
     schemaExp.type === 'CallExpression' &&
     schemaExp.callee.type === 'MemberExpression' &&
@@ -21,6 +53,8 @@ export function transformStrict(
       schemaExp.arguments
     );
   }
+  
+  // Handle other cases (like previously defined schemas)
   return j.callExpression(
     j.memberExpression(
       j.identifier(valibotIdentifier),

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/strict/strict.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/strict/strict.ts
@@ -21,15 +21,11 @@ export function transformStrict(
       schemaExp.arguments
     );
   }
-  return addToPipe(
-    valibotIdentifier,
-    schemaExp,
-    j.callExpression(
-      j.memberExpression(
-        j.identifier(valibotIdentifier),
-        j.identifier('strict')
-      ),
-      []
-    )
+  return j.callExpression(
+    j.memberExpression(
+      j.identifier(valibotIdentifier),
+      j.identifier('strictObject')
+    ),
+    [j.memberExpression(schemaExp, j.identifier('entries'))]
   );
 }

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/strict/strict.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/strict/strict.ts
@@ -16,7 +16,7 @@ export function transformStrict(
   ) {
     return schemaExp;
   }
-  
+
   // If the schema is a pipe with strictObject, return it as-is (no-op)
   if (
     schemaExp.type === 'CallExpression' &&
@@ -35,7 +35,7 @@ export function transformStrict(
   ) {
     return schemaExp;
   }
-  
+
   // Transform regular object to strictObject
   if (
     schemaExp.type === 'CallExpression' &&
@@ -53,13 +53,25 @@ export function transformStrict(
       schemaExp.arguments
     );
   }
-  
+
+  const entries = j.memberExpression(schemaExp, j.identifier('entries'));
+
+  if (schemaExp.type === 'Identifier') {
+    entries.comments = [
+      j.block(
+        `@valibot-migrate we can't detect if ${schemaExp.name} has a \`pipe\` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline`,
+        true,
+        false
+      ),
+    ];
+  }
+
   // Handle other cases (like previously defined schemas)
   return j.callExpression(
     j.memberExpression(
       j.identifier(valibotIdentifier),
       j.identifier('strictObject')
     ),
-    [j.memberExpression(schemaExp, j.identifier('entries'))]
+    [entries]
   );
 }

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
@@ -140,6 +140,8 @@ function checkForObjectModifierInChain(
   cur: j.ASTPath<j.CallExpression>
 ): ObjectModifier {
   let parent = cur.parentPath;
+  let latestModifier: ObjectModifier = null;
+  
   while (parent) {
     if (
       parent.value.type === 'CallExpression' &&
@@ -147,8 +149,8 @@ function checkForObjectModifierInChain(
       parent.value.callee.property.type === 'Identifier'
     ) {
       const methodName = parent.value.callee.property.name;
-      if (methodName === 'strict' || methodName === 'passthrough') {
-        return methodName;
+      if (methodName === 'strict' || methodName === 'passthrough' || methodName === 'strip') {
+        latestModifier = methodName;
       }
     }
     if (
@@ -157,13 +159,13 @@ function checkForObjectModifierInChain(
       parent.parentPath?.value.type === 'CallExpression'
     ) {
       const methodName = parent.value.property.name;
-      if (methodName === 'strict' || methodName === 'passthrough') {
-        return methodName;
+      if (methodName === 'strict' || methodName === 'passthrough' || methodName === 'strip') {
+        latestModifier = methodName;
       }
     }
     parent = parent.parentPath;
   }
-  return null;
+  return latestModifier;
 }
 
 function toValibotSchemaExp(

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas/object/object.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas/object/object.ts
@@ -1,13 +1,22 @@
 import j from 'jscodeshift';
+import { ObjectModifier } from '../../types';
 import { getSchemaComps, getSchemaWithOptionalDescription } from '../helpers';
 
 export function transformObject(
   valibotIdentifier: string,
-  args: j.CallExpression['arguments']
+  args: j.CallExpression['arguments'],
+  modifier: ObjectModifier = null
 ) {
+  let schemaName = 'object';
+  if (modifier === 'strict') {
+    schemaName = 'strictObject';
+  } else if (modifier === 'passthrough') {
+    schemaName = 'looseObject';
+  }
+
   const { baseSchema, description } = getSchemaComps(
     valibotIdentifier,
-    'object',
+    schemaName,
     args,
     2
   );

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/types.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/types.ts
@@ -1,1 +1,3 @@
 export type ZodSchemaType = 'value' | 'length' | 'size' | 'none';
+
+export type ObjectModifier = 'strict' | 'passthrough' | null;


### PR DESCRIPTION
Currently `strict` migrate to the wrong code as you can see from the test input and output:

input
```ts
import { z } from "zod";

const Schema1 = z.object({key: z.string()}).strict();
const Schema2 = z.object({key: z.string()}, {message: "some message"}).strict();
const Schema3 = z.object({key: z.string()}, {description: "some description"}).strict();
const Schema4 = z.object({key: z.string()});
const Schema5 = Schema4.strict();
```

output
```ts
const Schema1 = v.strictObject({key: v.string()});
const Schema2 = v.strictObject({key: v.string()}, "some message");
const Schema3 = v.pipe(v.object({key: v.string()}), v.description("some description"), v.strict());
const Schema4 = v.object({key: v.string()});
const Schema5 = v.pipe(Schema4, v.strict());
```

`v.strict()` is not a thing.

this is the new output
```ts
const Schema8 = v.object({key: v.string()});
const Schema9 = v.object({key: v.string()}, "some message");
const Schema10 = v.object(
  v.pipe(v.object({key: v.string()}), v.description("some description")).entries
);
const Schema11 = v.strictObject({key: v.string()});
const Schema12 = v.pipe(Schema11, v.strip());
const Schema13 = v.object({key: v.string()});
const Schema14 = v.object(Schema13.entries);
```