### PR TITLE
fix(i18n): fix typo for Indonesian lang

### DIFF
--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to the library will be documented in this file.
 
 ## v0.17.0 (July 26, 2024)
 
-- Add Indonesia (id) translations (pull request #683)
+- Add Indonesian (id) translations (pull request #683)
 
 ## v0.16.0 (June 19, 2024)
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -17,7 +17,7 @@ The official i18n translations for Valibot. See the [internationalization guide]
 | French (fr)     | [#418][pr-418-url] | ✅     |
 | German (de)     | [#397][pr-397-url] | ✅     |
 | Hungarian (hu)  | [#560][pr-560-url] | ✅     |
-| Indonesia (id)  | [#683][pr-683-url] | ✅     |
+| Indonesian (id) | [#683][pr-683-url] | ✅     |
 | Italian (it)    | [#605][pr-605-url] | ✅     |
 | Japanese (ja)   | [#431][pr-431-url] | ✅     |
 | Korean (kr)     | [#429][pr-429-url] | ✅     |


### PR DESCRIPTION
Minor fix:

The country is **Indonesia** and the language is **Indonesian**.