### PR TITLE
feat: graceful multiple imports exit + `transform` and `refine`

### DIFF
--- a/codemod/zod-to-valibot/__testfixtures__/multiple-imports-from-zod/input.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/multiple-imports-from-zod/input.ts
@@ -1,0 +1,3 @@
+import { z, ZodAnyType } from "zod";
+
+const Schema1 = z.string();

--- a/codemod/zod-to-valibot/__testfixtures__/multiple-imports-from-zod/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/multiple-imports-from-zod/output.ts
@@ -1,0 +1,4 @@
+/* @valibot-migrate: unable to transform imports from Zod to Valibot: Expected exactly one import specifier from "zod" or "zod/v4". */
+import { z, ZodAnyType } from "zod";
+
+const Schema1 = z.string();

--- a/codemod/zod-to-valibot/__testfixtures__/refine/input.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/refine/input.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+// Basic refine
+const Schema1 = z.number().refine((val) => val < 100, "Must be less then 100");
+
+// Refine with string schema
+const Schema2 = z.string().refine((val) => val.length > 0, "Required");
+
+// Refine after validator
+const Schema3 = z.number().min(0).refine((val) => val % 2 === 0, "Must be even");
+
+// Multiple refines
+const Schema4 = z.string().refine((val) => val.length > 3).refine((val) => val.includes("@"));
+
+// Refine with complex condition
+const Schema5 = z.object({ name: z.string() }).refine((data) => data.name !== "admin", {
+  message: "Cannot use admin"
+});
+
+// Refine on linked schema
+const BaseSchema = z.string();
+const RefinedSchema = BaseSchema.refine((val) => val.trim().length > 0);

--- a/codemod/zod-to-valibot/__testfixtures__/refine/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/refine/output.ts
@@ -1,0 +1,27 @@
+import * as v from "valibot";
+
+// Basic refine
+const Schema1 = v.pipe(v.number(), v.check((val) => val < 100, "Must be less then 100"));
+
+// Refine with string schema
+const Schema2 = v.pipe(v.string(), v.check((val) => val.length > 0, "Required"));
+
+// Refine after validator
+const Schema3 = v.pipe(v.number(), v.minValue(0), v.check((val) => val % 2 === 0, "Must be even"));
+
+// Multiple refines
+const Schema4 = v.pipe(
+  v.string(),
+  v.check((val) => val.length > 3),
+  v.check((val) => val.includes("@"))
+);
+
+// Refine with complex condition
+const Schema5 = v.pipe(
+  v.object({ name: v.string() }),
+  v.check((data) => data.name !== "admin", "Cannot use admin")
+);
+
+// Refine on linked schema
+const BaseSchema = v.string();
+const RefinedSchema = v.pipe(BaseSchema, v.check((val) => val.trim().length > 0));

--- a/codemod/zod-to-valibot/__testfixtures__/transform/input.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/transform/input.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+// Basic transform
+const Schema1 = z.number().transform((val) => val * 2);
+
+// Transform with string schema
+const Schema2 = z.string().transform((val) => val.toUpperCase());
+
+// Chained transform with validator
+const Schema3 = z.number().min(0).transform((val) => val + 1);
+
+// Transform after validator chain
+const Schema4 = z.string().email().transform((val) => `Email: ${val}`);
+
+// Multiple transforms
+const Schema5 = z.number().transform((val) => val * 2).transform((val) => val + 10);
+
+// Transform with complex function
+const Schema6 = z.object({ name: z.string() }).transform((data) => ({
+  ...data,
+  displayName: data.name.toUpperCase()
+}));
+
+// Transform on linked schema
+const BaseSchema = z.string();
+const TransformedSchema = BaseSchema.transform((val) => val.trim());

