### PR TITLE
fix: use the ts parser in website codemod playground

### DIFF
--- a/website/src/routes/guides/(migration)/migrate-from-zod/CodemodEditor.tsx
+++ b/website/src/routes/guides/(migration)/migrate-from-zod/CodemodEditor.tsx
@@ -49,12 +49,14 @@ export const CodemodEditor = component$(() => {
     // Get current code from editor model
     const currentCode = model.value!.getValue();
 
+    const tsParser = jscodeshift.withParser('ts');
+
     // Execute codemod with current code
     const transformedCode = await transform(
       { path: 'index.ts', source: currentCode },
       {
-        j: jscodeshift.withParser('ts'),
-        jscodeshift,
+        j: tsParser,
+        jscodeshift: tsParser,
         stats: () => {},
         report: () => {},
       },


### PR DESCRIPTION
The playground was creating the ts parser but internally the codemod uses `api.jscodeshift` not `api.j` so it was actually using the js parser (thus failing to parse any TS...which you know it is kinda of important for valibot 😄)