### PR TITLE
fix: enable ESLint `no-duplicate-imports` rule

### DIFF
--- a/library/eslint.config.js
+++ b/library/eslint.config.js
@@ -84,9 +84,6 @@ export default tseslint.config(
       '@typescript-eslint/consistent-indexed-object-style': 'off',
       '@typescript-eslint/no-inferrable-types': 'off',
 
-      // Imports
-      'no-duplicate-imports': 'off',
-
       // JSDoc
       'jsdoc/require-param-type': 'off',
       'jsdoc/require-returns-type': 'off',

--- a/packages/to-json-schema/eslint.config.js
+++ b/packages/to-json-schema/eslint.config.js
@@ -64,9 +64,6 @@ export default tseslint.config(
       '@typescript-eslint/ban-ts-comment': 'off',
       '@typescript-eslint/no-non-null-assertion': 'off',
 
-      // Imports
-      'no-duplicate-imports': 'off',
-
       // JSDoc
       'jsdoc/require-param-type': 'off',
       'jsdoc/require-returns-type': 'off',


### PR DESCRIPTION
Remove `no-duplicate-imports` from being disabled in ESLint configuration.