### PR TITLE
docs: add prisma-valibot-generator & drzl to “X → Valibot” ecosystem

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -89,6 +89,8 @@ This page is for you if you are looking for frameworks or libraries that support
 - [graphql-codegen-typescript-validation-schema](https://github.com/Code-Hex/graphql-codegen-typescript-validation-schema): GraphQL Code Generator plugin to generate form validation schema from your GraphQL schema.
 - [TypeBox-Codegen](https://sinclairzx81.github.io/typebox-workbench/): Code generation for schema libraries
 - [TypeMap](https://github.com/sinclairzx81/typemap/): Uniform Syntax, Mapping and Compiler Library for TypeBox, Valibot and Zod
+- [Prisma Valibot Generator](https://github.com/omar-dulaimi/prisma-valibot-generator): Generate Valibot validators from your Prisma schema so types and runtime stay in sync.
+- [DRZL](https://github.com/use-drzl/drzl): Analyze Drizzle ORM schema(s) and auto-generate Valibot validators, typed services, and strongly typed routers (oRPC/tRPC/etc) via a modular pipeline.
 
 ## Utilities
 


### PR DESCRIPTION
### Summary
Expands the **X → Valibot** section with two community tools for Prisma and Drizzle users:

- **[Prisma Valibot Generator](https://github.com/omar-dulaimi/prisma-valibot-generator)** — generates Valibot validators directly from a Prisma schema.
- **[DRZL](https://github.com/use-drzl/drzl)** — analyzes Drizzle ORM schema(s) and outputs Valibot validators, typed services, and strongly typed routers (oRPC/tRPC/etc).
