### PR TITLE
docs(ecosystem): add valifetch

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -28,6 +28,7 @@ contributors:
   - logaretm
   - victorgarciaesgi
   - gadicc
+  - haihv
 ---
 
 # Ecosystem
@@ -51,6 +52,7 @@ This page is for you if you are looking for frameworks or libraries that support
 - [piying-orm](https://github.com/piying-org/piying-orm): ORM for Valibot; Supports TypeORM, with more to come.
 - [tRPC](https://trpc.io/): Move Fast and Break Nothing. End-to-end typesafe APIs made easy
 - [upfetch](https://github.com/L-Blondy/up-fetch): Advanced fetch client builder
+- [valifetch](https://github.com/haihv/valifetch): Type-safe HTTP client with Valibot schema validation
 
 ## AI libraries
 


### PR DESCRIPTION
## Summary

Adds [valifetch](https://github.com/haihv/valifetch) to the **API libraries** section of the ecosystem page.

**valifetch** is a type-safe HTTP client built on native `fetch` with Valibot schema validation. It validates request bodies, path params, search params, and response payloads against Valibot schemas — making it a natural fit for the valibot ecosystem.

- npm: https://www.npmjs.com/package/valifetch
- JSR: https://jsr.io/@haihv/valifetch
- GitHub: https://github.com/haihv/valifetch