### PR TITLE
Add packageManager and devEngines

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,14 @@
     "url": "https://github.com/fabian-hiller/valibot"
   },
   "private": true,
+  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "10",
+      "onFail": "warn"
+    }
+  },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "prettier": "^3.5.2",


### PR DESCRIPTION
The PR adds the standard [packageManager](https://github.com/nodejs/corepack) (for corepack) and [devEngines](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines) (for package manager) fields to `package.json`, ensuring a consistent developer experience for contributors.