### PR TITLE
Fix typos (`begining`)

### DIFF
--- a/library/src/actions/email/email.test.ts
+++ b/library/src/actions/email/email.test.ts
@@ -76,15 +76,15 @@ describe('email', () => {
 
     // Start of local part
 
-    test('for underscore in begining of local part', () => {
+    test('for underscore in beginning of local part', () => {
       expectNoActionIssue(action, ['_email@example.com']);
     });
 
-    test('for hyphen in begining of local part', () => {
+    test('for hyphen in beginning of local part', () => {
       expectNoActionIssue(action, ['-email@example.com']);
     });
 
-    test('for plus in begining of local part', () => {
+    test('for plus in beginning of local part', () => {
       expectNoActionIssue(action, ['+email@example.com']);
     });
 

--- a/library/src/actions/rfcEmail/rfcEmail.test.ts
+++ b/library/src/actions/rfcEmail/rfcEmail.test.ts
@@ -80,15 +80,15 @@ describe('rfcEmail', () => {
 
     // Start of local part
 
-    test('for underscore in begining of local part', () => {
+    test('for underscore in beginning of local part', () => {
       expectNoActionIssue(action, ['_email@example.com']);
     });
 
-    test('for hyphen in begining of local part', () => {
+    test('for hyphen in beginning of local part', () => {
       expectNoActionIssue(action, ['-email@example.com']);
     });
 
-    test('for plus in begining of local part', () => {
+    test('for plus in beginning of local part', () => {
       expectNoActionIssue(action, ['+email@example.com']);
     });
 


### PR DESCRIPTION
> [!NOTE]
> This PR only includes test case description updates and has no impact on runtime behavior.

# Summary

I just fixed typos of `begining` to `beginning`.