### PR TITLE
feat: use pnpm version 10

### DIFF
--- a/.github/actions/environment/action.yml
+++ b/.github/actions/environment/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: 9
+        version: 10
         run_install: false
 
     - name: Setup Node.js

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,11 @@
 packages:
-  - 'codemod/*'
-  - 'library'
-  - 'packages/*'
-  - 'website'
+  - codemod/*
+  - library
+  - packages/*
+  - website
+
+onlyBuiltDependencies:
+  - '@ast-grep/cli'
+  - '@vercel/speed-insights'
+  - esbuild
+  - sharp


### PR DESCRIPTION
- Use pnpm version 10 in CI because it's no longer actively maintained (see [this](https://pnpm.io/9.x/installation)).
- Added `onlyBuiltDependencies` in `pnpm-workspace.yaml` because of the following warning:
  <img width="569" height="293" alt="image" src="https://github.com/user-attachments/assets/f8123e27-54d9-44cc-b987-241f9c38a581" />
