### PR TITLE
docs: fix 'sting' typo to 'string' across multiple type inference examples

### DIFF
--- a/website/src/routes/api/(types)/InferNonNullableInput/index.mdx
+++ b/website/src/routes/api/(types)/InferNonNullableInput/index.mdx
@@ -10,7 +10,7 @@ contributors:
 Infer non nullable input type.
 
 ```ts
-// Create nullable sting schema
+// Create nullable string schema
 const NullableStringSchema = v.nullable(
   v.pipe(
     v.string(),

--- a/website/src/routes/api/(types)/InferNonNullableOutput/index.mdx
+++ b/website/src/routes/api/(types)/InferNonNullableOutput/index.mdx
@@ -10,7 +10,7 @@ contributors:
 Infer non nullable output type.
 
 ```ts
-// Create nullable sting schema
+// Create nullable string schema
 const NullableStringSchema = v.nullable(
   v.pipe(
     v.string(),

--- a/website/src/routes/api/(types)/InferNonNullishInput/index.mdx
+++ b/website/src/routes/api/(types)/InferNonNullishInput/index.mdx
@@ -10,7 +10,7 @@ contributors:
 Infer non nullable input type.
 
 ```ts
-// Create nullish sting schema
+// Create nullish string schema
 const NullishStringSchema = v.nullish(
   v.pipe(
     v.string(),

--- a/website/src/routes/api/(types)/InferNonNullishOutput/index.mdx
+++ b/website/src/routes/api/(types)/InferNonNullishOutput/index.mdx
@@ -10,7 +10,7 @@ contributors:
 Infer non nullable output type.
 
 ```ts
-// Create nullish sting schema
+// Create nullish string schema
 const NullishStringSchema = v.nullish(
   v.pipe(
     v.string(),

--- a/website/src/routes/api/(types)/InferNonOptionalInput/index.mdx
+++ b/website/src/routes/api/(types)/InferNonOptionalInput/index.mdx
@@ -10,7 +10,7 @@ contributors:
 Infer non optional input type.
 
 ```ts
-// Create optional sting schema
+// Create optional string schema
 const OptionalStringSchema = v.optional(
   v.pipe(
     v.string(),

--- a/website/src/routes/api/(types)/InferNonOptionalOutput/index.mdx
+++ b/website/src/routes/api/(types)/InferNonOptionalOutput/index.mdx
@@ -10,7 +10,7 @@ contributors:
 Infer non optional output type.
 
 ```ts
-// Create optional sting schema
+// Create optional string schema
 const OptionalStringSchema = v.optional(
   v.pipe(
     v.string(),


### PR DESCRIPTION
This PR fixes minor typos in the Valibot documentation.

Replaces occurrences of **'sting'** with the correct spelling **'string'** in:

- InferNonNullableInput
- InferNonNullableOutput
- InferNonNullishInput
- InferNonNullishOutput
- InferNonOptionalInput
- InferNonOptionalOutput

Thanks for your awesome work on Valibot! 🛠️✨
