### PR TITLE
doc: adds `@traversable/valibot` and `@traversable/valibot-test` to ecosystem

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -89,6 +89,7 @@ This page is for you if you are looking for frameworks or libraries that support
 - [graphql-codegen-typescript-validation-schema](https://github.com/Code-Hex/graphql-codegen-typescript-validation-schema): GraphQL Code Generator plugin to generate form validation schema from your GraphQL schema.
 - [TypeBox-Codegen](https://sinclairzx81.github.io/typebox-workbench/): Code generation for schema libraries
 - [TypeMap](https://github.com/sinclairzx81/typemap/): Uniform Syntax, Mapping and Compiler Library for TypeBox, Valibot and Zod
+- [@traversable/valibot](https://github.com/traversable/schema/tree/main/packages/valibot): Trivially build your own "Valibot to X" library, or pick one of 10+ off-the-shelf transformers
 
 ## Utilities
 
@@ -101,3 +102,4 @@ This page is for you if you are looking for frameworks or libraries that support
 - [valiload](https://github.com/JuerGenie/valiload): A simple and lightweight library for overloading functions in TypeScript
 - [valimock](https://github.com/saeris/valimock): Generate mock data using your Valibot schemas using [Faker](https://github.com/faker-js/faker)
 - [valipass](https://github.com/Saeris/valipass): Collection of password validation actions for Valibot schemas
+- [@traversable/valibot-test](https://github.com/traversable/schema/tree/main/packages/valibot-test): Random Valibot schema generator built for fuzz testing, includes generators for both valid and invalid data

--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -89,7 +89,7 @@ This page is for you if you are looking for frameworks or libraries that support
 - [graphql-codegen-typescript-validation-schema](https://github.com/Code-Hex/graphql-codegen-typescript-validation-schema): GraphQL Code Generator plugin to generate form validation schema from your GraphQL schema.
 - [TypeBox-Codegen](https://sinclairzx81.github.io/typebox-workbench/): Code generation for schema libraries
 - [TypeMap](https://github.com/sinclairzx81/typemap/): Uniform Syntax, Mapping and Compiler Library for TypeBox, Valibot and Zod
-- [@traversable/valibot](https://github.com/traversable/schema/tree/main/packages/valibot): Trivially build your own "Valibot to X" library, or pick one of 10+ off-the-shelf transformers
+- [@traversable/valibot](https://github.com/traversable/schema/tree/main/packages/valibot): Build your own "Valibot to X" library, or pick one of 10+ off-the-shelf transformers
 
 ## Utilities
 


### PR DESCRIPTION
Hello Valibot maintainers!

This PR adds 2 libraries to the ecosystem:

1. [@traversable/valibot](https://github.com/traversable/schema/tree/main/packages/valibot)
2. [@traversable/valibot-test](https://github.com/traversable/schema/tree/main/packages/valibot-test)

These libraries were primarily built for developers who are building tools on top of Valibot, but can also be used for one of the 10+ off-the-shelf transformers that we currently support.

Happy to talk more about the library if you have any questions!