### PR TITLE
Update Hey API link to Valibot plugin

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -84,7 +84,7 @@ This page is for you if you are looking for frameworks or libraries that support
 
 ## X to Valibot
 
-- [@hey-api/openapi-ts](https://heyapi.dev/): The OpenAPI to TypeScript codegen. Generate clients, SDKs, validators, and more.
+- [@hey-api/openapi-ts](https://heyapi.dev/openapi-ts/plugins/valibot): The OpenAPI to TypeScript codegen. Generate clients, SDKs, validators, and more.
 - [graphql-codegen-typescript-validation-schema](https://github.com/Code-Hex/graphql-codegen-typescript-validation-schema): GraphQL Code Generator plugin to generate form validation schema from your GraphQL schema.
 - [TypeBox-Codegen](https://sinclairzx81.github.io/typebox-workbench/): Code generation for schema libraries
 - [TypeMap](https://github.com/sinclairzx81/typemap/): Uniform Syntax, Mapping and Compiler Library for TypeBox, Valibot and Zod


### PR DESCRIPTION
This should make Hey API more relevant when people search for things like "openapi valibot"