--- a/codemod/zod-to-valibot/__testfixtures__/transform/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/transform/output.ts
@@ -1,0 +1,26 @@
+import * as v from "valibot";
+
+// Basic transform
+const Schema1 = v.pipe(v.number(), v.transform((val) => val * 2));
+
+// Transform with string schema
+const Schema2 = v.pipe(v.string(), v.transform((val) => val.toUpperCase()));
+
+// Chained transform with validator
+const Schema3 = v.pipe(v.number(), v.minValue(0), v.transform((val) => val + 1));
+
+// Transform after validator chain
+const Schema4 = v.pipe(v.string(), v.email(), v.transform((val) => `Email: ${val}`));
+
+// Multiple transforms
+const Schema5 = v.pipe(v.number(), v.transform((val) => val * 2), v.transform((val) => val + 10));
+
+// Transform with complex function
+const Schema6 = v.pipe(v.object({ name: v.string() }), v.transform((data) => ({
+  ...data,
+  displayName: data.name.toUpperCase()
+})));
+
+// Transform on linked schema
+const BaseSchema = v.string();
+const TransformedSchema = v.pipe(BaseSchema, v.transform((val) => val.trim()));

--- a/codemod/zod-to-valibot/src/test-setup.test.ts
+++ b/codemod/zod-to-valibot/src/test-setup.test.ts
@@ -26,6 +26,7 @@ defineTests(transform, [
   'intersection-schema',
   'literal-schema',
   'map-schema',
+  'multiple-imports-from-zod',
   'named-import',
   'named-import-with-alias',
   'named-import-with-specific-alias',

--- a/codemod/zod-to-valibot/src/test-setup.test.ts
+++ b/codemod/zod-to-valibot/src/test-setup.test.ts
@@ -56,6 +56,7 @@ defineTests(transform, [
   'parsing',
   'readonly',
   'record-schema',
+  'refine',
   'schema-chain',
   'schema-options',
   'set-schema',

--- a/codemod/zod-to-valibot/src/test-setup.test.ts
+++ b/codemod/zod-to-valibot/src/test-setup.test.ts
@@ -64,6 +64,7 @@ defineTests(transform, [
   'specific-namespace-import',
   'string-validation-methods',
   'symbol-schema',
+  'transform',
   'tuple-schema',
   'type-inference',
   'undefined-schema',

--- a/codemod/zod-to-valibot/src/transform/imports/imports.ts
+++ b/codemod/zod-to-valibot/src/transform/imports/imports.ts
@@ -3,6 +3,7 @@ import j, { type Collection } from 'jscodeshift';
 type TransformImportsReturn =
   | {
       conclusion: 'skip' | 'unsuccessful';
+      cause: string;
       valibotIdentifier?: undefined;
     }
   | { conclusion: 'successful'; valibotIdentifier: string };
@@ -20,6 +21,7 @@ export function transformImports(
   if (importNodes.length !== 1) {
     return {
       conclusion: importNodes.length === 0 ? 'skip' : 'unsuccessful',
+      cause: 'Expected exactly one import statement from "zod" or "zod/v4".',
     };
   }
   // Check the number of specifiers is exactly one
@@ -27,6 +29,7 @@ export function transformImports(
   if (importSpecifiers?.length !== 1) {
     return {
       conclusion: 'unsuccessful',
+      cause: 'Expected exactly one import specifier from "zod" or "zod/v4".',
     };
   }
   // Obtain the identifier
@@ -35,6 +38,7 @@ export function transformImports(
   if (typeof zodIdentifier !== 'string') {
     return {
       conclusion: 'unsuccessful',
+      cause: 'Expected the import specifier to have a local name.',
     };
   }
   const isZodIdentifierZ = zodIdentifier === 'z';

--- a/codemod/zod-to-valibot/src/transform/index.ts
+++ b/codemod/zod-to-valibot/src/transform/index.ts
@@ -9,9 +9,20 @@ const transform: Transform = (fileInfo, api) => {
   // ------------ Imports ------------
   const transformImportsResult = transformImports(root);
   if (transformImportsResult.conclusion !== 'successful') {
-    return transformImportsResult.conclusion === 'skip'
-      ? undefined
-      : root.toSource();
+    if (transformImportsResult.conclusion === 'unsuccessful') {
+      const node = root.get().node;
+      // Add comment indicating unsuccessful transformation
+      node.comments ??= [];
+      node.comments.unshift(
+        j.commentBlock(
+          ` @valibot-migrate: unable to transform imports from Zod to Valibot: ${transformImportsResult.cause} `,
+          true,
+          false
+        )
+      );
+      return root.toSource();
+    }
+    return undefined;
   }
   const valibotIdentifier = transformImportsResult.valibotIdentifier;
 

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/constants.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/constants.ts
@@ -153,6 +153,7 @@ export const ZOD_METHODS = [
   'partial',
   'passthrough',
   'pick',
+  'refine',
   'required',
   'rest',
   'safeParse',

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/constants.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/constants.ts
@@ -160,6 +160,7 @@ export const ZOD_METHODS = [
   'strict',
   'strip',
   'spa',
+  'transform',
   'unwrap',
 ] as const;
 

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/index.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/index.ts
@@ -23,4 +23,5 @@ export * from './safeParse';
 export * from './safeParseAsync';
 export * from './strict';
 export * from './strip';
+export * from './transform';
 export * from './unwrap';

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/index.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/index.ts
@@ -17,6 +17,7 @@ export * from './parseAsync';
 export * from './partial';
 export * from './passthrough';
 export * from './pick';
+export * from './refine';
 export * from './required';
 export * from './rest';
 export * from './safeParse';

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/refine/index.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/refine/index.ts
@@ -1,0 +1,1 @@
+export * from './refine';

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/refine/refine.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/refine/refine.ts
@@ -1,0 +1,35 @@
+import j from 'jscodeshift';
+import { addToPipe } from '../../helpers';
+
+export function transformRefine(
+  valibotIdentifier: string,
+  schemaExp: j.CallExpression | j.MemberExpression | j.Identifier,
+  args: j.CallExpression['arguments']
+) {
+  // Transform Zod's refine arguments to Valibot's check arguments
+  const transformedArgs = args.map((arg) => {
+    // If the argument is an object with { message: "..." }, extract the message
+    if (
+      arg.type === 'ObjectExpression' &&
+      arg.properties.length === 1 &&
+      arg.properties[0].type === 'ObjectProperty' &&
+      arg.properties[0].key.type === 'Identifier' &&
+      arg.properties[0].key.name === 'message'
+    ) {
+      return arg.properties[0].value;
+    }
+    return arg;
+  }) as typeof args;
+
+  return addToPipe(
+    valibotIdentifier,
+    schemaExp,
+    j.callExpression(
+      j.memberExpression(
+        j.identifier(valibotIdentifier),
+        j.identifier('check')
+      ),
+      transformedArgs
+    )
+  );
+}

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/transform/index.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/transform/index.ts
@@ -1,0 +1,1 @@
+export * from './transform';

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/transform/transform.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/transform/transform.ts
@@ -1,0 +1,20 @@
+import j from 'jscodeshift';
+import { addToPipe } from '../../helpers';
+
+export function transformTransform(
+  valibotIdentifier: string,
+  schemaExp: j.CallExpression | j.MemberExpression | j.Identifier,
+  args: j.CallExpression['arguments']
+) {
+  return addToPipe(
+    valibotIdentifier,
+    schemaExp,
+    j.callExpression(
+      j.memberExpression(
+        j.identifier(valibotIdentifier),
+        j.identifier('transform')
+      ),
+      args
+    )
+  );
+}

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
@@ -29,6 +29,7 @@ import {
   transformPartial,
   transformPassthrough,
   transformPick,
+  transformRefine,
   transformRequired,
   transformRest,
   transformSafeParse,
@@ -412,6 +413,8 @@ function toValibotMethodExp(
       return transformPassthrough(valibotIdentifier, schemaExp);
     case 'pick':
       return transformPick(...args);
+    case 'refine':
+      return transformRefine(...args);
     case 'required':
       return transformRequired(...args);
     case 'rest':

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
@@ -35,6 +35,7 @@ import {
   transformSafeParseAsync,
   transformStrict,
   transformStrip,
+  transformTransform,
   transformUnwrap,
 } from './methods';
 import {
@@ -424,6 +425,8 @@ function toValibotMethodExp(
       return transformStrict(valibotIdentifier, schemaExp);
     case 'strip':
       return transformStrip(valibotIdentifier, schemaExp);
+    case 'transform':
+      return transformTransform(...args);
     case 'unwrap':
       return transformUnwrap(...args);
     case 'nullish':


### PR DESCRIPTION
Some other small codemod fixes: this fixes `transform`, `refine` and adds a comment to explain why it's not possible to migrate the file when there's multiple zod imports (i also think we could try to be a bit smarter here and still migrate if at least one import is `z` from `zod` but that would lead to squiggles in the file unless we also replace all the zod types)