### PR TITLE
docs: add Valibot-Fast-Check library to ecosystem guide

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -81,6 +81,7 @@ This page is for you if you are looking for frameworks or libraries that support
 - [Hono OpenAPI](https://github.com/rhinobase/hono-openapi): A plugin for Hono to generate OpenAPI Swagger documentation
 - [TypeMap](https://github.com/sinclairzx81/typemap/): Uniform Syntax, Mapping and Compiler Library for TypeBox, Valibot and Zod
 - [TypeSchema](https://typeschema.com/): Universal adapter for schema validation
+- [Valibot-Fast-Check](https://github.com/Eronmmer/valibot-fast-check): A library to generate [fast-check](https://fast-check.dev) arbitraries from Valibot schemas for property-based testing
 
 ## X to Valibot
 


### PR DESCRIPTION
This PR adds a new library, [ valibot-fast-check](https://github.com/Eronmmer/valibot-fast-check) to the ecosystem guide, under the `Valibot to X` section
